### PR TITLE
update fr translations file and fix spacing in tsx block

### DIFF
--- a/action-extension/locales/fr.json.liquid
+++ b/action-extension/locales/fr.json.liquid
@@ -1,4 +1,4 @@
 {
-  "label": "Action {{ name }}",
+  "label": "{{ name }}",
   "welcome": "Bienvenue dans l'extension {{extensionPoint}}!"
 }

--- a/action-extension/src/ActionExtension.liquid
+++ b/action-extension/src/ActionExtension.liquid
@@ -10,7 +10,7 @@ export default reactExtension<any>('admin.product.index.action', () => <App />);
 export default reactExtension('admin.product.index.action', () => <App />);
 {% endif %}
 function App() {
-  {%- if flavor contains "typescript" -%}
+  {% if flavor contains "typescript" %}
   const {extensionPoint, i18n} = useApi() as any;
   {% else %}
   const {extensionPoint, i18n} = useApi();


### PR DESCRIPTION
On a previous PR, we converted the `en` template to liquid to populate the name directly, but missed the `fr` example file. This PR updates the `fr` to match the `en` file.

It also fixes a spacing issue in the typescript block of the Action extension template. 

We will make this template more robust when we finalize the AppChrome API. 

Generated template:

![Screenshot 2023-06-09 at 11 10 50 AM](https://github.com/Shopify/ui-extensions-templates/assets/7654369/66297734-5f2a-4007-bd6d-b7af14d67aba)

Extension:

![Screenshot 2023-06-09 at 11 11 24 AM](https://github.com/Shopify/ui-extensions-templates/assets/7654369/2696b2cf-a267-4fc5-b0bd-eaa94d5c7378)

