### PR TITLE
Add block extension templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # ui-extensions-templates
+
+This repo contains the templates used by `@shopify/app` CLI when generating extensions.

--- a/action-extension/README.md.liquid
+++ b/action-extension/README.md.liquid
@@ -1,4 +1,4 @@
 # Action Extension
 
 Action extensions let app developers build custom functionality that merchants can install at defined points in the
-admin flow. You can learn more about Action extensions in Shopify’s [developer documentation]().
+Shopify Admin experience. You can learn more about Action extensions in Shopify’s [developer documentation]().

--- a/action-extension/shopify.ui.extension.toml.liquid
+++ b/action-extension/shopify.ui.extension.toml.liquid
@@ -5,6 +5,7 @@ api_version = "2022-10"
 
 
 [[extension_points]]
+# The target used here must match the target used in the module file (./src/ActionExtension.{{ srcFileExtension }})
 target = "admin.product.index.action"
 module = "./src/ActionExtension.{{ srcFileExtension }}"
 label = "t:label"

--- a/block-extension/README.md.liquid
+++ b/block-extension/README.md.liquid
@@ -1,0 +1,4 @@
+# Block Extension
+
+Block extensions let app developers build custom functionality that merchants can install at defined points in the
+Shopify Admin experience. You can learn more about Block extensions in Shopify’s [developer documentation]().

--- a/block-extension/locales/en.default.json.liquid
+++ b/block-extension/locales/en.default.json.liquid
@@ -1,0 +1,4 @@
+{
+  "label": "{{ name }}",
+  "welcome": "Welcome to the {{extensionPoint}} extension!"
+}

--- a/block-extension/locales/fr.json.liquid
+++ b/block-extension/locales/fr.json.liquid
@@ -1,0 +1,4 @@
+{
+  "label": "{{ name }}",
+  "welcome": "Bienvenue dans l'extension {{extensionPoint}}!"
+}

--- a/block-extension/package.json.liquid
+++ b/block-extension/package.json.liquid
@@ -1,0 +1,25 @@
+{%- if flavor contains "react" -%}
+{
+  "name": "{{ name }}",
+  "version": "1.0.0",
+  "main": "dist/main.js",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "react": "^17.0.0",
+    "@shopify/ui-extensions-react": "0.0.0-unstable-20230602162636"
+  },
+  "devDependencies": {
+    "@types/react": "^17.0.0"
+  }
+}
+{%- else -%}
+{
+  "name": "{{ name }}",
+  "version": "1.0.0",
+  "main": "dist/main.js",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "@shopify/ui-extensions": "unstable"
+  }
+}
+{%- endif -%}

--- a/block-extension/shopify.ui.extension.toml.liquid
+++ b/block-extension/shopify.ui.extension.toml.liquid
@@ -1,0 +1,17 @@
+name = "{{ name }}"
+type = "ui_extension"
+
+api_version = "2022-10"
+
+
+[[extension_points]]
+# The target used here must match the target used in the module file (./src/BlockExtension.{{ srcFileExtension }})
+target = "admin.product.index.block"
+module = "./src/BlockExtension.{{ srcFileExtension }}"
+label = "t:label"
+
+
+# Valid extension points:
+# - admin.order.item.block
+# - admin.customer.item.block
+# - admin.product.item.block

--- a/block-extension/src/BlockExtension.liquid
+++ b/block-extension/src/BlockExtension.liquid
@@ -1,0 +1,37 @@
+{%- if flavor contains "react" -%}
+import {
+  reactExtension,
+  useApi,
+  Banner,
+} from '@shopify/ui-extensions-react/admin';
+{% if flavor contains "typescript" %}
+export default reactExtension<any>('admin.product.index.block', () => <App />);
+{% else %}
+export default reactExtension('admin.product.index.block', () => <App />);
+{% endif %}
+function App() {
+  {% if flavor contains "typescript" %}
+  const {extensionPoint, i18n} = useApi() as any;
+  {% else %}
+  const {extensionPoint, i18n} = useApi();
+  {% endif %}
+  return (
+    <Banner title="{{ name }}">
+      {i18n.translate('welcome', {extensionPoint})}
+    </Banner>
+  );
+}
+
+{%- else -%}
+import { extend, Banner } from "@shopify/ui-extensions/admin";
+
+extend("admin.product.index.action", (root, { extensionPoint, i18n }) => {
+  root.appendChild(
+    root.createComponent(
+      Banner,
+      { title: "{{ name }}" },
+      i18n.translate('welcome', {extensionPoint})
+    )
+  );
+});
+{%- endif -%}

--- a/block-extension/tsconfig.json
+++ b/block-extension/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  // This tsconfig.json file is only needed to inform the IDE
+  // About the `react-jsx` tsconfig option, so IDE don't complain about missing react import
+  // Changing options here won't affect the build of your extension
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": ["./src"]
+}


### PR DESCRIPTION
## What problem is this PR solving?

Partially resolves https://github.com/Shopify/app-ui/issues/144 
Closes https://github.com/Shopify/app-ui/issues/171

- Adds basic template for Block extension (We'll develop this further. This is just a starting point to start testing the CLI)
- Adds comment in toml file for both Action and Block to remind devs to make sure the targets match
- Tiny updates to readmes (We'll need to revisit these too)
