### PR TITLE
chore(localization): fix missing {{extensionPoint}} field in locale files

### DIFF
--- a/action-extension/locales/en.default.json.liquid
+++ b/action-extension/locales/en.default.json.liquid
@@ -1,4 +1,4 @@
 {
   "label": "{{ name }}",
-  "welcome": "Welcome to the {{extensionPoint}} extension!"
+  "welcome": "Welcome to the {% raw %}{{extensionPoint}}{% endraw %} extension!"
 }

--- a/action-extension/locales/fr.json.liquid
+++ b/action-extension/locales/fr.json.liquid
@@ -1,4 +1,4 @@
 {
   "label": "{{ name }}",
-  "welcome": "Bienvenue dans l'extension {{extensionPoint}}!"
+  "welcome": "Bienvenue dans l'extension {% raw %}{{extensionPoint}}{% endraw %}!"
 }

--- a/block-extension/locales/en.default.json.liquid
+++ b/block-extension/locales/en.default.json.liquid
@@ -1,4 +1,4 @@
 {
   "label": "{{ name }}",
-  "welcome": "Welcome to the {{extensionPoint}} extension!"
+  "welcome": "Welcome to the {% raw %}{{extensionPoint}}{% endraw %} extension!"
 }

--- a/block-extension/locales/fr.json.liquid
+++ b/block-extension/locales/fr.json.liquid
@@ -1,4 +1,4 @@
 {
   "label": "{{ name }}",
-  "welcome": "Bienvenue dans l'extension {{extensionPoint}}!"
+  "welcome": "Bienvenue dans l'extension {% raw %}{{extensionPoint}}{% endraw %}!"
 }


### PR DESCRIPTION
### Background

The `{{extensionPoint}}` template field in our scaffolded locale definitions was being interpolated by Liquid, but it's supposed to be literal text (that gets interpolated by i18n.translate() at runtime).
