### PR TITLE
Adding Product Configuration Extension template

### DIFF
--- a/product-configuration-extension/README.md.liquid
+++ b/product-configuration-extension/README.md.liquid
@@ -1,0 +1,5 @@
+# Product Configuration Extension
+
+The Product Configuration extensions let app developers build custom functionality at defined points in
+the Product Details and Product Variant Details sections of the Shopify Admin experience. 
+You can learn more about Product Configuration extensions in Shopify’s [developer documentation]().

--- a/product-configuration-extension/README.md.liquid
+++ b/product-configuration-extension/README.md.liquid
@@ -2,4 +2,4 @@
 
 The Product Configuration extensions let app developers build custom functionality at defined points in
 the Product Details and Product Variant Details sections of the Shopify Admin experience. 
-You can learn more about Product Configuration extensions in Shopify’s [developer documentation]().
+You can learn more about Product Configuration extensions in Shopify’s [developer documentation](https://shopify.dev/docs/apps/selling-strategies/bundles/ui).

--- a/product-configuration-extension/locales/en.default.json.liquid
+++ b/product-configuration-extension/locales/en.default.json.liquid
@@ -1,3 +1,3 @@
 {
-  "welcome": "Welcome to the {% raw %}{{extensionPoint}}{% endraw %} extension!"
+  "welcome": "Welcome to the {% raw %}{{target}}{% endraw %} extension!"
 }

--- a/product-configuration-extension/locales/en.default.json.liquid
+++ b/product-configuration-extension/locales/en.default.json.liquid
@@ -1,0 +1,3 @@
+{
+  "welcome": "Welcome to the {% raw %}{{extensionPoint}}{% endraw %} extension!"
+}

--- a/product-configuration-extension/locales/fr.json.liquid
+++ b/product-configuration-extension/locales/fr.json.liquid
@@ -1,3 +1,3 @@
 {
-  "welcome": "Bienvenue dans l'extension {% raw %}{{extensionPoint}}{% endraw %}!"
+  "welcome": "Bienvenue dans l'extension {% raw %}{{target}}{% endraw %}!"
 }

--- a/product-configuration-extension/locales/fr.json.liquid
+++ b/product-configuration-extension/locales/fr.json.liquid
@@ -1,0 +1,3 @@
+{
+  "welcome": "Bienvenue dans l'extension {% raw %}{{extensionPoint}}{% endraw %}!"
+}

--- a/product-configuration-extension/package.json.liquid
+++ b/product-configuration-extension/package.json.liquid
@@ -2,7 +2,6 @@
 {
   "name": "{{ handle }}",
   "version": "1.0.0",
-  "main": "dist/main.js",
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^17.0.0",

--- a/product-configuration-extension/package.json.liquid
+++ b/product-configuration-extension/package.json.liquid
@@ -1,0 +1,25 @@
+{%- if flavor contains "react" -%}
+{
+  "name": "{{ name }}",
+  "version": "1.0.0",
+  "main": "dist/main.js",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "react": "^17.0.0",
+    "@shopify/ui-extensions-react": "unstable"
+  },
+  "devDependencies": {
+    "@types/react": "^17.0.0"
+  }
+}
+{%- else -%}
+{
+  "name": "{{ name }}",
+  "version": "1.0.0",
+  "main": "dist/main.js",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "@shopify/ui-extensions": "unstable"
+  }
+}
+{%- endif -%}

--- a/product-configuration-extension/package.json.liquid
+++ b/product-configuration-extension/package.json.liquid
@@ -1,6 +1,6 @@
 {%- if flavor contains "react" -%}
 {
-  "name": "{{ name }}",
+  "name": "{{ handle }}",
   "version": "1.0.0",
   "main": "dist/main.js",
   "license": "UNLICENSED",

--- a/product-configuration-extension/shopify.extension.toml.liquid
+++ b/product-configuration-extension/shopify.extension.toml.liquid
@@ -1,16 +1,18 @@
-name = "{{ name }}"
-type = "ui_extension"
-
 api_version = "2023-07"
 
-# Both extension points are required
+[[extensions]]
+name = "t:name"
+handle = "{{ handle }}"
+type = "ui_extension"
 
-[[extension_points]]
+# Both extension points are required
+[[extensions.targeting]]
+module = "./src/ProductDetailsConfigurationExtension.{{ srcFileExtension }}"
 # The target used here must match the target used in the module file (./src/ProductDetailsConfigurationExtension.{{ srcFileExtension }})
 target = "admin.product-details.configuration.render"
-module = "./src/ProductDetailsConfigurationExtension.{{ srcFileExtension }}"
 
-[[extension_points]]
+
+[[extensions.targeting]]
+module = "./src/ProductVariantDetailsConfigurationExtension.{{ srcFileExtension }}"
 # The target used here must match the target used in the module file (./src/ProductVariantDetailsConfigurationExtension.{{ srcFileExtension }})
 target = "admin.product-variant-details.configuration.render"
-module = "./src/ProductVariantDetailsConfigurationExtension.{{ srcFileExtension }}"

--- a/product-configuration-extension/shopify.ui.extension.toml.liquid
+++ b/product-configuration-extension/shopify.ui.extension.toml.liquid
@@ -1,0 +1,16 @@
+name = "{{ name }}"
+type = "ui_extension"
+
+api_version = "unstable"
+
+# Both extension points are required
+
+[[extension_points]]
+# The target used here must match the target used in the module file (./src/ProductDetailsConfigurationExtension.{{ srcFileExtension }})
+target = "admin.product-details.configuration.render"
+module = "./src/ProductDetailsConfigurationExtension.{{ srcFileExtension }}"
+
+[[extension_points]]
+# The target used here must match the target used in the module file (./src/ProductVariantDetailsConfigurationExtension.{{ srcFileExtension }})
+target = "admin.product-variant-details.configuration.render"
+module = "./src/ProductVariantDetailsConfigurationExtension.{{ srcFileExtension }}"

--- a/product-configuration-extension/shopify.ui.extension.toml.liquid
+++ b/product-configuration-extension/shopify.ui.extension.toml.liquid
@@ -1,7 +1,7 @@
 name = "{{ name }}"
 type = "ui_extension"
 
-api_version = "unstable"
+api_version = "2023-07"
 
 # Both extension points are required
 

--- a/product-configuration-extension/src/ProductDetailsConfigurationExtension.liquid
+++ b/product-configuration-extension/src/ProductDetailsConfigurationExtension.liquid
@@ -5,7 +5,7 @@ import {
   Text,
 } from '@shopify/ui-extensions-react/admin';
 
-// The target used here must match the target used in the extension's toml file (./shopify.ui.extension.toml)
+// The target used here must match the target used in the extension's toml file (./shopify.extension.toml)
 {% if flavor contains "typescript" %}
 export default reactExtension<any>('admin.product-details.configuration.render', () => <App />);
 {% else %}
@@ -13,13 +13,13 @@ export default reactExtension('admin.product-details.configuration.render', () =
 {% endif %}
 function App() {
   {% if flavor contains "typescript" %}
-  const {extensionPoint, i18n} = useApi<'admin.product-details.configuration.render'>();
+  const {extension: {target}, i18n} = useApi<'admin.product-details.configuration.render'>();
   {% else %}
-  const {extensionPoint, i18n} = useApi();
+  const {extension: {target}, i18n} = useApi();
   {% endif %}
   return (
     <Text>
-      {i18n.translate('welcome', {extensionPoint})}
+      {i18n.translate('welcome', {target})}
     </Text>
   );
 }
@@ -27,12 +27,12 @@ function App() {
 {%- else -%}
 import { extend, Banner } from "@shopify/ui-extensions/admin";
 
-extend("admin.product-details.configuration.render", (root, { extensionPoint, i18n }) => {
+extend("admin.product-details.configuration.render", (root, { extension: {target}, i18n }) => {
   root.appendChild(
     root.createComponent(
       Text,
       {},
-      i18n.translate('welcome', {extensionPoint})
+      i18n.translate('welcome', {target})
     )
   );
 });

--- a/product-configuration-extension/src/ProductDetailsConfigurationExtension.liquid
+++ b/product-configuration-extension/src/ProductDetailsConfigurationExtension.liquid
@@ -1,0 +1,39 @@
+{%- if flavor contains "react" -%}
+import {
+  reactExtension,
+  useApi,
+  Text,
+} from '@shopify/ui-extensions-react/admin';
+
+// The target used here must match the target used in the extension's toml file (./shopify.ui.extension.toml)
+{% if flavor contains "typescript" %}
+export default reactExtension<any>('admin.product-details.configuration.render', () => <App />);
+{% else %}
+export default reactExtension('admin.product-details.configuration.render', () => <App />);
+{% endif %}
+function App() {
+  {% if flavor contains "typescript" %}
+  const {extensionPoint, i18n} = useApi<'admin.product-details.configuration.render'>();
+  {% else %}
+  const {extensionPoint, i18n} = useApi();
+  {% endif %}
+  return (
+    <Text>
+      {i18n.translate('welcome', {extensionPoint})}
+    </Text>
+  );
+}
+
+{%- else -%}
+import { extend, Banner } from "@shopify/ui-extensions/admin";
+
+extend("admin.product-details.configuration.render", (root, { extensionPoint, i18n }) => {
+  root.appendChild(
+    root.createComponent(
+      Text,
+      {},
+      i18n.translate('welcome', {extensionPoint})
+    )
+  );
+});
+{%- endif -%}

--- a/product-configuration-extension/src/ProductVariantDetailsConfigurationExtension.liquid
+++ b/product-configuration-extension/src/ProductVariantDetailsConfigurationExtension.liquid
@@ -15,7 +15,7 @@ function App() {
   {% if flavor contains "typescript" %}
   const {extension: {target}, i18n} = useApi<'admin.product-variant-details.configuration.render'>();
   {% else %}
-  const {extensionPoint, i18n} = useApi();
+  const {extension: {target}, i18n} = useApi();
   {% endif %}
   return (
     <Text>

--- a/product-configuration-extension/src/ProductVariantDetailsConfigurationExtension.liquid
+++ b/product-configuration-extension/src/ProductVariantDetailsConfigurationExtension.liquid
@@ -1,0 +1,39 @@
+{%- if flavor contains "react" -%}
+import {
+  reactExtension,
+  useApi,
+  Text,
+} from '@shopify/ui-extensions-react/admin';
+
+// The target used here must match the target used in the extension's toml file (./shopify.ui.extension.toml)
+{% if flavor contains "typescript" %}
+export default reactExtension<any>('admin.product-variant-details.configuration.render', () => <App />);
+{% else %}
+export default reactExtension('admin.product-variant-details.configuration.render', () => <App />);
+{% endif %}
+function App() {
+  {% if flavor contains "typescript" %}
+  const {extensionPoint, i18n} = useApi<'admin.product-variant-details.configuration.render'>();
+  {% else %}
+  const {extensionPoint, i18n} = useApi();
+  {% endif %}
+  return (
+    <Text>
+      {i18n.translate('welcome', {extensionPoint})}
+    </Text>
+  );
+}
+
+{%- else -%}
+import { extend, Banner } from "@shopify/ui-extensions/admin";
+
+extend("admin.product-variant-details.configuration.render", (root, { extensionPoint, i18n }) => {
+  root.appendChild(
+    root.createComponent(
+      Text,
+      {},
+      i18n.translate('welcome', {extensionPoint})
+    )
+  );
+});
+{%- endif -%}

--- a/product-configuration-extension/src/ProductVariantDetailsConfigurationExtension.liquid
+++ b/product-configuration-extension/src/ProductVariantDetailsConfigurationExtension.liquid
@@ -5,7 +5,7 @@ import {
   Text,
 } from '@shopify/ui-extensions-react/admin';
 
-// The target used here must match the target used in the extension's toml file (./shopify.ui.extension.toml)
+// The target used here must match the target used in the extension's toml file (./shopify.extension.toml)
 {% if flavor contains "typescript" %}
 export default reactExtension<any>('admin.product-variant-details.configuration.render', () => <App />);
 {% else %}
@@ -13,13 +13,13 @@ export default reactExtension('admin.product-variant-details.configuration.rende
 {% endif %}
 function App() {
   {% if flavor contains "typescript" %}
-  const {extensionPoint, i18n} = useApi<'admin.product-variant-details.configuration.render'>();
+  const {extension: {target}, i18n} = useApi<'admin.product-variant-details.configuration.render'>();
   {% else %}
   const {extensionPoint, i18n} = useApi();
   {% endif %}
   return (
     <Text>
-      {i18n.translate('welcome', {extensionPoint})}
+      {i18n.translate('welcome', {target})}
     </Text>
   );
 }
@@ -27,12 +27,12 @@ function App() {
 {%- else -%}
 import { extend, Banner } from "@shopify/ui-extensions/admin";
 
-extend("admin.product-variant-details.configuration.render", (root, { extensionPoint, i18n }) => {
+extend("admin.product-variant-details.configuration.render", (root, { extension: {target}, i18n }) => {
   root.appendChild(
     root.createComponent(
       Text,
       {},
-      i18n.translate('welcome', {extensionPoint})
+      i18n.translate('welcome', {target})
     )
   );
 });

--- a/product-configuration-extension/tsconfig.json
+++ b/product-configuration-extension/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  // This tsconfig.json file is only needed to inform the IDE
+  // About the `react-jsx` tsconfig option, so IDE don't complain about missing react import
+  // Changing options here won't affect the build of your extension
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": ["./src"]
+}


### PR DESCRIPTION
### Background
Part of https://github.com/Shopify/core-issues/issues/57533
Related to https://github.com/Shopify/ui-extensions/pull/1069

### Solution
Adds a new template for Bundles UI Extension

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
