### PR TITLE
feat: clean up name / title

### DIFF
--- a/action-extension/locales/en.default.json.liquid
+++ b/action-extension/locales/en.default.json.liquid
@@ -1,4 +1,4 @@
 {
-  "label": "{{ name }}",
+  "name": "{{ name }}",
   "welcome": "Welcome to the {% raw %}{{target}}{% endraw %} extension!"
 }

--- a/action-extension/locales/fr.json.liquid
+++ b/action-extension/locales/fr.json.liquid
@@ -1,4 +1,4 @@
 {
-  "label": "{{ name }}",
+  "name": "{{ name }}",
   "welcome": "Bienvenue dans l'extension {% raw %}{{target}}{% endraw %}!"
 }

--- a/action-extension/shopify.extension.toml.liquid
+++ b/action-extension/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-name = "t:label"
+name = "t:name"
 api_version = "unstable"
 
 [[extensions]]

--- a/action-extension/src/ActionExtension.liquid
+++ b/action-extension/src/ActionExtension.liquid
@@ -50,7 +50,6 @@ function App() {
   return (
     // The AdminAction component provides an API for setting the title and actions of the Action extension wrapper.
     <AdminAction
-      title="{{ name }}"
       primaryAction={
         <Button
           onPress={() => {
@@ -96,7 +95,6 @@ extend("admin.product-details.action.render", (root, { extension: {target}, i18n
       // The AdminAction component provides an API for setting the title and actions of the Action extension wrapper.
       AdminAction,
       {
-        title: "{{ name }}",
         primaryAction: root.createComponent(Button, {
           onPress: () => {
             console.log("saving");

--- a/block-extension/src/BlockExtension.liquid
+++ b/block-extension/src/BlockExtension.liquid
@@ -22,7 +22,7 @@ function App() {
 
   return (
     // The AdminBlock component provides an API for setting the title and summary of the Block extension wrapper.
-    <AdminBlock title="{{ name }}" summary="3 items">
+    <AdminBlock summary="3 items">
       {i18n.translate('welcome', {target})}
     </AdminBlock>
   );
@@ -37,7 +37,7 @@ extend("admin.product-details.block.render", (root, { extension: {target}, i18n,
   root.appendChild(
     root.createComponent(
       AdminBlock,
-      { title: "{{ name }}", summary: "3 items" },
+      { summary: "3 items" },
       i18n.translate('welcome', {target})
     )
   );


### PR DESCRIPTION
### Background

Make name translatable in Action and Block templates.

### Solution

Add `t:` to `name` to indicate translation-ready value.

### Checklist

- [x] I have squashed my commits into chunks of work with meaningful commit messages
