### PR TITLE
Change label to name in block extension

### DIFF
--- a/block-extension/locales/en.default.json.liquid
+++ b/block-extension/locales/en.default.json.liquid
@@ -1,4 +1,4 @@
 {
-  "label": "{{ name }}",
+  "name": "{{ name }}",
   "welcome": "Welcome to the {% raw %}{{target}}{% endraw %} extension!"
 }

--- a/block-extension/locales/fr.json.liquid
+++ b/block-extension/locales/fr.json.liquid
@@ -1,4 +1,4 @@
 {
-  "label": "{{ name }}",
+  "name": "{{ name }}",
   "welcome": "Bienvenue dans l'extension {% raw %}{{target}}{% endraw %}!"
 }

--- a/block-extension/shopify.extension.toml.liquid
+++ b/block-extension/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-name = "t:label"
+name = "t:name"
 api_version = "unstable"
 
 [[extensions]]


### PR DESCRIPTION
### Background

We are using name in the toml and translation files. This change is being made to be consistent with Action extension.

### Solution

Change label to name in block extension template.

### Checklist

- [x] I have squashed my commits into chunks of work with meaningful commit messages
