### PR TITLE
add checkout-extension template

### DIFF
--- a/checkout-extension/README.md.liquid
+++ b/checkout-extension/README.md.liquid
@@ -1,0 +1,89 @@
+# Checkout UI Extension
+
+Checkout UI extensions let app developers build custom functionality that merchants can install at defined points in the checkout flow. You can learn more about checkout UI extensions in Shopify’s [developer documentation](https://shopify.dev/api/checkout-extensions/checkout).
+
+
+## Prerequisites
+Make sure to complete [all the prerequisites](https://shopify.dev/apps/checkout/delivery-instructions/getting-started#requirements) from any tutorials to develop a Checkout UI extension.
+
+## Tutorials
+The best way to get started is to follow some of the available Extension Tutorials:
+
+For creating an extension:
+* [Enable extended delivery instructions](https://shopify.dev/apps/checkout/delivery-instructions)
+* [Adding product offer recommendations](https://shopify.dev/apps/checkout/product-offers)
+* [Creating a custom banner](https://shopify.dev/apps/checkout/custom-banners)
+
+To add specific features to an extension
+* [Adding field validation](https://shopify.dev/apps/checkout/validation)
+* [Localizing an extension](https://shopify.dev/apps/checkout/localize-ui-extensions)
+
+## Getting Started
+Initially, your extension will have the following files:
+
+```
+└── my-app
+  └── extensions
+    └── my-checkout-ui-extension
+        ├── src
+        │   └── AdminCheckoutEditorRenderSettings.{{ srcFileExtension }} The source code for the ADMIN::CHECKOUT::EDITOR extension point
+        │   └── CheckoutDynamicRender.{{ srcFileExtension }} The source code for the CHECKOUT:DYNAMIC::RENDER extension point
+        ├── locales
+        │   ├── en.default.json // The default locale for the checkout UI extension. Shared across all extension points.
+        │   └── fr.json // The locale file for non-regional French translations. Shared across all extension points.
+        └── shopify.ui.extension.toml // The config file for the checkout UI extension
+
+```
+
+You can customize your new extension by editing the code in the `src/AdminCheckoutEditorRenderSettings.{{ srcFileExtension }}` or `src/CheckoutDynamicRender.{{ srcFileExtension }}` file.
+
+> By default, your extension is configured to target the `Checkout::Dynamic::Render` [extension point](https://shopify.dev/api/checkout-extensions/checkout#extension-points). This extension point does not have a single location in the checkout where it will appear; instead, a merchant installing your extension will configure where *they* want your extension to show up.
+> If you are building an extension that is tied to existing UI element in the checkout, such as the cart lines or shipping method, you can change the extension point so that your UI extension will render in the correct location. Check out the list of [all available extension points](https://shopify.dev/api/checkout-extensions/checkout#extension-points) to get some inspiration for the kinds of content you can provide with checkout UI extensions.
+
+You can add new extension points by adding a new entry point to `src/shopify.ui.extension.toml`, e.g:
+
+```` toml
+[[extension_points]]
+target = "Checkout::CartLines::RenderAfter"
+module = "./src/CheckoutCartLinesRenderAfter.{{ srcFileExtension }}"
+````
+
+You would then add a new file at `src/CheckoutCartLinesRenderAfter.{{ srcFileExtension }}`.
+
+To shape your extension you have the following collection of tools available:
+
+* [Checkout UI components](https://shopify.dev/api/checkout-extensions/checkout/components), the visual elements you can render in your checkout extension points.
+* Admin UI Extensions for [React](https://github.com/Shopify/ui-extensions/tree/main/packages/admin-ui-extensions-react) & [JavaScript](https://github.com/Shopify/ui-extensions/tree/main/packages/admin-ui-extensions)
+* [Extension APIs](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api), which give you access to read and write data in the checkout.
+
+> If you are using React, there is also a large collection of [React Hooks available](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#react-hooks) to ease access to these operations, otherwise you'll need to manually subscribe to the subscribable value directly with a callback.
+
+## FAQ
+* **How can I preview my extension?**
+
+  1. Make sure you've started your local development server using `npm|yarn|pnpm dev`
+  2. Depending on your selected location they may be either `dynamic` or `static` extension points, which diferr slightly on the process to preview them.
+      - `Dynamic extensions` can be placed using a [query string parameter](https://shopify.dev/apps/checkout/test-ui-extensions#dynamic-extension-points).
+      - `Static extensions` require no extra work, just note that a static extension is shown only if the section that they are attached to is enabled.
+
+* **How can I change my extension type?**
+
+    To change your extension type, be mindful that you have to change it in the following places:
+    1. In your `script file`, where you declared the extension (will be either _render()_ or _extend()_), you'll have to change the declared Extension Point.
+    2. In your `settings TOML file` (shopify.ui.extension.toml) you'll have to change the `extension_points` declaration for your new desired type.
+
+* **How do I let merchants customize my extension?**
+
+    You can enable merchants to customize your extension through the [checkout ui extension settings](https://shopify.dev/api/checkout-extensions/checkout/configuration#settings-definition) which define a set of fields and values that the merchant can set from the checkout editor. You can use validation options to apply additional constraints to the data that the setting can store, such as a minimum or maximum value.
+
+    To learn more, you can follow the step-by-step process in the tutorial to [add a custom banner](https://shopify.dev/apps/checkout/custom-banners/add-custom-banner).
+
+## Useful Links
+
+- [Checkout app documentation](https://shopify.dev/apps/checkout)
+
+- [Checkout UI extension documentation](https://shopify.dev/api/checkout-extensions)
+  - [Configuration](https://shopify.dev/api/checkout-extensions/checkout/configuration)
+  - [API Reference](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api)
+  - [UI Components](https://shopify.dev/api/checkout-extensions/checkout/components)
+  - [Available React Hooks](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#react-hooks)

--- a/checkout-extension/README.md.liquid
+++ b/checkout-extension/README.md.liquid
@@ -1,6 +1,6 @@
 # Checkout UI Extension
 
-Checkout UI extensions let app developers build custom functionality that merchants can install at defined points in the checkout flow. You can learn more about checkout UI extensions in Shopify’s [developer documentation](https://shopify.dev/api/checkout-extensions/checkout).
+Checkout UI extensions let app developers build custom functionality that merchants can install at defined targets in the checkout flow. You can learn more about checkout UI extensions in Shopify’s [developer documentation](https://shopify.dev/api/checkout-extensions/checkout).
 
 
 ## Prerequisites
@@ -39,7 +39,7 @@ You can customize your new extension by editing the code in the `src/CheckoutDyn
 > By default, your extension is configured to target the `purchase.checkout.block.render` [extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview). This extension target does not have a single location in the checkout where it will appear; instead, a merchant installing your extension will configure where *they* want your extension to show up.
 > If you are building an extension that is tied to existing UI element in the checkout, such as the cart lines or shipping method, you can change the extension target so that your UI extension will render in the correct location. Check out the list of [all available extension targets](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview) to get some inspiration for the kinds of content you can provide with checkout UI extensions.
 
-You can add new extension targets by adding a new entry point to `src/shopify.extension.toml`, e.g:
+You can add new extension targets by adding a new entry to `src/shopify.extension.toml`, e.g:
 
 ```` toml
 [[extensions.targeting]]
@@ -58,18 +58,18 @@ To shape your extension you have the following collection of tools available:
 > If you are using React, there is also a large collection of [React Hooks available](https://shopify.dev/docs/api/checkout-ui-extensions/react-hooks) to ease access to these operations, otherwise you'll need to manually subscribe to the subscribable value directly with a callback.
 
 ## FAQ
-* **How can I preview my extension?**
+* **How can I switch my extension between static and dynamic?**
 
   1. Make sure you've started your local development server using `npm|yarn|pnpm dev`
   2. Depending on your selected location they may be either `dynamic` or `static` extension targets, which diferr slightly on the process to preview them.
-      - `Dynamic extensions` can be placed using a [query string parameter](https://shopify.dev/apps/checkout/test-ui-extensions#dynamic-extension-points).
+      - `Dynamic extensions` can be placed using a [query string parameter](https://shopify.dev/apps/checkout/test-ui-extensions#dynamic-extension-targets).
       - `Static extensions` require no extra work, just note that a static extension is shown only if the section that they are attached to is enabled.
 
 * **How can I change my extension type?**
 
     To change your extension type, be mindful that you have to change it in the following places:
     1. In your `script file`, where you declared the extension (will be either _render()_ or _extend()_), you'll have to change the declared extension target.
-    2. In your `settings TOML file` (shopify.extension.toml) you'll have to change the `extension_points` declaration for your new desired type.
+    2. In your `settings TOML file` (shopify.extension.toml) you'll have to change the `[[extensions.targeting]]` declaration for your new desired target.
 
 * **How do I let merchants customize my extension?**
 

--- a/checkout-extension/README.md.liquid
+++ b/checkout-extension/README.md.liquid
@@ -26,24 +26,24 @@ Initially, your extension will have the following files:
   └── extensions
     └── my-checkout-ui-extension
         ├── src
-        │   └── CheckoutDynamicRender.{{ srcFileExtension }} The source code for the CHECKOUT:DYNAMIC::RENDER extension point
+        │   └── CheckoutDynamicRender.{{ srcFileExtension }} The source code for the `purchase.checkout.block.render` extension target
         ├── locales
-        │   ├── en.default.json // The default locale for the checkout UI extension. Shared across all extension points.
-        │   └── fr.json // The locale file for non-regional French translations. Shared across all extension points.
-        └── shopify.ui.extension.toml // The config file for the checkout UI extension
+        │   ├── en.default.json // The default locale for the checkout UI extension. Shared across all extension targets.
+        │   └── fr.json // The locale file for non-regional French translations. Shared across all extension targets.
+        └── shopify.extension.toml // The config file for the checkout UI extension
 
 ```
 
 You can customize your new extension by editing the code in the `src/CheckoutDynamicRender.{{ srcFileExtension }}` file.
 
-> By default, your extension is configured to target the `Checkout::Dynamic::Render` [extension point](https://shopify.dev/api/checkout-extensions/checkout#extension-points). This extension point does not have a single location in the checkout where it will appear; instead, a merchant installing your extension will configure where *they* want your extension to show up.
-> If you are building an extension that is tied to existing UI element in the checkout, such as the cart lines or shipping method, you can change the extension point so that your UI extension will render in the correct location. Check out the list of [all available extension points](https://shopify.dev/api/checkout-extensions/checkout#extension-points) to get some inspiration for the kinds of content you can provide with checkout UI extensions.
+> By default, your extension is configured to target the `purchase.checkout.block.render` [extension target](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview). This extension target does not have a single location in the checkout where it will appear; instead, a merchant installing your extension will configure where *they* want your extension to show up.
+> If you are building an extension that is tied to existing UI element in the checkout, such as the cart lines or shipping method, you can change the extension target so that your UI extension will render in the correct location. Check out the list of [all available extension targets](https://shopify.dev/docs/api/checkout-ui-extensions/extension-targets-overview) to get some inspiration for the kinds of content you can provide with checkout UI extensions.
 
-You can add new extension points by adding a new entry point to `src/shopify.ui.extension.toml`, e.g:
+You can add new extension targets by adding a new entry point to `src/shopify.extension.toml`, e.g:
 
 ```` toml
-[[extension_points]]
-target = "Checkout::CartLines::RenderAfter"
+[[extensions.targeting]]
+target = "purchase.checkout.cart-line-item.render-after"
 module = "./src/CheckoutCartLinesRenderAfter.{{ srcFileExtension }}"
 ````
 
@@ -51,29 +51,29 @@ You would then add a new file at `src/CheckoutCartLinesRenderAfter.{{ srcFileExt
 
 To shape your extension you have the following collection of tools available:
 
-* [Checkout UI components](https://shopify.dev/api/checkout-extensions/checkout/components), the visual elements you can render in your checkout extension points.
+* [Checkout UI components](https://shopify.dev/docs/api/checkout-ui-extensions/components), the visual elements you can render in your checkout extension targets.
 * Admin UI Extensions for [React](https://github.com/Shopify/ui-extensions/tree/main/packages/admin-ui-extensions-react) & [JavaScript](https://github.com/Shopify/ui-extensions/tree/main/packages/admin-ui-extensions)
-* [Extension APIs](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api), which give you access to read and write data in the checkout.
+* [Extension APIs](https://shopify.dev/docs/docs/api/checkout-ui-extensions/apis/extensiontargets), which give you access to read and write data in the checkout.
 
-> If you are using React, there is also a large collection of [React Hooks available](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#react-hooks) to ease access to these operations, otherwise you'll need to manually subscribe to the subscribable value directly with a callback.
+> If you are using React, there is also a large collection of [React Hooks available](https://shopify.dev/docs/api/checkout-ui-extensions/react-hooks) to ease access to these operations, otherwise you'll need to manually subscribe to the subscribable value directly with a callback.
 
 ## FAQ
 * **How can I preview my extension?**
 
   1. Make sure you've started your local development server using `npm|yarn|pnpm dev`
-  2. Depending on your selected location they may be either `dynamic` or `static` extension points, which diferr slightly on the process to preview them.
+  2. Depending on your selected location they may be either `dynamic` or `static` extension targets, which diferr slightly on the process to preview them.
       - `Dynamic extensions` can be placed using a [query string parameter](https://shopify.dev/apps/checkout/test-ui-extensions#dynamic-extension-points).
       - `Static extensions` require no extra work, just note that a static extension is shown only if the section that they are attached to is enabled.
 
 * **How can I change my extension type?**
 
     To change your extension type, be mindful that you have to change it in the following places:
-    1. In your `script file`, where you declared the extension (will be either _render()_ or _extend()_), you'll have to change the declared Extension Point.
-    2. In your `settings TOML file` (shopify.ui.extension.toml) you'll have to change the `extension_points` declaration for your new desired type.
+    1. In your `script file`, where you declared the extension (will be either _render()_ or _extend()_), you'll have to change the declared extension target.
+    2. In your `settings TOML file` (shopify.extension.toml) you'll have to change the `extension_points` declaration for your new desired type.
 
 * **How do I let merchants customize my extension?**
 
-    You can enable merchants to customize your extension through the [checkout ui extension settings](https://shopify.dev/api/checkout-extensions/checkout/configuration#settings-definition) which define a set of fields and values that the merchant can set from the checkout editor. You can use validation options to apply additional constraints to the data that the setting can store, such as a minimum or maximum value.
+    You can enable merchants to customize your extension through the [checkout ui extension settings](https://shopify.dev/docs/api/checkout-ui-extensions/configuration#settings-definition) which define a set of fields and values that the merchant can set from the checkout editor. You can use validation options to apply additional constraints to the data that the setting can store, such as a minimum or maximum value.
 
     To learn more, you can follow the step-by-step process in the tutorial to [add a custom banner](https://shopify.dev/apps/checkout/custom-banners/add-custom-banner).
 
@@ -82,7 +82,7 @@ To shape your extension you have the following collection of tools available:
 - [Checkout app documentation](https://shopify.dev/apps/checkout)
 
 - [Checkout UI extension documentation](https://shopify.dev/api/checkout-extensions)
-  - [Configuration](https://shopify.dev/api/checkout-extensions/checkout/configuration)
-  - [API Reference](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api)
-  - [UI Components](https://shopify.dev/api/checkout-extensions/checkout/components)
-  - [Available React Hooks](https://shopify.dev/api/checkout-extensions/checkout/extension-points/api#react-hooks)
+  - [Configuration](https://shopify.dev/docs/api/checkout-ui-extensions/configuration)
+  - [API Reference](https://shopify.dev/docs/api/checkout-ui-extensions/apis)
+  - [UI Components](https://shopify.dev/docs/api/checkout-ui-extensions/components)
+  - [Available React Hooks](https://shopify.dev/docs/api/checkout-ui-extensions/react-hooks)

--- a/checkout-extension/README.md.liquid
+++ b/checkout-extension/README.md.liquid
@@ -26,7 +26,6 @@ Initially, your extension will have the following files:
   └── extensions
     └── my-checkout-ui-extension
         ├── src
-        │   └── AdminCheckoutEditorRenderSettings.{{ srcFileExtension }} The source code for the ADMIN::CHECKOUT::EDITOR extension point
         │   └── CheckoutDynamicRender.{{ srcFileExtension }} The source code for the CHECKOUT:DYNAMIC::RENDER extension point
         ├── locales
         │   ├── en.default.json // The default locale for the checkout UI extension. Shared across all extension points.
@@ -35,7 +34,7 @@ Initially, your extension will have the following files:
 
 ```
 
-You can customize your new extension by editing the code in the `src/AdminCheckoutEditorRenderSettings.{{ srcFileExtension }}` or `src/CheckoutDynamicRender.{{ srcFileExtension }}` file.
+You can customize your new extension by editing the code in the `src/CheckoutDynamicRender.{{ srcFileExtension }}` file.
 
 > By default, your extension is configured to target the `Checkout::Dynamic::Render` [extension point](https://shopify.dev/api/checkout-extensions/checkout#extension-points). This extension point does not have a single location in the checkout where it will appear; instead, a merchant installing your extension will configure where *they* want your extension to show up.
 > If you are building an extension that is tied to existing UI element in the checkout, such as the cart lines or shipping method, you can change the extension point so that your UI extension will render in the correct location. Check out the list of [all available extension points](https://shopify.dev/api/checkout-extensions/checkout#extension-points) to get some inspiration for the kinds of content you can provide with checkout UI extensions.

--- a/checkout-extension/locales/en.default.json
+++ b/checkout-extension/locales/en.default.json
@@ -1,0 +1,3 @@
+{
+  "welcome": "Welcome to the {{target}} extension!"
+}

--- a/checkout-extension/locales/fr.json
+++ b/checkout-extension/locales/fr.json
@@ -1,0 +1,3 @@
+{
+  "welcome": "Bienvenue dans l'extension {{target}}!"
+}

--- a/checkout-extension/package.json.liquid
+++ b/checkout-extension/package.json.liquid
@@ -1,0 +1,25 @@
+{%- if flavor contains "react" -%}
+{
+  "name": "{{ name }}",
+  "version": "1.0.0",
+  "main": "dist/main.js",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "react": "^17.0.0",
+    "@shopify/ui-extensions-react": "2023.7.x"
+  },
+  "devDependencies": {
+    "@types/react": "^17.0.0"
+  }
+}
+{%- else -%}
+{
+  "name": "{{ name }}",
+  "version": "1.0.0",
+  "main": "dist/main.js",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "@shopify/ui-extensions": "2023.7.x"
+  }
+}
+{%- endif -%}

--- a/checkout-extension/package.json.liquid
+++ b/checkout-extension/package.json.liquid
@@ -2,7 +2,6 @@
 {
   "name": "{{ name }}",
   "version": "1.0.0",
-  "main": "dist/main.js",
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^17.0.0",
@@ -16,7 +15,6 @@
 {
   "name": "{{ name }}",
   "version": "1.0.0",
-  "main": "dist/main.js",
   "license": "UNLICENSED",
   "dependencies": {
     "@shopify/ui-extensions": "2023.7.x"

--- a/checkout-extension/package.json.liquid
+++ b/checkout-extension/package.json.liquid
@@ -1,6 +1,6 @@
 {%- if flavor contains "react" -%}
 {
-  "name": "{{ name }}",
+  "name": "{{ handle }}",
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
@@ -13,7 +13,7 @@
 }
 {%- else -%}
 {
-  "name": "{{ name }}",
+  "name": "{{ handle }}",
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {

--- a/checkout-extension/shopify.extension.toml.liquid
+++ b/checkout-extension/shopify.extension.toml.liquid
@@ -1,10 +1,10 @@
 # Learn more about configuring your checkout UI extension:
 # https://shopify.dev/api/checkout-extensions/checkout/configuration
 
-name = "{{ name }}"
 api_version = "2023-07"
 
 [[extensions]]
+name = "{{ name }}"
 type = "ui_extension"
 handle = "{{ handle }}"
 

--- a/checkout-extension/shopify.extension.toml.liquid
+++ b/checkout-extension/shopify.extension.toml.liquid
@@ -1,0 +1,35 @@
+# Learn more about configuring your checkout UI extension:
+# https://shopify.dev/api/checkout-extensions/checkout/configuration
+
+name = "{{ name }}"
+api_version = "2023-07"
+
+[[extensions]]
+type = "ui_extension"
+handle = "{{ handle }}"
+
+# [[extensions.metafields]]
+# namespace = "my-namespace"
+# key = "my-key"
+# [[extensions.metafields]]
+# namespace = "my-namespace"
+# key = "my-other-key"
+
+[extensions.capabilities]
+api_access = true
+network_access = true
+block_progress = true
+
+# [extensions.settings]
+#   [[extensions.settings.fields]]
+#   key = "banner_title"
+#   type = "single_line_text_field"
+#   name = "Banner title"
+#   description = "Enter a title for the banner"
+
+[[extensions.targeting]]
+module = "./src/CheckoutDynamicRender.{{ srcFileExtension }}"
+target = "Checkout::Dynamic::Render"
+
+
+

--- a/checkout-extension/src/CheckoutDynamicRender.liquid
+++ b/checkout-extension/src/CheckoutDynamicRender.liquid
@@ -5,7 +5,6 @@ import {
   useTranslate,
   reactExtension,
   Banner,
-
 } from '@shopify/ui-extensions-react/checkout';
 
 export default reactExtension('Checkout::Dynamic::Render', () => <App />);

--- a/checkout-extension/src/CheckoutDynamicRender.liquid
+++ b/checkout-extension/src/CheckoutDynamicRender.liquid
@@ -1,0 +1,35 @@
+{%- if flavor contains "react" -%}
+import React from 'react';
+import {
+  useApi,
+  useTranslate,
+  reactExtension,
+  Banner,
+
+} from '@shopify/ui-extensions-react/checkout';
+
+export default reactExtension('Checkout::Dynamic::Render', () => <App />);
+
+function App() {
+  const { extension: { target } } = useApi();
+  const translate = useTranslate();
+  return (
+    <Banner title="{{ name }}">
+      {translate('welcome', {target})}
+    </Banner>
+  );
+}
+
+{%- else -%}
+import { extension, Banner } from "@shopify/ui-extensions/checkout";
+
+export default extension("purchase.checkout.block.render", (root, { extension: { target } , i18n }) => {
+  root.appendChild(
+    root.createComponent(
+      Banner,
+      { title: "{{ name }}" },
+      i18n.translate('welcome', {target})
+    )
+  );
+});
+{%- endif -%}

--- a/checkout-extension/tsconfig.json
+++ b/checkout-extension/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  // This tsconfig.json file is only needed to inform the IDE
+  // About the `react-jsx` tsconfig option, so IDE don't complain about missing react import
+  // Changing options here won't affect the build of your extension
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": ["./src"]
+}


### PR DESCRIPTION
### Background
Closes https://github.com/Shopify/cli/issues/2199.
Related to https://github.com/Shopify/checkout-web/issues/21910.

Adds the ui-extension template for checkout using the new toml spec and soon to be released `ui-extensions@2023.7`.

This also requires a updated ruby spec in partners to use this new template.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
