### PR TITLE
Change target names in checkout-extension template

### DIFF
--- a/checkout-extension/shopify.extension.toml.liquid
+++ b/checkout-extension/shopify.extension.toml.liquid
@@ -29,7 +29,7 @@ block_progress = true
 
 [[extensions.targeting]]
 module = "./src/CheckoutDynamicRender.{{ srcFileExtension }}"
-target = "Checkout::Dynamic::Render"
+target = "purchase.checkout.block.render"
 
 
 

--- a/checkout-extension/src/CheckoutDynamicRender.liquid
+++ b/checkout-extension/src/CheckoutDynamicRender.liquid
@@ -7,7 +7,7 @@ import {
   Banner,
 } from '@shopify/ui-extensions-react/checkout';
 
-export default reactExtension('Cpurchase.checkout.block.render', () => <App />);
+export default reactExtension('purchase.checkout.block.render', () => <App />);
 
 function App() {
   const { extension: { target } } = useApi();

--- a/checkout-extension/src/CheckoutDynamicRender.liquid
+++ b/checkout-extension/src/CheckoutDynamicRender.liquid
@@ -7,7 +7,7 @@ import {
   Banner,
 } from '@shopify/ui-extensions-react/checkout';
 
-export default reactExtension('Checkout::Dynamic::Render', () => <App />);
+export default reactExtension('Cpurchase.checkout.block.render', () => <App />);
 
 function App() {
   const { extension: { target } } = useApi();


### PR DESCRIPTION
### Background

Ensure the new `purchase.checkout.block.render` is used as opposed to `Checkout::Dynamic::Render`.

### Solution

Update the target name.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
