### PR TITLE
Polish block and action templates

### DIFF
--- a/admin-action/shopify.extension.toml.liquid
+++ b/admin-action/shopify.extension.toml.liquid
@@ -1,6 +1,7 @@
 api_version = "2023-07"
 
 [[extensions]]
+# Change the merchant-facing name of the extension in locales/en.default.json
 name = "t:name"
 handle = "{{ handle }}"
 type = "ui_extension"

--- a/admin-action/src/ActionExtension.liquid
+++ b/admin-action/src/ActionExtension.liquid
@@ -4,21 +4,19 @@ import {
   reactExtension,
   useApi,
   AdminAction,
+  BlockStack,
   Button,
+  Text,
 } from '@shopify/ui-extensions-react/admin';
 
 // The target used here must match the target used in the extension's toml file (./shopify.extension.toml)
-{% if flavor contains "typescript" %}
-export default reactExtension<any>('admin.product-details.action.render', () => <App />);
-{% else %}
-export default reactExtension('admin.product-details.action.render', () => <App />);
+{% if flavor contains "typescript" %}export default reactExtension<any>('admin.product-details.action.render', () => <App />);
+{% else %}export default reactExtension('admin.product-details.action.render', () => <App />);
 {% endif %}
 function App() {
   // The useApi hook provides access to several useful APIs like i18n, close, and data.
-  {% if flavor contains "typescript" %}
-  const {extension: {target}, i18n, close, data} = useApi() as any;
-  {% else %}
-  const {extension: {target}, i18n, close, data} = useApi();
+  {% if flavor contains "typescript" %}const {extension: {target}, i18n, close, data} = useApi() as any;
+  {% else %}const {extension: {target}, i18n, close, data} = useApi();
   {% endif %}
   const [productTitle, setProductTitle] = useState('');
   // Use direct API calls to fetch data from Shopify.
@@ -57,7 +55,7 @@ function App() {
             close();
           }}
         >
-          Save
+          Done
         </Button>
       }
       secondaryAction={
@@ -72,14 +70,17 @@ function App() {
       }
     >
       {/* Set the translation values for each supported language in the locales directory */}
-      {i18n.translate('welcome', {target})}
-      Current product: {productTitle}
+      <BlockStack>
+        {/* Set the translation values for each supported language in the locales directory */}
+        <Text fontWeight="bold">{i18n.translate('welcome', {target})}</Text>
+        <Text>Current product: {productTitle}</Text>
+      </BlockStack>
     </AdminAction>
   );
 }
 
 {%- else -%}
-import { extend, AdminAction, Button } from "@shopify/ui-extensions/admin";
+import { extend, AdminAction, BlockStack, Button, Text } from "@shopify/ui-extensions/admin";
 
 // The target used here must match the target used in the extension's toml file (./shopify.extension.toml)
 // The second argument to the render callback provides access to several useful APIs like i18n, close, and data.
@@ -100,7 +101,7 @@ extend("admin.product-details.action.render", (root, { extension: {target}, i18n
             console.log("saving");
             close();
           },
-        }, 'Save'),
+        }, 'Done'),
         secondaryAction: root.createComponent(Button, {
           onPress: () => {
             console.log("closing");
@@ -108,10 +109,11 @@ extend("admin.product-details.action.render", (root, { extension: {target}, i18n
           },
         }, 'Close')
       },
-      // Set the translation values for each supported language in the locales directory
-      i18n.translate('welcome', {target}),
-      '\nCurrent product: ',
-      productTitle,
+      root.createComponent(BlockStack, null,
+        // Set the translation values for each supported language in the locales directory
+        root.createComponent(Text, {fontWeight: 'bold'}, i18n.translate('welcome', {target})),
+        root.createComponent(Text, null, 'Current product: ', productTitle)
+      )
     )
   );
 });

--- a/admin-block/shopify.extension.toml.liquid
+++ b/admin-block/shopify.extension.toml.liquid
@@ -1,6 +1,7 @@
 api_version = "2023-07"
 
 [[extensions]]
+# Change the merchant-facing name of the extension in locales/en.default.json
 name = "t:name"
 handle = "{{ handle }}"
 type = "ui_extension"

--- a/admin-block/src/BlockExtension.liquid
+++ b/admin-block/src/BlockExtension.liquid
@@ -3,33 +3,33 @@ import {
   reactExtension,
   useApi,
   AdminBlock,
+  BlockStack,
+  Text,
 } from '@shopify/ui-extensions-react/admin';
 
 // The target used here must match the target used in the extension's toml file (./shopify.extension.toml)
-{% if flavor contains "typescript" %}
-export default reactExtension<any>('admin.product-details.block.render', () => <App />);
-{% else %}
-export default reactExtension('admin.product-details.block.render', () => <App />);
+{% if flavor contains "typescript" %}export default reactExtension<any>('admin.product-details.block.render', () => <App />);
+{% else %}export default reactExtension('admin.product-details.block.render', () => <App />);
 {% endif %}
 function App() {
-  {% if flavor contains "typescript" %}
   // The useApi hook provides access to several useful APIs like i18n and data.
-  const {extension: {target}, i18n, data} = useApi() as any;
-  {% else %}
-  const {extension: {target}, i18n, data} = useApi();
+  {% if flavor contains "typescript" %}const {extension: {target}, i18n, data} = useApi() as any;
+  {% else %}const {extension: {target}, i18n, data} = useApi();
   {% endif %}
   console.log({data});
 
   return (
     // The AdminBlock component provides an API for setting the title and summary of the Block extension wrapper.
     <AdminBlock summary="3 items">
-      {i18n.translate('welcome', {target})}
+      <BlockStack>
+        <Text fontWeight="bold">{i18n.translate('welcome', {target})}</Text>
+      </BlockStack>
     </AdminBlock>
   );
 }
 
 {%- else -%}
-import { extend,AdminBlock } from "@shopify/ui-extensions/admin";
+import { extend, AdminBlock, BlockStack, Text } from "@shopify/ui-extensions/admin";
 
 // The target used here must match the target used in the extension's toml file (./shopify.extension.toml)
 extend("admin.product-details.block.render", (root, { extension: {target}, i18n, data }) => {
@@ -38,7 +38,9 @@ extend("admin.product-details.block.render", (root, { extension: {target}, i18n,
     root.createComponent(
       AdminBlock,
       { summary: "3 items" },
-      i18n.translate('welcome', {target})
+      root.createComponent(BlockStack, null,
+        root.createComponent(Text, { fontWeight: "bold" }, i18n.translate('welcome', {target}))
+      )
     )
   );
 });


### PR DESCRIPTION
### Background

Re-enables BlockStack and formats the templates for style.

<img width="691" alt="Screenshot 2023-07-21 at 12 39 18 PM" src="https://github.com/Shopify/extensions-templates/assets/5873610/3c5ebe9b-1797-4935-b74d-1261ef1d2d77">
<img width="660" alt="Screenshot 2023-07-21 at 12 39 07 PM" src="https://github.com/Shopify/extensions-templates/assets/5873610/9ff1e48d-626d-4831-9c0b-57323d2af429">


### Tophatting

In a new app, run the following (note the flags might be changed depending on when the CLI update gets merged)

```
npm run generate extension -- --type admin_action --clone-url https://github.com/Shopify/extensions-templates#ml/template-updates --name=action-react --template react
npm run generate extension -- --type admin_action --clone-url https://github.com/Shopify/extensions-templates#ml/template-updates --name=action-vanilla --template vanilla-js
npm run generate extension -- --type admin_action --clone-url https://github.com/Shopify/extensions-templates#ml/template-updates --name=action-react-ts --template typescript-react
npm run generate extension -- --type admin_block --clone-url https://github.com/Shopify/extensions-templates#ml/template-updates --name=block-react --template react
npm run generate extension -- --type admin_block --clone-url https://github.com/Shopify/extensions-templates#ml/template-updates --name=block-vanilla --template vanilla-js
npm run generate extension -- --type admin_block --clone-url https://github.com/Shopify/extensions-templates#ml/template-updates --name=block-react-ts --template typescript-react
```


### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
