### PR TITLE
Pass target to useApi, remove differentiation for ts

### DIFF
--- a/admin-action/src/ActionExtension.liquid
+++ b/admin-action/src/ActionExtension.liquid
@@ -10,14 +10,12 @@ import {
 } from '@shopify/ui-extensions-react/admin';
 
 // The target used here must match the target used in the extension's toml file (./shopify.extension.toml)
-{% if flavor contains "typescript" %}export default reactExtension<any>('admin.product-details.action.render', () => <App />);
-{% else %}export default reactExtension('admin.product-details.action.render', () => <App />);
-{% endif %}
+export default reactExtension('admin.product-details.action.render', () => <App />);
+
 function App() {
   // The useApi hook provides access to several useful APIs like i18n, close, and data.
-  {% if flavor contains "typescript" %}const {extension: {target}, i18n, close, data} = useApi() as any;
-  {% else %}const {extension: {target}, i18n, close, data} = useApi();
-  {% endif %}
+  const {extension: {target}, i18n, close, data} = useApi('admin.product-details.action.render');
+
   const [productTitle, setProductTitle] = useState('');
   // Use direct API calls to fetch data from Shopify.
   // See https://shopify.dev/docs/api/admin-graphql for more information about Shopify's GraphQL API

--- a/admin-block/src/BlockExtension.liquid
+++ b/admin-block/src/BlockExtension.liquid
@@ -8,14 +8,11 @@ import {
 } from '@shopify/ui-extensions-react/admin';
 
 // The target used here must match the target used in the extension's toml file (./shopify.extension.toml)
-{% if flavor contains "typescript" %}export default reactExtension<any>('admin.product-details.block.render', () => <App />);
-{% else %}export default reactExtension('admin.product-details.block.render', () => <App />);
-{% endif %}
+export default reactExtension('admin.product-details.block.render', () => <App />);
+
 function App() {
   // The useApi hook provides access to several useful APIs like i18n and data.
-  {% if flavor contains "typescript" %}const {extension: {target}, i18n, data} = useApi() as any;
-  {% else %}const {extension: {target}, i18n, data} = useApi();
-  {% endif %}
+  const {extension: {target}, i18n, data} = useApi('admin.product-details.block.render');
   console.log({data});
 
   return (


### PR DESCRIPTION
### Background

This PR should be merged *after* [this change](https://github.com/Shopify/ui-extensions/pull/1132) lands in ui-extensions.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
