### PR TITLE
Update ui-extensions packages to target `2023-07`

### DIFF
--- a/admin-action/package.json.liquid
+++ b/admin-action/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^17.0.0",
-    "@shopify/ui-extensions": "unstable",
-    "@shopify/ui-extensions-react": "unstable"
+    "@shopify/ui-extensions": "2023.7.x",
+    "@shopify/ui-extensions-react": "2023.7.x"
   },
   "devDependencies": {
     "@types/react": "^17.0.0"
@@ -20,7 +20,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "unstable"
+    "@shopify/ui-extensions": "2023.7.x"
   }
 }
 {%- endif -%}

--- a/admin-block/package.json.liquid
+++ b/admin-block/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^17.0.0",
-    "@shopify/ui-extensions": "unstable",
-    "@shopify/ui-extensions-react": "unstable"
+    "@shopify/ui-extensions": "2023.7.x",
+    "@shopify/ui-extensions-react": "2023.7.x"
   },
   "devDependencies": {
     "@types/react": "^17.0.0"
@@ -20,7 +20,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "unstable"
+    "@shopify/ui-extensions": "2023.7.x"
   }
 }
 {%- endif -%}

--- a/checkout-extension/package.json.liquid
+++ b/checkout-extension/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^17.0.0",
-    "@shopify/ui-extensions": "unstable",
-    "@shopify/ui-extensions-react": "unstable"
+    "@shopify/ui-extensions": "2023.7.x",
+    "@shopify/ui-extensions-react": "2023.7.x"
   },
   "devDependencies": {
     "@types/react": "^17.0.0"
@@ -20,7 +20,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "unstable"
+    "@shopify/ui-extensions": "2023.7.x"
   }
 }
 {%- endif -%}

--- a/product-configuration-extension/package.json.liquid
+++ b/product-configuration-extension/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^17.0.0",
-    "@shopify/ui-extensions": "unstable",
-    "@shopify/ui-extensions-react": "unstable"
+    "@shopify/ui-extensions": "2023.7.x",
+    "@shopify/ui-extensions-react": "2023.7.x"
   },
   "devDependencies": {
     "@types/react": "^17.0.0"
@@ -20,7 +20,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "unstable"
+    "@shopify/ui-extensions": "2023.7.x"
   }
 }
 {%- endif -%}


### PR DESCRIPTION
These package versions aren't published yet, but I just wanted to get the PR ready to update the templates when `2023.7.0` is ready.