### PR TITLE
Fixes link in checkout-ui-extensions template

### DIFF
--- a/checkout-extension/shopify.extension.toml.liquid
+++ b/checkout-extension/shopify.extension.toml.liquid
@@ -12,7 +12,7 @@ handle = "{{ handle }}"
 
 # Controls where in Shopify your extension will be injected,
 # and the file that contains your extension’s source code. Learn more:
-# https://shopify.dev/docs/api/checkout-ui-extensions/unstable/targets-overview
+# https://shopify.dev/docs/api/checkout-ui-extensions/unstable/extension-targets-overview
 
 [[extensions.targeting]]
 module = "./src/Checkout.{{ srcFileExtension }}"


### PR DESCRIPTION
### Background
I noticed the current extensions targets link in this template is a 404

### Solution

This seems to be the correct link and is used in the readme (except it doesn't specify a version).

### 🎩 
old
https://shopify.dev/docs/api/checkout-ui-extensions/unstable/targets-overview 404s

new
https://shopify.dev/docs/api/checkout-ui-extensions/unstable/extension-targets-overview works

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
