### PR TITLE
remove network access by default for checkout ui extensions

### DIFF
--- a/checkout-extension/shopify.extension.toml.liquid
+++ b/checkout-extension/shopify.extension.toml.liquid
@@ -26,7 +26,7 @@ api_access = true
 # Gives your extension access to make external network calls, using the
 # JavaScript `fetch()` API. Learn more:
 # https://shopify.dev/docs/api/checkout-ui-extensions/unstable/configuration#network-access
-network_access = true
+# network_access = true
 
 # Loads metafields on checkout resources, including the cart,
 # products, customers, and more. Learn more:


### PR DESCRIPTION
### Background

addresses https://github.com/Shopify/extensions-templates/issues/40

comments out `network_access` for checkout ui extensions by default.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
