### PR TITLE
Add segmentation templates extension

### DIFF
--- a/customer-segment-template-extension/README.md.liquid
+++ b/customer-segment-template-extension/README.md.liquid
@@ -1,0 +1,5 @@
+# Segmentation Template Extension
+
+Segmentation template extensions enable app developers to build custom templates into the context of Shopify Admin. These extensions surface as usable segmentation templates in the segment editor to enhance the merchant experience. Developers can build the content of these extensions using Shopify's UI Extension components for Admin.
+
+Learn more about segmentation template extensions in Shopify’s [developer documentation](https://shopify.dev/docs/apps/admin/segmentation-templates).

--- a/customer-segment-template-extension/locales/en.default.json
+++ b/customer-segment-template-extension/locales/en.default.json
@@ -1,0 +1,4 @@
+{
+    "name": "First-time customers who bought specific products",
+    "description": "Send customers invitations to encourage them to create an account for faster checkouts, easily track order status, and view order history."
+}

--- a/customer-segment-template-extension/locales/fr.json
+++ b/customer-segment-template-extension/locales/fr.json
@@ -1,0 +1,4 @@
+{
+    "name": "Nouveaux clients ayant acheté des produits spécifiques",
+    "description": "Envoyez des invitations aux clients pour les encourager à créer un compte afin d'accélérer la procédure de paiement, suivre facilement le statut des commandes et voir l'historique de leurs commandes."
+}

--- a/customer-segment-template-extension/package.json.liquid
+++ b/customer-segment-template-extension/package.json.liquid
@@ -1,0 +1,26 @@
+{%- if flavor contains "react" -%}
+{
+  "name": "{{ handle }}",
+  "private": true,
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "react": "^17.0.0",
+    "@shopify/ui-extensions": "2023.7.x",
+    "@shopify/ui-extensions-react": "2023.7.x"
+  },
+  "devDependencies": {
+    "@types/react": "^17.0.0"
+  }
+}
+{%- else -%}
+{
+  "name": "{{ handle }}",
+  "private": true,
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "@shopify/ui-extensions": "2023.7.x"
+  }
+}
+{%- endif -%}

--- a/customer-segment-template-extension/package.json.liquid
+++ b/customer-segment-template-extension/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^17.0.0",
-    "@shopify/ui-extensions": "2023.7.x",
-    "@shopify/ui-extensions-react": "2023.7.x"
+    "@shopify/ui-extensions": "unstable",
+    "@shopify/ui-extensions-react": "unstable"
   },
   "devDependencies": {
     "@types/react": "^17.0.0"
@@ -20,7 +20,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2023.7.x"
+    "@shopify/ui-extensions": "unstable"
   }
 }
 {%- endif -%}

--- a/customer-segment-template-extension/shopify.extension.toml.liquid
+++ b/customer-segment-template-extension/shopify.extension.toml.liquid
@@ -1,0 +1,17 @@
+api_version = "unstable"
+
+[[extensions]]
+# Change the merchant-facing name of the extension in locales/en.default.json
+name = "t:name"
+description = "t:description"
+handle = "{{ handle }}"
+type = "ui_extension"
+[[extensions.targeting]]
+module = "./src/CustomerSegmentTemplate.{{ srcFileExtension }}"
+# The target used here must match the target used in the module file (./src/CustomerSegmentTemplate.{{ srcFileExtension }})
+target = "admin.customers.segmentation-templates.render"
+
+
+# Valid extension points:
+
+# - admin.customers.segmentation-templates.render

--- a/customer-segment-template-extension/src/CustomerSegmentTemplate.liquid
+++ b/customer-segment-template-extension/src/CustomerSegmentTemplate.liquid
@@ -1,0 +1,44 @@
+{%- if flavor contains "react" -%}
+import {
+  reactExtension,
+  CustomerSegmentTemplate,
+} from '@shopify/ui-extensions-react/admin';
+
+// The target used here must match the target used in the extension's toml file (./shopify.extension.toml)
+const TARGET = 'admin.customers.segmentation-templates.render';
+
+export default reactExtension(TARGET, () => <App />);
+
+function App() {
+  const templateQuery = 'number_of_orders = 1 AND products_purchased(id: (product_id)) = true'
+  const templateQueryToInsert = 'number_of_orders = 1 AND products_purchased(id: (',
+
+  return (
+    // The CustomerSegmentTemplate component provides an API for setting the title, description, date, query, and query to insert of the segmentation template.
+    <CustomerSegmentTemplate
+        dateAdded={new Date('2023-08-15').toISOString()}
+        templateQuery={templateQuery}
+        templateQueryToInsert={templateQueryToInsert}
+    />
+  );
+}
+
+{%- else -%}
+import { extend, CustomerSegmentTemplate } from "@shopify/ui-extensions/admin";
+
+// The target used here must match the target used in the extension's toml file (./shopify.extension.toml)
+// The second argument to the render callback provides access to several useful APIs like i18n.
+extend("admin.customers.segmentation-templates.render", (root) => {
+  root.appendChild(
+    root.createComponent(
+      // The CustomerSegmentTemplate component provides an API for setting the title, description, date, query, and query to insert of the segmentation template.
+      CustomerSegmentTemplate,
+      {
+        dateAdded: new Date('2023-08-15').toISOString(),
+        templateQuery: 'number_of_orders = 1 AND products_purchased(id: (product_id)) = true',
+        templateQueryToInsert: 'number_of_orders = 1 AND products_purchased(id: (',
+      }
+    )
+  );
+});
+{%- endif -%}

--- a/customer-segment-template-extension/src/CustomerSegmentTemplate.liquid
+++ b/customer-segment-template-extension/src/CustomerSegmentTemplate.liquid
@@ -15,6 +15,7 @@ function App() {
 
   return (
     // The CustomerSegmentTemplate component provides an API for setting the title, description, date, query, and query to insert of the segmentation template.
+    // The title and description do not need to be explicitly set as they will be obtained from the extension's configuration file (TOM)L.
     <CustomerSegmentTemplate
         dateAdded={new Date('2023-08-15').toISOString()}
         templateQuery={templateQuery}
@@ -32,6 +33,7 @@ extend("admin.customers.segmentation-templates.render", (root) => {
   root.appendChild(
     root.createComponent(
       // The CustomerSegmentTemplate component provides an API for setting the title, description, date, query, and query to insert of the segmentation template.
+      // The title and description do not need to be explicitly set as they will be obtained from the extension's configuration file (TOML).
       CustomerSegmentTemplate,
       {
         dateAdded: new Date('2023-08-15').toISOString(),

--- a/customer-segment-template-extension/tsconfig.json
+++ b/customer-segment-template-extension/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  // This tsconfig.json file is only needed to inform the IDE
+  // About the `react-jsx` tsconfig option, so IDE don't complain about missing react import
+  // Changing options here won't affect the build of your extension
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": ["./src"]
+}


### PR DESCRIPTION
### Background

- Close https://github.com/Shopify/customer-data-platform/issues/5712

### Solution

Providing code templates for the new segmentation template type we are trying to introduce. 

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
