### PR TITLE
Add api_version to tax_calculation template

### DIFF
--- a/tax-calculation/shopify.extension.toml.liquid
+++ b/tax-calculation/shopify.extension.toml.liquid
@@ -1,5 +1,6 @@
 type = "tax_calculation"
 name = "{{ name }}"
+# api_version = 2023-07
 
 production_api_base_url = ""
 benchmark_api_base_url = ""


### PR DESCRIPTION
### Background
https://github.com/Shopify/cli/pull/2602

### Solution
Adds a comment for the `api_version`, as this changes every quarter we only specify how to set it rather than setting it for the app. If this field is not set it will always default to the latest api version.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
