### PR TITLE
Add customer-account-extension template

### DIFF
--- a/customer-account-extension/README.md.liquid
+++ b/customer-account-extension/README.md.liquid
@@ -1,0 +1,3 @@
+# Customer account UI Extension
+
+Allow developers to build extensions on customer account.

--- a/customer-account-extension/locales/en.default.json
+++ b/customer-account-extension/locales/en.default.json
@@ -1,0 +1,3 @@
+{
+  "welcome": "Welcome to the {{target}} customer account ui extension!"
+}

--- a/customer-account-extension/locales/fr.json
+++ b/customer-account-extension/locales/fr.json
@@ -1,0 +1,3 @@
+{
+  "welcome": "Bienvenue dans l'extension {{target}} de l'interface utilisateur du compte client!"
+}

--- a/customer-account-extension/package.json.liquid
+++ b/customer-account-extension/package.json.liquid
@@ -1,0 +1,25 @@
+{%- if flavor contains "react" -%}
+{
+  "name": "{{ handle }}",
+  "private": true,
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "react": "^17.0.0",
+    "@shopify/customer-account-ui-extensions-react": "^0.0.47"
+  },
+  "devDependencies": {
+    "@types/react": "^17.0.0"
+  }
+}
+{%- else -%}
+{
+  "name": "{{ handle }}",
+  "private": true,
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "@shopify/customer-account-ui-extensions": "^0.0.53"
+  }
+}
+{%- endif -%}

--- a/customer-account-extension/shopify.extension.toml.liquid
+++ b/customer-account-extension/shopify.extension.toml.liquid
@@ -1,0 +1,10 @@
+api_version = "2023-07"
+
+[[extensions]]
+type = "ui_extension"
+name = "{{ name }}"
+handle = "{{ handle }}"
+
+[[extensions.targeting]]
+module = "./src/CustomerAccountExtension.{{ srcFileExtension }}"
+target = "customer-account.dynamic.render"

--- a/customer-account-extension/src/CustomerAccountExtension.liquid
+++ b/customer-account-extension/src/CustomerAccountExtension.liquid
@@ -1,0 +1,25 @@
+{%- if flavor contains "react" -%}
+  import React from 'react';
+  import {render, Banner} from '@shopify/customer-account-ui-extensions-react';
+  
+  render('customer-account.dynamic.render', (api) => <App api={api} />);
+  
+  function App(api) {
+    return <Banner>{api.i18n.translate("welcome")}</Banner>;
+  }
+  {%- else -%}
+  import { extend, Banner } from "@shopify/customer-account-ui-extensions";
+  
+  extend('customer-account.dynamic.render', (root, api) => {
+    const { i18n } = api;
+
+    root.appendChild(
+      root.createComponent(
+        Banner,
+        {},
+        i18n.translate("welcome")
+      )
+    );
+    root.mount();
+  });
+  {%- endif -%}

--- a/customer-account-extension/tsconfig.json
+++ b/customer-account-extension/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  // This tsconfig.json file is only needed to inform the IDE
+  // About the `react-jsx` tsconfig option, so IDE don't complain about missing react import
+  // Changing options here won't affect the build of your extension
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": ["./src"]
+}


### PR DESCRIPTION
### Background

Create a temporary template for customer account ui extension specification. The extension type is `ui_extension`

[Customer account web](https://github.com/Shopify/customer-account-web) is using legacy ui-extension library. To keep the consistence, this template is using legacy ui-extension library as well. Will update once customer-account-web is updated.

### 🎩 
There is not a way to tophat at this moment.

This template will be [behind the betaflag](https://github.com/Shopify/partners/pull/49306/files#diff-f3fac56b6301c67fdbd99e49f6bc81b8c29d63a8e0ec56728a7fd47e863e5f12R99), and will only be shown internally.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
