### PR TITLE
remove duplicate comment about translations

### DIFF
--- a/admin-action/src/ActionExtension.liquid
+++ b/admin-action/src/ActionExtension.liquid
@@ -69,7 +69,6 @@ function App() {
         </Button>
       }
     >
-      {/* Set the translation values for each supported language in the locales directory */}
       <BlockStack>
         {/* Set the translation values for each supported language in the locales directory */}
         <Text fontWeight="bold">{i18n.translate('welcome', {target})}</Text>


### PR DESCRIPTION
### Background

- `/* Set the translation values for each supported language in the locales directory */}` is duplicated in the react segment of the action extension

### Solution

- Remove duplicate comment

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
