### PR TITLE
fix api prop in customer account

### DIFF
--- a/customer-account-extension/src/CustomerAccountExtension.liquid
+++ b/customer-account-extension/src/CustomerAccountExtension.liquid
@@ -1,15 +1,15 @@
 {%- if flavor contains "react" -%}
   import React from 'react';
   import {render, Banner} from '@shopify/customer-account-ui-extensions-react';
-  
+
   render('customer-account.dynamic.render', (api) => <App api={api} />);
-  
-  function App(api) {
+
+  function App({api}) {
     return <Banner>{api.i18n.translate("welcome")}</Banner>;
   }
   {%- else -%}
   import { extend, Banner } from "@shopify/customer-account-ui-extensions";
-  
+
   extend('customer-account.dynamic.render', (root, api) => {
     const { i18n } = api;
 


### PR DESCRIPTION
### Background

`api` is undefined in the current version.
That said, we should probably change the example to be closer to checkout's and use `useApi` in the react example.



- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
