### PR TITLE
Update retail-ui-ext to 1.3.0

### DIFF
--- a/pos-ui-extension/package.json.liquid
+++ b/pos-ui-extension/package.json.liquid
@@ -7,7 +7,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^17.0.0",
-    "@shopify/retail-ui-extensions-react": "^1.2.0"
+    "@shopify/retail-ui-extensions-react": "^1.3.0"
   },
   "devDependencies": {
     "@types/react": "^17.0.0"
@@ -21,7 +21,7 @@
   "main": "dist/main.js",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/retail-ui-extensions": "^1.2.0"
+    "@shopify/retail-ui-extensions": "^1.3.0"
   }
 }
 {%- endif -%}


### PR DESCRIPTION
### Background
Retail ui extensions is now version 1.3.0, we need to update the default version for scaffolding new extensions.

https://shopify.dev/changelog/pos-ui-extensions-update-new-components-fixes
