### PR TITLE
Adds segment details to admin action toml

### DIFF
--- a/admin-action/shopify.extension.toml.liquid
+++ b/admin-action/shopify.extension.toml.liquid
@@ -17,6 +17,7 @@ target = "admin.product-details.action.render"
 # - admin.customer-index.action.render
 # - admin.customer-index.selection-action.render
 # - admin.customer-details.action.render
+# - admin.customer-segment-details.action.render
 
 # Order index and detail pages
 # - admin.order-index.action.render


### PR DESCRIPTION
### Background

Resolves https://github.com/Shopify/customer-data-platform/issues/5848

When creating an action extension, our new target `admin.customer-segment-details.action.render` is missing from the shopify.extension.toml file.

**Can't ship until `2023.10` version is released** - [It's been released](https://github.com/Shopify/ui-extensions/releases/tag/%40shopify%2Fui-extensions-react%402023.10.0) ✅ 

<img width="1021" alt="image" src="https://github.com/Shopify/extensions-templates/assets/17357985/6483b9b3-4738-49ff-b7f2-a7007f982657">


### Solution

Added target to list under Customers section

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
