### PR TITLE
Bump react version fixing error seen in prod

### DIFF
--- a/customer-segment-template-extension/package.json.liquid
+++ b/customer-segment-template-extension/package.json.liquid
@@ -5,12 +5,13 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "react": "^17.0.0",
+    "react": "^18.0.0",
     "@shopify/ui-extensions": "unstable",
     "@shopify/ui-extensions-react": "unstable"
   },
   "devDependencies": {
-    "@types/react": "^17.0.0"
+    "@types/react": "^18.0.0",
+    "react-reconciler": "0.29.0"
   }
 }
 {%- else -%}


### PR DESCRIPTION
### Background

- Close https://github.com/Shopify/customer-data-platform/issues/6049

When testing the Customer Segment Template extension generation in production, I encountered the following error: 
![image](https://github.com/Shopify/extensions-templates/assets/33726710/6b7e6d90-79cc-4a3e-8ed3-06b6d08b195b)

### Solution

Bumping the react version to 18 should fix the issue as we are matching the one in ui-extensions-react.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
