### PR TITLE
Update checkout-ui extension template for version 2023-10

### DIFF
--- a/checkout-extension/package.json.liquid
+++ b/checkout-extension/package.json.liquid
@@ -5,12 +5,13 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "react": "^17.0.0",
-    "@shopify/ui-extensions": "2023.7.x",
-    "@shopify/ui-extensions-react": "2023.7.x"
+    "react": "^18.0.0",
+    "@shopify/ui-extensions": "2023.10.x",
+    "@shopify/ui-extensions-react": "2023.10.x"
   },
   "devDependencies": {
-    "@types/react": "^17.0.0"
+    "@types/react": "^18.0.0",
+    "react-reconciler": "0.29.0"
   }
 }
 {%- else -%}
@@ -20,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2023.7.x"
+    "@shopify/ui-extensions": "2023.10.x"
   }
 }
 {%- endif -%}

--- a/checkout-extension/shopify.extension.toml.liquid
+++ b/checkout-extension/shopify.extension.toml.liquid
@@ -3,7 +3,7 @@
 
 # The version of APIs your extension will receive. Learn more:
 # https://shopify.dev/docs/api/usage/versioning
-api_version = "2023-07"
+api_version = "2023-10"
 
 [[extensions]]
 type = "ui_extension"


### PR DESCRIPTION
### Background

Updates the extension template used for checkout-ui-extensions. As of `2023-10`, extensions now use React 18.

### Solution

Update the templates used by the CLI.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
