### PR TITLE
Bump ui-extensions to 2023.10 and react to 18

### DIFF
--- a/admin-action/package.json.liquid
+++ b/admin-action/package.json.liquid
@@ -5,12 +5,13 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "react": "^17.0.0",
-    "@shopify/ui-extensions": "2023.7.x",
-    "@shopify/ui-extensions-react": "2023.7.x"
+    "react": "^18.0.0",
+    "@shopify/ui-extensions": "2023.10.x",
+    "@shopify/ui-extensions-react": "2023.10.x"
   },
   "devDependencies": {
-    "@types/react": "^17.0.0"
+    "@types/react": "^18.0.0",
+    "react-reconciler": "0.29.0"
   }
 }
 {%- else -%}
@@ -20,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2023.7.x"
+    "@shopify/ui-extensions": "2023.10.x"
   }
 }
 {%- endif -%}

--- a/admin-action/shopify.extension.toml.liquid
+++ b/admin-action/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2023-07"
+api_version = "2023-10"
 
 [[extensions]]
 # Change the merchant-facing name of the extension in locales/en.default.json

--- a/admin-block/package.json.liquid
+++ b/admin-block/package.json.liquid
@@ -5,12 +5,13 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "react": "^17.0.0",
-    "@shopify/ui-extensions": "2023.7.x",
-    "@shopify/ui-extensions-react": "2023.7.x"
+    "react": "^18.0.0",
+    "@shopify/ui-extensions": "2023.10.x",
+    "@shopify/ui-extensions-react": "2023.10.x"
   },
   "devDependencies": {
-    "@types/react": "^17.0.0"
+    "@types/react": "^18.0.0",
+    "react-reconciler": "0.29.0"
   }
 }
 {%- else -%}
@@ -20,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2023.7.x"
+    "@shopify/ui-extensions": "2023.10.x"
   }
 }
 {%- endif -%}

--- a/admin-block/shopify.extension.toml.liquid
+++ b/admin-block/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2023-07"
+api_version = "2023-10"
 
 [[extensions]]
 # Change the merchant-facing name of the extension in locales/en.default.json


### PR DESCRIPTION
### Background

Updates extension templates to use the latest version of ui-extensions and react@18.

Also includes a new dependency on `react-reconciler`, since this was a requirement of a `remote-ui` version bump that was included in the latest version of `ui-extensions`.

### Solution

To tophat:
1. Set up an app per the wiki
2. `npm run generate extension -- --clone-url https://github.com/Shopify/extensions-templates#ml/upgrades`
3. `npm run dev`
4. Assert that the extension behaves as normal


### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
