### PR TITLE
Update shopify.extension.toml.liquid

### DIFF
--- a/tax-calculation/shopify.extension.toml.liquid
+++ b/tax-calculation/shopify.extension.toml.liquid
@@ -8,3 +8,7 @@ calculate_taxes_api_endpoint = ""
 # [[metafields]]
 # namespace = "my-namespace"
 # key = "my-key"
+
+# [input.metafield_identifiers]
+# namespace = "$app:my-namespace"
+# key = "my-key"


### PR DESCRIPTION
https://github.com/Shopify/cli/pull/2938

Includes optional changes to the toml to include the new `[input.metafield_identifiers]` object.

### Background

We've added a new field that a tax_calculation extension can set called input.metafield_identifiers which is an object containing a namespace/key pair. The field is [intended](https://docs.google.com/document/d/1ztZBtbZkNOal6GGlGF9F-xxJm7zO_vhUysdLiFQAtuA/edit#heading=h.bxzgv3ebhdbg) to be a metafield reference where the partner will store which metafields per merchant they want Shopify to query the value for come tax calculation time to passed back to the app.

### Solution

https://github.com/Shopify/cli/pull/2938
https://github.com/Shopify/shopify/pull/456448 --> how we intend to use it.

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
