### PR TITLE
[CustomerSegmentTemplate] Add title and description locales

### DIFF
--- a/customer-segment-template-extension/locales/en.default.json
+++ b/customer-segment-template-extension/locales/en.default.json
@@ -1,4 +1,4 @@
 {
-    "name": "First-time customers who bought specific products",
+    "title": "First-time customers who bought specific products",
     "description": "Send customers invitations to encourage them to create an account for faster checkouts, easily track order status, and view order history."
 }

--- a/customer-segment-template-extension/locales/fr.json
+++ b/customer-segment-template-extension/locales/fr.json
@@ -1,4 +1,4 @@
 {
-    "name": "Nouveaux clients ayant acheté des produits spécifiques",
+    "title": "Nouveaux clients ayant acheté des produits spécifiques",
     "description": "Envoyez des invitations aux clients pour les encourager à créer un compte afin d'accélérer la procédure de paiement, suivre facilement le statut des commandes et voir l'historique de leurs commandes."
 }

--- a/customer-segment-template-extension/shopify.extension.toml.liquid
+++ b/customer-segment-template-extension/shopify.extension.toml.liquid
@@ -2,7 +2,7 @@ api_version = "unstable"
 
 [[extensions]]
 # Change the merchant-facing name of the extension in locales/en.default.json
-name = "t:name"
+name = "t:title"
 description = "t:description"
 handle = "{{ handle }}"
 type = "ui_extension"

--- a/customer-segment-template-extension/src/CustomerSegmentTemplate.liquid
+++ b/customer-segment-template-extension/src/CustomerSegmentTemplate.liquid
@@ -10,13 +10,17 @@ const TARGET = 'admin.customers.segmentation-templates.render';
 export default reactExtension(TARGET, () => <App />);
 
 function App() {
+  // The useApi hook provides access to several useful APIs like i18n, close, and data.
+  const { i18n } = useApi(TARGET);
+
   const query = 'number_of_orders = 1 AND products_purchased(id: (product_id)) = true';
   const queryToInsert = 'number_of_orders = 1 AND products_purchased(id: (';
 
   return (
     // The CustomerSegmentTemplate component provides an API for setting the title, description, date, query, and query to insert of the segmentation template.
-    // The title and description do not need to be explicitly set as they will be obtained from the extension's configuration file (TOML).
     <CustomerSegmentTemplate
+        title={i18n.translate('title')}
+        description={i18n.translate('description')}
         createdOn={new Date('2023-08-15').toISOString()}
         query={query}
         queryToInsert={queryToInsert}
@@ -29,13 +33,14 @@ import { extend, CustomerSegmentTemplate } from "@shopify/ui-extensions/admin";
 
 // The target used here must match the target used in the extension's toml file (./shopify.extension.toml)
 // The second argument to the render callback provides access to several useful APIs like i18n.
-extend("admin.customers.segmentation-templates.render", (root) => {
+extend("admin.customers.segmentation-templates.render", (root, { i18n }) => {
   root.appendChild(
     root.createComponent(
       // The CustomerSegmentTemplate component provides an API for setting the title, description, date, query, and query to insert of the segmentation template.
-      // The title and description do not need to be explicitly set as they will be obtained from the extension's configuration file (TOML).
       CustomerSegmentTemplate,
       {
+        title: i18n.translate('title'),
+        description: i18n.translate('description'),
         createdOn: new Date('2023-08-15').toISOString(),
         query: 'number_of_orders = 1 AND products_purchased(id: (product_id)) = true',
         queryToInsert: 'number_of_orders = 1 AND products_purchased(id: (',


### PR DESCRIPTION
### Background

The `name` and `description` locales are not being automatically picked up and are not showing up in the `CustomerSegmentTemplate`.

This will better match the [tutorials](https://github.com/Shopify/shopify-dev/pull/38211) I've created for Shopify dev. 

### Solution

 I've switched the liquid file to use `i18n` to populate the `title` and `description` props.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
