### PR TITLE
Add allow_one_click_activate field to Flow template ext

### DIFF
--- a/flow-template/shopify.extension.toml.liquid
+++ b/flow-template/shopify.extension.toml.liquid
@@ -15,3 +15,5 @@ require_app = false
 discoverable = true
 
 enabled = true
+
+allow_one_click_activate = false

--- a/flow-template/template.flow
+++ b/flow-template/template.flow
@@ -1,1 +1,1 @@
-Replace this with a .flow file exported from your Dev shop. Ensure the file name matches the template key.
+Replace this with a .flow file exported from your Dev shop. Ensure the file name and path matches what's set in config.


### PR DESCRIPTION
### Background
Adds an additional field to the Flow template extension to support one click install of templates. Made a small tweak to some wording in the .flow file.
Related main task: https://github.com/Shopify/flow-app/issues/2997

### Solution

Adds field to TOML file.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
