### PR TITLE
Fix missing import in react template

### DIFF
--- a/customer-segment-template-extension/src/CustomerSegmentTemplate.liquid
+++ b/customer-segment-template-extension/src/CustomerSegmentTemplate.liquid
@@ -2,6 +2,7 @@
 import {
   reactExtension,
   CustomerSegmentTemplate,
+  useApi,
 } from '@shopify/ui-extensions-react/admin';
 
 // The target used here must match the target used in the extension's toml file (./shopify.extension.toml)


### PR DESCRIPTION
### Background

Adding missing import for useApi in the react template

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
