### PR TITLE
Add translation for name in product config extension

### DIFF
--- a/product-configuration-extension/locales/en.default.json.liquid
+++ b/product-configuration-extension/locales/en.default.json.liquid
@@ -1,3 +1,4 @@
 {
+  "name": "{{ name }}",
   "welcome": "Welcome to the {% raw %}{{target}}{% endraw %} extension!"
 }

--- a/product-configuration-extension/locales/fr.json.liquid
+++ b/product-configuration-extension/locales/fr.json.liquid
@@ -1,3 +1,4 @@
 {
+  "name": "{{ name }}",
   "welcome": "Bienvenue dans l'extension {% raw %}{{target}}{% endraw %}!"
 }


### PR DESCRIPTION
### Background

Currently the extension fails to deploy with following error:
<img width="785" alt="Screenshot 2023-10-30 at 1 27 46 PM" src="https://github.com/Shopify/extensions-templates/assets/17237680/1199f6a1-3392-46a0-99db-8d93943eeaea">


### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
