### PR TITLE
Pin pos version to 1.5.0 for new extensions, and update templates to …

### DIFF
--- a/pos-ui-extension/package.json.liquid
+++ b/pos-ui-extension/package.json.liquid
@@ -7,7 +7,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^17.0.0",
-    "@shopify/retail-ui-extensions-react": "^1.4.0"
+    "@shopify/retail-ui-extensions-react": "1.5.0"
   },
   "devDependencies": {
     "@types/react": "^17.0.0"
@@ -21,7 +21,7 @@
   "main": "dist/main.js",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/retail-ui-extensions": "^1.4.0"
+    "@shopify/retail-ui-extensions": "1.5.0"
   }
 }
 {%- endif -%}

--- a/pos-ui-extension/src/index.liquid
+++ b/pos-ui-extension/src/index.liquid
@@ -1,35 +1,38 @@
 {%- if flavor contains "react" -%}
-import React from 'react';
-import {Tile, Text, Screen, Navigator, render, useExtensionApi} from '@shopify/retail-ui-extensions-react';
+  import React from 'react'
+  import { Tile, Text, Screen, ScrollView, Navigator, render, useExtensionApi } from '@shopify/retail-ui-extensions-react'
 
-const SmartGridTile = () => {
-  const api = useExtensionApi();
-  return (
-    <Tile
-      title="My app"
-      subtitle="SmartGrid Extension"
-      onPress={() => {
-        api.smartGrid.presentModal();
-      }}
-      enabled
-    />
-  );
-};
+  const SmartGridTile = () => {
+    const api = useExtensionApi()
+    return (
+      <Tile
+        title="My app"
+        subtitle="SmartGrid Extension"
+        onPress={() => {
+          api.smartGrid.presentModal()
+        }}
+        enabled
+      />
+    )
+  }
 
-const SmartGridModal = () => {
-  return (
-    <Navigator>
-      <Screen name="HelloWorld" title="Hello World!">
-        <Text>Welcome to the extension!</Text>
-      </Screen>
-    </Navigator>
-  );
-}
+  const SmartGridModal = () => {
+    return (
+      <Navigator>
+        <Screen name="HelloWorld" title="Hello World!">
+          <ScrollView>
+            <Text>Welcome to the extension!</Text>
+          </ScrollView>
+        </Screen>
+      </Navigator>
+    )
+  }
 
-render('pos.home.tile.render', () => <SmartGridTile />);
-render('pos.home.modal.render', () => <SmartGridModal />);
+  render('pos.home.tile.render', () => <SmartGridTile />)
+  render('pos.home.modal.render', () => <SmartGridModal />)
+
 {%- else -%}
-import { extend, Navigator, Text, Screen } from "@shopify/retail-ui-extensions";
+import { extend, Navigator, Text, Screen, ScrollView } from '@shopify/retail-ui-extensions'
 
 extend('pos.home.tile.render', (root, api) => {
   const tileProps = {
@@ -37,24 +40,27 @@ extend('pos.home.tile.render', (root, api) => {
     subtitle: 'SmartGrid Extension',
     enabled: true,
     onPress: () => {
-      api.smartGrid.presentModal();
-    },
-  };
+      api.smartGrid.presentModal()
+    }
+  }
 
-  const tile = root.createComponent('Tile', tileProps);
+  const tile = root.createComponent('Tile', tileProps)
 
-  root.appendChild(tile);
-  root.mount();
-});
+  root.appendChild(tile)
+  root.mount()
+})
 
-extend('pos.home.modal.render', (root, api) => {
-  const navigator = root.createComponent(Navigator, {});
-  const screen = root.createComponent(Screen, {name: 'HelloWorld', title: 'Hello World'});
+extend('pos.home.modal.render', (root, _api) => {
+  const navigator = root.createComponent(Navigator, {})
+  const screen = root.createComponent(Screen, { name: 'HelloWorld', title: 'Hello World' })
   navigator.appendChild(screen)
-  root.appendChild(navigator);
+  root.appendChild(navigator)
 
-  screen.appendChild(root.createComponent(Text, {}, `Welcome to the extension!`));
+  const scrollView = root.createComponent(ScrollView, {})
+  scrollView.appendChild(root.createComponent(Text, {}, 'Welcome to the extension!'))
+  screen.appendChild(scrollView)
 
-  root.mount();
-});
+  root.mount()
+})
+
 {%- endif -%}


### PR DESCRIPTION
…include ScrollView

### Background

The current version pinning allows users to unknowingly update to 1.5.1, which is a problem version right now.

Also, while I was in there, I figured I should wrap the Text in a ScrollView, per:
https://github.com/Shopify/extensions-templates/issues/66 

### Solution

We should pin new extensions to 1.5.0 to prevent some amount of damage.
Prettier also did a bit of editing, but I did verify that both templates work as expected.

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have squashed my commits into chunks of work with meaningful commit messages
