### PR TITLE
Deprecate summary on AdminBlock

### DIFF
--- a/admin-block/src/BlockExtension.liquid
+++ b/admin-block/src/BlockExtension.liquid
@@ -18,8 +18,8 @@ function App() {
   console.log({data});
 
   return (
-    // The AdminBlock component provides an API for setting the title and summary of the Block extension wrapper.
-    <AdminBlock summary="3 items">
+    // The AdminBlock component provides an API for setting the title of the Block extension wrapper.
+    <AdminBlock title="My Block Extension">
       <BlockStack>
         <Text fontWeight="bold">{i18n.translate('welcome', {target})}</Text>
       </BlockStack>
@@ -34,9 +34,10 @@ import { extend, AdminBlock, BlockStack, Text } from "@shopify/ui-extensions/adm
 extend("admin.product-details.block.render", (root, { extension: {target}, i18n, data }) => {
   console.log({data});
   root.appendChild(
+    // The AdminBlock component provides an API for setting the title of the Block extension wrapper.
     root.createComponent(
       AdminBlock,
-      { summary: "3 items" },
+      { title: "My Block Extension" },
       root.createComponent(BlockStack, null,
         root.createComponent(Text, { fontWeight: "bold" }, i18n.translate('welcome', {target}))
       )


### PR DESCRIPTION
### Background

Removes references to `summary` from the AdminBlock templates.

Related PRs: 

- https://github.com/Shopify/ui-extensions/pull/1598
- https://github.com/Shopify/ui-api-design/pull/215
- https://github.com/Shopify/shopify-dev/pull/39812


### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
