### PR TITLE
Updates location rule ui extension template

### DIFF
--- a/order-routing-location-rule/locales/en.default.json.liquid
+++ b/order-routing-location-rule/locales/en.default.json.liquid
@@ -1,4 +1,4 @@
 {
   "name": "{{ name }}",
-  "helpText": "Edit the configuration for the {{label}} rule"
+  "helpText": "Edit the configuration for the rule"
 }

--- a/order-routing-location-rule/locales/fr.json.liquid
+++ b/order-routing-location-rule/locales/fr.json.liquid
@@ -1,4 +1,4 @@
 {
   "name": "{{ name }}",
-  "helpText": "Modifier la configuration de la règle {{label}}"
+  "helpText": "Modifier la configuration de la règle"
 }

--- a/order-routing-location-rule/package.json.liquid
+++ b/order-routing-location-rule/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2023.10.x",
-    "@shopify/ui-extensions-react": "2023.10.x"
+    "@shopify/ui-extensions": "unstable",
+    "@shopify/ui-extensions-react": "unstable"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2023.10.x"
+    "@shopify/ui-extensions": "unstable"
   }
 }
 {%- endif -%}

--- a/order-routing-location-rule/src/OrderRoutingLocationRule.liquid
+++ b/order-routing-location-rule/src/OrderRoutingLocationRule.liquid
@@ -14,25 +14,28 @@ export default reactExtension(TARGET, () => <App />);
 
 function App() {
   // The useApi hook provides access to several useful APIs like i18n, data and saveMetafields.
-  const {data, saveMetafields, i18n} = useApi(TARGET);
+  const {data, applyMetafieldsChange, i18n} = useApi(TARGET);
 
   // Transform your state into metafields and send them back to the admin to batch the
   // changes together with the rest of merchant updates to the routing strategy
   const handleSubmit = () => {
     console.log('submit');
 
-    /*
-     * const metafields = [
-     *   {
-     *     namespace: 'metafields',
-     *     key: 'test',
-     *     type: 'string',
-     *     value: 'test',
-     *   },
-     * ];
-     *
-     * saveMetafields(metafields);
-     */
+    {% if flavor contains "typescript" %}
+    // const metafields: Parameters<typeof applyMetafieldsChange>[0] = [
+    {% else %}
+    // const metafields = [
+    {% endif %}
+    //   {
+    //     namespace: 'ns',
+    //     key: 'config-1',
+    //     type: 'updateMetafield',
+    //     value: '{value: test}',
+    //     valueType: 'json',
+    //   }
+    // ];
+
+    // applyMetafieldsChange(metafields);
   };
 
   // Reset your state to the default values
@@ -44,7 +47,7 @@ function App() {
     <Form onSubmit={handleSubmit} onReset={handleOnReset}>
       <Box padding="base">
         <Text fontWeight="bold">
-          {i18n.translate('helpText', {label: data.rule.label})}
+          {i18n.translate('helpText')}
         </Text>
       </Box>
       <Box padding="base">
@@ -62,18 +65,21 @@ import { extend, Box, Form, Text } from "@shopify/ui-extensions/admin";
 const handleSubmit = () => {
   console.log('submit');
 
-  /*
-   * const metafields = [
-   *   {
-   *     namespace: 'metafields',
-   *     key: 'test',
-   *     type: 'string',
-   *     value: 'test',
-   *   },
-   * ];
-   *
-   * saveMetafields(metafields);
-   */
+    {% if flavor contains "typescript" %}
+    // const metafields: Parameters<typeof applyMetafieldsChange>[0] = [
+    {% else %}
+    // const metafields = [
+    {% endif %}
+    //   {
+    //     namespace: 'ns',
+    //     key: 'config-1',
+    //     type: 'updateMetafield',
+    //     value: '{value: test}',
+    //     valueType: 'json',
+    //   }
+    // ];
+
+    // applyMetafieldsChange(metafields);
 };
 
 // Reset your state to the default values
@@ -82,14 +88,14 @@ const handleOnReset = () => {
 };
 
 // The target used here must match the target used in the extension's toml file (./shopify.extension.toml)
-extend("admin.settings.order-routing-rule.render", (root, { extension: {target}, i18n, data, saveMetafields }) => {
+extend("admin.settings.order-routing-rule.render", (root, { extension: {target}, i18n, data, applyMetafieldsChange }) => {
   console.log({data});
   root.appendChild(
     root.createComponent(
       Form,
       { onSubmit: handleSubmit, onReset: handleOnReset },
       root.createComponent(Box, {padding: 'base'},
-        root.createComponent(Text, { fontWeight: "bold" }, i18n.translate('helpText', {label: data.rule.label}))
+        root.createComponent(Text, { fontWeight: "bold" }, i18n.translate('helpText'))
       )
     )
   );


### PR DESCRIPTION
### Background

This is a follow up on https://github.com/Shopify/extensions-templates/pull/72 based on the last minute [API-alignment on the original `saveMetafields`](https://github.com/Shopify/web/pull/110519)

### Solution

- Updates the template to the new `applyMetafieldsChange` API
- Properly sets package version to `unstable` until we publish `2024-01`

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
