### PR TITLE
Create offsite payments app extension template

### DIFF
--- a/payments-app-extension-offsite/shopify.extension.toml.liquid
+++ b/payments-app-extension-offsite/shopify.extension.toml.liquid
@@ -1,0 +1,21 @@
+# The version of APIs your extension will receive. Learn more:
+# https://shopify.dev/docs/api/usage/versioning
+api_version = "2021-07"
+
+[[extensions]]
+name = "{{ name }}"
+type = "payments_extension"
+handle = "{{ handle }}"
+
+[[extensions.targeting]]
+target = "payments.offsite.render"
+
+merchant_label = "Offsite Payments App Extension"
+payment_session_url = "https://api.paymentprovider.com/endpoint"
+supports_oversell_protection = false
+supported_countries = ["US"]
+supported_payment_methods = ["visa"]
+supports_3ds = false
+supports_installments = false
+supports_deferred_payments = false
+test_mode_available = true


### PR DESCRIPTION
### Background

Related issue: https://github.com/Shopify/payments-platform/issues/4378
Related project: https://docs.google.com/document/d/1Y2Ly5sw6MalZQP8w3yraQlOs8dK3UK38LVQvQz7fC_M/edit#heading=h.8coln95uazox

Creates an offsite payments app extension template to be used via the CLI


### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
