### PR TITLE
Create payments app extension credit card template

### DIFF
--- a/payments-app-extension-credit-card/shopify.extension.toml.liquid
+++ b/payments-app-extension-credit-card/shopify.extension.toml.liquid
@@ -1,0 +1,24 @@
+# The version of APIs your extension will receive. Learn more:
+# https://shopify.dev/docs/api/usage/versioning
+api_version = "2021-07"
+
+[[extensions]]
+name = "{{ name }}"
+type = "payments_extension"
+handle = "{{ handle }}"
+
+[[extensions.targeting]]
+target = "payments.credit-card.render"
+
+merchant_label = "Credit Credit Payments App Extension"
+payment_session_url = "https://api.paymentprovider.com/endpoint"
+refund_session_url = "https://api.paymentprovider.com/refund"
+capture_session_url = "https://api.paymentprovider.com/capture"
+void_session_url = "https://api.paymentprovider.com/void"
+supported_countries = ["US"]
+supported_payment_methods = ["visa"]
+supports_3ds = false
+supports_installments = false
+supports_deferred_payments = false
+test_mode_available = true
+encryption_certificate = {}


### PR DESCRIPTION
### Background

Related issue: https://github.com/Shopify/payments-platform/issues/4378
Related project: https://docs.google.com/document/d/1Y2Ly5sw6MalZQP8w3yraQlOs8dK3UK38LVQvQz7fC_M/edit#heading=h.8coln95uazox
Related management class: https://github.com/Shopify/shopify/blob/main/components/payment_processing/payments_partners/app/models/payments_partners/payments_app_extensions/credit_card_payments_app_extension.rb

Creates an credit card payments app extension template to be used via the CLI

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
