### PR TITLE
Create custom credit card payments app extension template

### DIFF
--- a/payments-app-extension-custom-credit-card/shopify.extension.toml.liquid
+++ b/payments-app-extension-custom-credit-card/shopify.extension.toml.liquid
@@ -1,0 +1,23 @@
+# The version of APIs your extension will receive. Learn more:
+# https://shopify.dev/docs/api/usage/versioning
+api_version = "unstable"
+
+[[extensions]]
+name = "{{ name }}"
+type = "payments_extension"
+handle = "{{ handle }}"
+
+[[extensions.targeting]]
+target = "payments.custom-credit-card.render"
+
+merchant_label = "Custom Credit Credit Payments App Extension"
+payment_session_url = "https://api.paymentprovider.com/endpoint"
+refund_session_url = "https://api.paymentprovider.com/refund"
+capture_session_url = "https://api.paymentprovider.com/capture"
+void_session_url = "https://api.paymentprovider.com/void"
+supported_countries = ["US"]
+supported_payment_methods = ["visa"]
+supports_3ds = false
+test_mode_available = true
+encryption_certificate = {}
+multiple_capture = false


### PR DESCRIPTION
Related issue: https://github.com/Shopify/payments-platform/issues/4380
Related project: https://docs.google.com/document/d/1Y2Ly5sw6MalZQP8w3yraQlOs8dK3UK38LVQvQz7fC_M/edit#heading=h.8coln95uazox
Related management class: [CustomCreditCard management class](https://github.com/Shopify/shopify/blob/main/components/payment_processing/payments_partners/app/models/payments_partners/payments_app_extensions/custom_credit_card_payments_app_extension.rb)

Creates a custom credit card payments app extension template to be used via the CLI

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
