### PR TITLE
Create custom onsite payments app extension template

### DIFF
--- a/payments-app-extension-custom-onsite/shopify.extension.toml.liquid
+++ b/payments-app-extension-custom-onsite/shopify.extension.toml.liquid
@@ -1,0 +1,21 @@
+# The version of APIs your extension will receive. Learn more:
+# https://shopify.dev/docs/api/usage/versioning
+api_version = "2021-07"
+
+[[extensions]]
+name = "{{ name }}"
+type = "payments_extension"
+handle = "{{ handle }}"
+
+[[extensions.targeting]]
+target = "payments.custom-onsite.render"
+
+merchant_label = "Custom Onsite Payments App Extension"
+payment_session_url = "https://api.paymentprovider.com/endpoint"
+supports_oversell_protection = false
+supported_countries = ["US"]
+supported_payment_methods = ["visa"]
+supports_3ds = false
+supports_installments = false
+supports_deferred_payments = false
+test_mode_available = true


### PR DESCRIPTION
### Background

Related issue: https://github.com/Shopify/payments-platform/issues/4381
Related project: https://docs.google.com/document/d/1Y2Ly5sw6MalZQP8w3yraQlOs8dK3UK38LVQvQz7fC_M/edit#heading=h.8coln95uazox
Related management class: [CustomOnsite management class](https://github.com/Shopify/shopify/blob/main/components/payment_processing/payments_partners/app/models/payments_partners/payments_app_extensions/custom_onsite_payments_app_extension.rb)

Creates an custom onsite payments app extension template to be used via the CLI

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)
### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
