### PR TITLE
Update action and block to use latest ui-ext version

### DIFF
--- a/admin-action/package.json.liquid
+++ b/admin-action/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2023.10.x",
-    "@shopify/ui-extensions-react": "2023.10.x"
+    "@shopify/ui-extensions": "2024.01.x",
+    "@shopify/ui-extensions-react": "2024.01.x"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/admin-action/shopify.extension.toml.liquid
+++ b/admin-action/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2023-10"
+api_version = "2024-01"
 
 [[extensions]]
 # Change the merchant-facing name of the extension in locales/en.default.json

--- a/admin-block/package.json.liquid
+++ b/admin-block/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2023.10.x",
-    "@shopify/ui-extensions-react": "2023.10.x"
+    "@shopify/ui-extensions": "2024.01.x",
+    "@shopify/ui-extensions-react": "2024.01.x"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/admin-block/shopify.extension.toml.liquid
+++ b/admin-block/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2023-10"
+api_version = "2024-01"
 
 [[extensions]]
 # Change the merchant-facing name of the extension in locales/en.default.json


### PR DESCRIPTION
### Background

Updates templates for 2024-01, which was just released in https://github.com/Shopify/ui-extensions/pull/1615

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
