### PR TITLE
Update checkout UI extension version to 2024-01

### DIFF
--- a/checkout-extension/package.json.liquid
+++ b/checkout-extension/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2023.10.x",
-    "@shopify/ui-extensions-react": "2023.10.x"
+    "@shopify/ui-extensions": "2024.1.x",
+    "@shopify/ui-extensions-react": "2024.1.x"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2023.10.x"
+    "@shopify/ui-extensions": "2024.1.x"
   }
 }
 {%- endif -%}

--- a/checkout-extension/shopify.extension.toml.liquid
+++ b/checkout-extension/shopify.extension.toml.liquid
@@ -3,7 +3,7 @@
 
 # The version of APIs your extension will receive. Learn more:
 # https://shopify.dev/docs/api/usage/versioning
-api_version = "2023-10"
+api_version = "2024-01"
 
 [[extensions]]
 type = "ui_extension"


### PR DESCRIPTION
### Background

Updates the checkout ui extension template to use the new 2024-01 API version. 

### Solution

Similar to this [previous PR](https://github.com/Shopify/extensions-templates/pull/56) that did the same for version 2023-10.

This was tophatted by scaffolding a new extension and making these same changes in there, running it locally and also installing it on a shop.

![Screenshot 2024-01-05 at 1 58 40 PM](https://github.com/Shopify/extensions-templates/assets/12719665/ef2bc56a-09ee-43e1-b57a-9b62460d2979)

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have squashed my commits into chunks of work with meaningful commit messages
