### PR TITLE
Update broken payment app templates

### DIFF
--- a/payments-app-extension-credit-card/shopify.extension.toml.liquid
+++ b/payments-app-extension-credit-card/shopify.extension.toml.liquid
@@ -7,9 +7,6 @@ name = "{{ name }}"
 type = "payments_extension"
 handle = "{{ handle }}"
 
-[[extensions.targeting]]
-target = "payments.credit-card.render"
-
 merchant_label = "Credit Credit Payments App Extension"
 payment_session_url = "https://api.paymentprovider.com/endpoint"
 refund_session_url = "https://api.paymentprovider.com/refund"
@@ -22,3 +19,6 @@ supports_installments = false
 supports_deferred_payments = false
 test_mode_available = true
 encryption_certificate = {}
+
+[[extensions.targeting]]
+target = "payments.credit-card.render"

--- a/payments-app-extension-custom-credit-card/shopify.extension.toml.liquid
+++ b/payments-app-extension-custom-credit-card/shopify.extension.toml.liquid
@@ -7,9 +7,6 @@ name = "{{ name }}"
 type = "payments_extension"
 handle = "{{ handle }}"
 
-[[extensions.targeting]]
-target = "payments.custom-credit-card.render"
-
 merchant_label = "Custom Credit Credit Payments App Extension"
 payment_session_url = "https://api.paymentprovider.com/endpoint"
 refund_session_url = "https://api.paymentprovider.com/refund"
@@ -21,3 +18,6 @@ supports_3ds = false
 test_mode_available = true
 encryption_certificate = {}
 multiple_capture = false
+
+[[extensions.targeting]]
+target = "payments.custom-credit-card.render"

--- a/payments-app-extension-custom-onsite/shopify.extension.toml.liquid
+++ b/payments-app-extension-custom-onsite/shopify.extension.toml.liquid
@@ -7,9 +7,6 @@ name = "{{ name }}"
 type = "payments_extension"
 handle = "{{ handle }}"
 
-[[extensions.targeting]]
-target = "payments.custom-onsite.render"
-
 merchant_label = "Custom Onsite Payments App Extension"
 payment_session_url = "https://api.paymentprovider.com/endpoint"
 supports_oversell_protection = false
@@ -19,3 +16,6 @@ supports_3ds = false
 supports_installments = false
 supports_deferred_payments = false
 test_mode_available = true
+
+[[extensions.targeting]]
+target = "payments.custom-onsite.render"

--- a/payments-app-extension-offsite/shopify.extension.toml.liquid
+++ b/payments-app-extension-offsite/shopify.extension.toml.liquid
@@ -7,9 +7,6 @@ name = "{{ name }}"
 type = "payments_extension"
 handle = "{{ handle }}"
 
-[[extensions.targeting]]
-target = "payments.offsite.render"
-
 merchant_label = "Offsite Payments App Extension"
 payment_session_url = "https://api.paymentprovider.com/endpoint"
 supports_oversell_protection = false
@@ -19,3 +16,6 @@ supports_3ds = false
 supports_installments = false
 supports_deferred_payments = false
 test_mode_available = true
+
+[[extensions.targeting]]
+target = "payments.offsite.render"

--- a/payments-app-extension-redeemable/shopify.extension.toml.liquid
+++ b/payments-app-extension-redeemable/shopify.extension.toml.liquid
@@ -7,9 +7,6 @@ name = "{{ name }}"
 type = "payments_extension"
 handle = "{{ handle }}"
 
-[[extensions.targeting]]
-target = "payments.redeemable.render"
-
 redeemable_type = "gift_card"
 payment_session_url = "https://api.paymentprovider.com/endpoint"
 supported_countries = ["US"]
@@ -17,3 +14,6 @@ supported_payment_methods = ["visa"]
 test_mode_available = true
 merchant_label = "Redeemable Payments App Extension"
 balance_url = "https://api.paymentprovider.com/balance"
+
+[[extensions.targeting]]
+target = "payments.redeemable.render"


### PR DESCRIPTION
### Background

When introducing payment app templates (like in [this PR](https://github.com/Shopify/extensions-templates/pull/78)), we expected new properties to be on the top level, and only the `target` property inside `extensions.targeting`.

Due to the nature of TOML, if a table is declared, new properties will fall under that table, even if you leave empty lines in between.

### Solution

Move the target property to the end of the TOML files.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
