### PR TITLE
Updates payment extension with valid encryption certificates

### DIFF
--- a/payments-app-extension-credit-card/shopify.extension.toml.liquid
+++ b/payments-app-extension-credit-card/shopify.extension.toml.liquid
@@ -18,7 +18,7 @@ supports_3ds = false
 supports_installments = false
 supports_deferred_payments = false
 test_mode_available = true
-encryption_certificate = {}
+encryption_certificate = { fingerprint = "", certificate = "" }
 
 [[extensions.targeting]]
 target = "payments.credit-card.render"

--- a/payments-app-extension-custom-credit-card/shopify.extension.toml.liquid
+++ b/payments-app-extension-custom-credit-card/shopify.extension.toml.liquid
@@ -16,7 +16,7 @@ supported_countries = ["US"]
 supported_payment_methods = ["visa"]
 supports_3ds = false
 test_mode_available = true
-encryption_certificate = {}
+encryption_certificate = { fingerprint = "", certificate = "" }
 multiple_capture = false
 
 [[extensions.targeting]]


### PR DESCRIPTION
### Background

When developers create a new payment app extension, they are required to provide an encryption certificate with today's cli schema rules. If they want to run `dev` to test their app, they would need to setup a certificate first.

### Solution

Make the certificate values optional, and match the templates to the cli schemas.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
