### PR TITLE
Update package.json.liquid for pos-ui-extensions v1.6.0

### DIFF
--- a/pos-ui-extension/package.json.liquid
+++ b/pos-ui-extension/package.json.liquid
@@ -7,7 +7,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^17.0.0",
-    "@shopify/retail-ui-extensions-react": "1.5.0"
+    "@shopify/retail-ui-extensions-react": "1.6.0"
   },
   "devDependencies": {
     "@types/react": "^17.0.0"
@@ -21,7 +21,7 @@
   "main": "dist/main.js",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/retail-ui-extensions": "1.5.0"
+    "@shopify/retail-ui-extensions": "1.6.0"
   }
 }
 {%- endif -%}


### PR DESCRIPTION
### Background

Released 1.6.0 today

### Solution

Update the package.json so that new extensions use 1.6.0 by default

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have squashed my commits into chunks of work with meaningful commit messages
