### PR TITLE
use TARGET directly, log data, and update deprecated methods

### DIFF
--- a/admin-action/locales/en.default.json.liquid
+++ b/admin-action/locales/en.default.json.liquid
@@ -1,4 +1,4 @@
 {
   "name": "{{ name }}",
-  "welcome": "Welcome to the {% raw %}{{target}}{% endraw %} extension!"
+  "welcome": "Welcome to the {% raw %}{{TARGET}}{% endraw %} extension!"
 }

--- a/admin-action/locales/fr.json.liquid
+++ b/admin-action/locales/fr.json.liquid
@@ -1,4 +1,4 @@
 {
   "name": "{{ name }}",
-  "welcome": "Bienvenue dans l'extension {% raw %}{{target}}{% endraw %}!"
+  "welcome": "Bienvenue dans l'extension {% raw %}{{TARGET}}{% endraw %}!"
 }

--- a/admin-action/src/ActionExtension.liquid
+++ b/admin-action/src/ActionExtension.liquid
@@ -16,8 +16,8 @@ export default reactExtension(TARGET, () => <App />);
 
 function App() {
   // The useApi hook provides access to several useful APIs like i18n, close, and data.
-  const {extension: {target}, i18n, close, data} = useApi(TARGET);
-
+  const {i18n, close, data} = useApi(TARGET);
+  console.log({data});
   const [productTitle, setProductTitle] = useState('');
   // Use direct API calls to fetch data from Shopify.
   // See https://shopify.dev/docs/api/admin-graphql for more information about Shopify's GraphQL API
@@ -44,7 +44,7 @@ function App() {
       const productData = await res.json();
       setProductTitle(productData.data.product.title);
     })();
-  }, []);
+  }, [data.selected]);
   return (
     // The AdminAction component provides an API for setting the title and actions of the Action extension wrapper.
     <AdminAction
@@ -71,7 +71,7 @@ function App() {
     >
       <BlockStack>
         {/* Set the translation values for each supported language in the locales directory */}
-        <Text fontWeight="bold">{i18n.translate('welcome', {target})}</Text>
+        <Text fontWeight="bold">{i18n.translate('welcome', {TARGET})}</Text>
         <Text>Current product: {productTitle}</Text>
       </BlockStack>
     </AdminAction>
@@ -82,15 +82,17 @@ function App() {
 import { extend, AdminAction, BlockStack, Button, Text } from "@shopify/ui-extensions/admin";
 
 // The target used here must match the target used in the extension's toml file (./shopify.extension.toml)
+const TARGET = 'admin.product-details.action.render';
+
 // The second argument to the render callback provides access to several useful APIs like i18n, close, and data.
-extend("admin.product-details.action.render", (root, { extension: {target}, i18n, close, data }) => {
+extend(TARGET, (root, { i18n, close, data }) => {
   const productTitle = root.createText('');
 
   getProductInfo(data).then((title) => {
-    productTitle.updateText(title);
+    productTitle.update(title);
   });
 
-  root.appendChild(
+  root.append(
     root.createComponent(
       // The AdminAction component provides an API for setting the title and actions of the Action extension wrapper.
       AdminAction,
@@ -110,7 +112,7 @@ extend("admin.product-details.action.render", (root, { extension: {target}, i18n
       },
       root.createComponent(BlockStack, null,
         // Set the translation values for each supported language in the locales directory
-        root.createComponent(Text, {fontWeight: 'bold'}, i18n.translate('welcome', {target})),
+        root.createComponent(Text, {fontWeight: 'bold'}, i18n.translate('welcome', {TARGET})),
         root.createComponent(Text, null, 'Current product: ', productTitle)
       )
     )

--- a/admin-block/locales/en.default.json.liquid
+++ b/admin-block/locales/en.default.json.liquid
@@ -1,4 +1,4 @@
 {
   "name": "{{ name }}",
-  "welcome": "Welcome to the {% raw %}{{target}}{% endraw %} extension!"
+  "welcome": "Welcome to the {% raw %}{{TARGET}}{% endraw %} extension!"
 }

--- a/admin-block/locales/fr.json.liquid
+++ b/admin-block/locales/fr.json.liquid
@@ -1,4 +1,4 @@
 {
   "name": "{{ name }}",
-  "welcome": "Bienvenue dans l'extension {% raw %}{{target}}{% endraw %}!"
+  "welcome": "Bienvenue dans l'extension {% raw %}{{TARGET}}{% endraw %}!"
 }

--- a/admin-block/src/BlockExtension.liquid
+++ b/admin-block/src/BlockExtension.liquid
@@ -14,32 +14,40 @@ export default reactExtension(TARGET, () => <App />);
 
 function App() {
   // The useApi hook provides access to several useful APIs like i18n and data.
-  const {extension: {target}, i18n, data} = useApi(TARGET);
+  const {i18n, data} = useApi(TARGET);
   console.log({data});
 
   return (
     // The AdminBlock component provides an API for setting the title of the Block extension wrapper.
     <AdminBlock title="My Block Extension">
       <BlockStack>
-        <Text fontWeight="bold">{i18n.translate('welcome', {target})}</Text>
+        <Text fontWeight="bold">{i18n.translate('welcome', {TARGET})}</Text>
       </BlockStack>
     </AdminBlock>
   );
 }
 
 {%- else -%}
-import { extend, AdminBlock, BlockStack, Text } from "@shopify/ui-extensions/admin";
+import {
+  extend,
+  AdminBlock,
+  BlockStack,
+  Text
+} from "@shopify/ui-extensions/admin";
 
 // The target used here must match the target used in the extension's toml file (./shopify.extension.toml)
-extend("admin.product-details.block.render", (root, { extension: {target}, i18n, data }) => {
+const TARGET = 'admin.product-details.block.render';
+
+extend(TARGET, (root, { i18n, data }) => {
   console.log({data});
-  root.appendChild(
+
+  root.append(
     // The AdminBlock component provides an API for setting the title of the Block extension wrapper.
     root.createComponent(
       AdminBlock,
       { title: "My Block Extension" },
       root.createComponent(BlockStack, null,
-        root.createComponent(Text, { fontWeight: "bold" }, i18n.translate('welcome', {target}))
+        root.createComponent(Text, { fontWeight: "bold" }, i18n.translate('welcome', {TARGET}))
       )
     )
   );


### PR DESCRIPTION
### Background

This PR uses the `TARGET` constant in the body of the extension directly (rather than getting the string from the API), updates some deprecated methods, and logs data in the action extension to be more consistent with the block example.   

### Solution

- Use `TARGET` string directly in rendered jsx
- Update deprecated methods: `appendChild` -> `append` and `updateText` -> `update`
- Add `console.log` to log data in action extension

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
