### PR TITLE
Updates encryption certificates to only use fingerprints

### DIFF
--- a/payments-app-extension-credit-card/shopify.extension.toml.liquid
+++ b/payments-app-extension-credit-card/shopify.extension.toml.liquid
@@ -18,7 +18,7 @@ supports_3ds = false
 supports_installments = false
 supports_deferred_payments = false
 test_mode_available = true
-encryption_certificate = { fingerprint = "", certificate = "" }
+encryption_certificate_fingerprint = ""
 
 [[extensions.targeting]]
 target = "payments.credit-card.render"

--- a/payments-app-extension-custom-credit-card/shopify.extension.toml.liquid
+++ b/payments-app-extension-custom-credit-card/shopify.extension.toml.liquid
@@ -16,7 +16,7 @@ supported_countries = ["US"]
 supported_payment_methods = ["visa"]
 supports_3ds = false
 test_mode_available = true
-encryption_certificate = { fingerprint = "", certificate = "" }
+encryption_certificate_fingerprint = ""
 multiple_capture = false
 
 [[extensions.targeting]]


### PR DESCRIPTION
### Background

We want to simplify the developer experience when developing payment apps. To do so, we would like partners to specify encryption certificates using only its fingerprint, rather than the whole certificate.

### Solution

Change templates to only use the certificate fingerprint.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
