### PR TITLE
Add inline comment explaining require_app setting

### DIFF
--- a/flow-template/shopify.extension.toml.liquid
+++ b/flow-template/shopify.extension.toml.liquid
@@ -19,5 +19,3 @@ require_app = false
 discoverable = true
 
 enabled = true
-
-allow_one_click_activate = false

--- a/flow-template/shopify.extension.toml.liquid
+++ b/flow-template/shopify.extension.toml.liquid
@@ -10,6 +10,10 @@ categories = ["orders", "risk"]
 
 module = "./template.flow"
 
+# When require_app is true your template will only be visible to users who have
+# your app installed. Below are the common selections:
+# Public apps require_app = false
+# Non public apps require_app = true
 require_app = false
 
 discoverable = true


### PR DESCRIPTION
### Background

- Adds additional context to the `require_app` setting. This should make is more clear to the author while they're setting up their template and avoid accidentally sharing to a wider audience if they didn't intend to. This information will be available in docs as well.

- Removes `allow_one_click_activate` option, we're not certain we'll allow this behaviour in the Flow UI so simply hiding for now in case we decide to reveal it in the future.

### Solution

Adds brief inline comment explaining the property's behaviour.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
