### PR TITLE
Update pos-ui-extension template for 1.7.0

### DIFF
--- a/pos-ui-extension/package.json.liquid
+++ b/pos-ui-extension/package.json.liquid
@@ -7,7 +7,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^17.0.0",
-    "@shopify/retail-ui-extensions-react": "1.6.0"
+    "@shopify/retail-ui-extensions-react": "1.7.0"
   },
   "devDependencies": {
     "@types/react": "^17.0.0"
@@ -21,7 +21,7 @@
   "main": "dist/main.js",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/retail-ui-extensions": "1.6.0"
+    "@shopify/retail-ui-extensions": "1.7.0"
   }
 }
 {%- endif -%}


### PR DESCRIPTION
### Background

We released retail-ui-extensions 1.7.0

### Solution

Update the template to use 1.7.0

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have squashed my commits into chunks of work with meaningful commit messages
