### PR TITLE
Use 2024.4.x for checkout extensions

### DIFF
--- a/checkout-extension/package.json.liquid
+++ b/checkout-extension/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2024.1.x",
-    "@shopify/ui-extensions-react": "2024.1.x"
+    "@shopify/ui-extensions": "2024.4.x",
+    "@shopify/ui-extensions-react": "2024.4.x"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2024.1.x"
+    "@shopify/ui-extensions": "2024.4.x"
   }
 }
 {%- endif -%}

--- a/checkout-extension/shopify.extension.toml.liquid
+++ b/checkout-extension/shopify.extension.toml.liquid
@@ -3,7 +3,7 @@
 
 # The version of APIs your extension will receive. Learn more:
 # https://shopify.dev/docs/api/usage/versioning
-api_version = "2024-01"
+api_version = "2024-04"
 
 [[extensions]]
 type = "ui_extension"


### PR DESCRIPTION
### Background

Now that version 2024.4.1 has been released, this updates the templates used by the CLI to use the latest 2024-04 package version.

### Solution

Similar to this https://github.com/Shopify/extensions-templates/pull/85 that did the same for version `2024-01`.

This was tophatted by scaffolding a new extension and making these same changes in there, running it locally and also installing it on a shop.

<img width="626" alt="Screenshot 2024-04-02 at 2 00 11 PM" src="https://github.com/Shopify/extensions-templates/assets/12719665/cc67e9da-73d2-4447-9dd3-088af4e9cf1c">


### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
