### PR TITLE
add new block targets to template comment

### DIFF
--- a/admin-block/shopify.extension.toml.liquid
+++ b/admin-block/shopify.extension.toml.liquid
@@ -12,6 +12,10 @@ target = "admin.product-details.block.render"
 
 
 # Valid extension targets:
+# - admin.abandoned-checkout-details.block.render
+# - admin.collection-details.block.render
 # - admin.customer-details.block.render
+# - admin.draft-order-details.block.render
 # - admin.order-details.block.render
 # - admin.product-details.block.render
+# - admin.product-variant-details.block.render


### PR DESCRIPTION
closes https://github.com/Shopify/app-ui/issues/958

Adding the new extension targets to the toml file of of the block extension template.

<img width="1099" alt="image" src="https://github.com/Shopify/extensions-templates/assets/113053586/e415b29d-a704-4b85-874f-a274d8cd6b44">

### 🎩  Tophat instructions 🎩 
- create an app
- generate an extension via my branch 
- `npm run generate extension -- --clone-url https://github.com/Shopify/extensions-templates\#jw/new-block-targets`
- inspect the toml file for new targets

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
