### PR TITLE
Fix redeemable type in redeemable payments extension TOML 

### DIFF
--- a/payments-app-extension-redeemable/shopify.extension.toml.liquid
+++ b/payments-app-extension-redeemable/shopify.extension.toml.liquid
@@ -7,7 +7,7 @@ name = "{{ name }}"
 type = "payments_extension"
 handle = "{{ handle }}"
 
-redeemable_type = "gift_card"
+redeemable_type = "gift-card"
 payment_session_url = "https://api.paymentprovider.com/endpoint"
 supported_countries = ["US"]
 supported_payment_methods = ["visa"]


### PR DESCRIPTION
### Background

Use the correct value for redeemable type as the default. 

See: https://github.com/Shopify/shopify/blob/main/components/payment_processing/payments_partners/app/models/payments_partners/redeemable_type.rb#L5

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
