### PR TITLE
Add dev notes for payments extension dynamic fields

### DIFF
--- a/payments-app-extension-credit-card/shopify.extension.toml.liquid
+++ b/payments-app-extension-credit-card/shopify.extension.toml.liquid
@@ -12,7 +12,11 @@ payment_session_url = "https://api.paymentprovider.com/endpoint"
 refund_session_url = "https://api.paymentprovider.com/refund"
 capture_session_url = "https://api.paymentprovider.com/capture"
 void_session_url = "https://api.paymentprovider.com/void"
+# List of ISO 3166 (alpha-2) country codes your app is available for installation by merchants. Learn more:
+# https://www.iso.org/iso-3166-country-codes.html
 supported_countries = ["US"]
+# List payment method names that your payment extension will support. Learn more:
+# https://github.com/activemerchant/payment_icons/blob/master/db/payment_icons.yml
 supported_payment_methods = ["visa"]
 supports_3ds = false
 supports_installments = false

--- a/payments-app-extension-custom-credit-card/shopify.extension.toml.liquid
+++ b/payments-app-extension-custom-credit-card/shopify.extension.toml.liquid
@@ -12,7 +12,11 @@ payment_session_url = "https://api.paymentprovider.com/endpoint"
 refund_session_url = "https://api.paymentprovider.com/refund"
 capture_session_url = "https://api.paymentprovider.com/capture"
 void_session_url = "https://api.paymentprovider.com/void"
+# List of ISO 3166 (alpha-2) country codes your app is available for installation by merchants. Learn more:
+# https://www.iso.org/iso-3166-country-codes.html
 supported_countries = ["US"]
+# List payment method names that your payment extension will support. Learn more:
+# https://github.com/activemerchant/payment_icons/blob/master/db/payment_icons.yml
 supported_payment_methods = ["visa"]
 supports_3ds = false
 test_mode_available = true

--- a/payments-app-extension-custom-onsite/shopify.extension.toml.liquid
+++ b/payments-app-extension-custom-onsite/shopify.extension.toml.liquid
@@ -10,7 +10,11 @@ handle = "{{ handle }}"
 merchant_label = "Custom Onsite Payments App Extension"
 payment_session_url = "https://api.paymentprovider.com/endpoint"
 supports_oversell_protection = false
+# List of ISO 3166 (alpha-2) country codes your app is available for installation by merchants. Learn more:
+# https://www.iso.org/iso-3166-country-codes.html
 supported_countries = ["US"]
+# List payment method names that your payment extension will support. Learn more:
+# https://github.com/activemerchant/payment_icons/blob/master/db/payment_icons.yml
 supported_payment_methods = ["visa"]
 supports_3ds = false
 supports_installments = false

--- a/payments-app-extension-offsite/shopify.extension.toml.liquid
+++ b/payments-app-extension-offsite/shopify.extension.toml.liquid
@@ -10,7 +10,11 @@ handle = "{{ handle }}"
 merchant_label = "Offsite Payments App Extension"
 payment_session_url = "https://api.paymentprovider.com/endpoint"
 supports_oversell_protection = false
+# List of ISO 3166 (alpha-2) country codes your app is available for installation by merchants. Learn more:
+# https://www.iso.org/iso-3166-country-codes.html
 supported_countries = ["US"]
+# List payment method names that your payment extension will support. Learn more:
+# https://github.com/activemerchant/payment_icons/blob/master/db/payment_icons.yml
 supported_payment_methods = ["visa"]
 supports_3ds = false
 supports_installments = false

--- a/payments-app-extension-redeemable/shopify.extension.toml.liquid
+++ b/payments-app-extension-redeemable/shopify.extension.toml.liquid
@@ -9,7 +9,11 @@ handle = "{{ handle }}"
 
 redeemable_type = "gift-card"
 payment_session_url = "https://api.paymentprovider.com/endpoint"
+# List of ISO 3166 (alpha-2) country codes your app is available for installation by merchants. Learn more:
+# https://www.iso.org/iso-3166-country-codes.html
 supported_countries = ["US"]
+# List payment method names that your payment extension will support. Learn more:
+# https://github.com/activemerchant/payment_icons/blob/master/db/payment_icons.yml
 supported_payment_methods = ["visa"]
 test_mode_available = true
 merchant_label = "Redeemable Payments App Extension"


### PR DESCRIPTION
### Background

See issue: https://github.com/Shopify/payments-platform/issues/5407

Adding developer notes to payments extension dynamic fields (ie. `supported countries`, `supported payment methods`)

We already have notes for `api_version` &  `buyer_label_to_locale` is not part of template field as it is an optional field 

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
