### PR TITLE
Use gift-card as supported payment method

### DIFF
--- a/payments-app-extension-redeemable/shopify.extension.toml.liquid
+++ b/payments-app-extension-redeemable/shopify.extension.toml.liquid
@@ -7,14 +7,13 @@ name = "{{ name }}"
 type = "payments_extension"
 handle = "{{ handle }}"
 
-redeemable_type = "gift-card"
 payment_session_url = "https://api.paymentprovider.com/endpoint"
 # List of ISO 3166 (alpha-2) country codes your app is available for installation by merchants. Learn more:
 # https://www.iso.org/iso-3166-country-codes.html
 supported_countries = ["US"]
 # List payment method names that your payment extension will support. Learn more:
 # https://github.com/activemerchant/payment_icons/blob/master/db/payment_icons.yml
-supported_payment_methods = ["visa"]
+supported_payment_methods = ["gift-card"]
 test_mode_available = true
 merchant_label = "Redeemable Payments App Extension"
 balance_url = "https://api.paymentprovider.com/balance"


### PR DESCRIPTION
This PR ensures we use [`gift-card`] as the `supported_payment_methods`

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
