### PR TITLE
Add uid to TOML templates

### DIFF
--- a/admin-action/shopify.extension.toml.liquid
+++ b/admin-action/shopify.extension.toml.liquid
@@ -5,6 +5,7 @@ api_version = "2024-04"
 name = "t:name"
 handle = "{{ handle }}"
 type = "ui_extension"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 [[extensions.targeting]]
 module = "./src/ActionExtension.{{ srcFileExtension }}"
 # The target used here must match the target used in the module file (./src/ActionExtension.{{ srcFileExtension }})

--- a/admin-block/shopify.extension.toml.liquid
+++ b/admin-block/shopify.extension.toml.liquid
@@ -5,6 +5,7 @@ api_version = "2024-04"
 name = "t:name"
 handle = "{{ handle }}"
 type = "ui_extension"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 [[extensions.targeting]]
 module = "./src/BlockExtension.{{ srcFileExtension }}"
 # The target used here must match the target used in the module file (./src/BlockExtension.{{ srcFileExtension }})

--- a/checkout-extension/shopify.extension.toml.liquid
+++ b/checkout-extension/shopify.extension.toml.liquid
@@ -6,9 +6,10 @@
 api_version = "2024-04"
 
 [[extensions]]
-type = "ui_extension"
 name = "{{ name }}"
 handle = "{{ handle }}"
+type = "ui_extension"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 
 # Controls where in Shopify your extension will be injected,
 # and the file that contains your extension’s source code. Learn more:

--- a/checkout-post-purchase/shopify.extension.toml.liquid
+++ b/checkout-post-purchase/shopify.extension.toml.liquid
@@ -1,5 +1,6 @@
-type = "checkout_post_purchase"
 name = "{{ name }}"
+type = "checkout_post_purchase"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 
 # [[metafields]]
 # namespace = "my-namespace"

--- a/customer-account-extension/shopify.extension.toml.liquid
+++ b/customer-account-extension/shopify.extension.toml.liquid
@@ -6,9 +6,10 @@
 api_version = "unstable"
 
 [[extensions]]
-type = "ui_extension"
 name = "{{ name }}"
 handle = "{{ handle }}"
+type = "ui_extension"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 
 # Controls where in Shopify your extension will be injected,
 # and the file that contains your extension’s source code. Learn more:

--- a/customer-segment-template-extension/shopify.extension.toml.liquid
+++ b/customer-segment-template-extension/shopify.extension.toml.liquid
@@ -3,9 +3,10 @@ api_version = "unstable"
 [[extensions]]
 # Change the merchant-facing name of the extension in locales/en.default.json
 name = "t:title"
-description = "t:description"
 handle = "{{ handle }}"
 type = "ui_extension"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+description = "t:description"
 [[extensions.targeting]]
 module = "./src/CustomerSegmentTemplate.{{ srcFileExtension }}"
 # The target used here must match the target used in the module file (./src/CustomerSegmentTemplate.{{ srcFileExtension }})

--- a/editor-extension-collection/shopify.extension.toml.liquid
+++ b/editor-extension-collection/shopify.extension.toml.liquid
@@ -1,7 +1,8 @@
 [[extensions]]
 name = "t:collection_one_name"
-type = "editor_extension_collection"
 handle = "{{ handle }}"
+type = "editor_extension_collection"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 # Add the handles of the extensions you want in this collection here
 includes=[]
 

--- a/flow-action/shopify.extension.toml.liquid
+++ b/flow-action/shopify.extension.toml.liquid
@@ -1,7 +1,8 @@
 [[extensions]]
 name = "{{ name }}"
-type = "flow_action"
 handle = "{{ handle }}"
+type = "flow_action"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 description = "Your description"
 runtime_url = "https://url.com/api/execute"
 

--- a/flow-template/shopify.extension.toml.liquid
+++ b/flow-template/shopify.extension.toml.liquid
@@ -1,7 +1,8 @@
 [[extensions]]
 name = "{{ name }}"
-type = "flow_template"
 handle = "{{ handle }}"
+type = "flow_template"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 description = "A Template that helps increase merchant productivity"
 
 [extensions.template]

--- a/flow-trigger/shopify.extension.toml.liquid
+++ b/flow-trigger/shopify.extension.toml.liquid
@@ -1,7 +1,8 @@
 [[extensions]]
 name = "{{ name }}"
-type = "flow_trigger"
 handle = "{{ handle }}"
+type = "flow_trigger"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 description = "Your description"
 
 [settings]

--- a/order-routing-location-rule/shopify.extension.toml.liquid
+++ b/order-routing-location-rule/shopify.extension.toml.liquid
@@ -5,6 +5,7 @@ api_version = "unstable"
 name = "t:name"
 handle = "{{ handle }}"
 type = "ui_extension"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 [[extensions.targeting]]
 module = "./src/OrderRoutingLocationRule.{{ srcFileExtension }}"
 target = "admin.settings.order-routing-rule.render"

--- a/payments-app-extension-credit-card/shopify.extension.toml.liquid
+++ b/payments-app-extension-credit-card/shopify.extension.toml.liquid
@@ -4,8 +4,9 @@ api_version = "2021-07"
 
 [[extensions]]
 name = "{{ name }}"
-type = "payments_extension"
 handle = "{{ handle }}"
+type = "payments_extension"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 
 merchant_label = "Credit Credit Payments App Extension"
 payment_session_url = "https://api.paymentprovider.com/endpoint"

--- a/payments-app-extension-custom-credit-card/shopify.extension.toml.liquid
+++ b/payments-app-extension-custom-credit-card/shopify.extension.toml.liquid
@@ -4,8 +4,9 @@ api_version = "unstable"
 
 [[extensions]]
 name = "{{ name }}"
-type = "payments_extension"
 handle = "{{ handle }}"
+type = "payments_extension"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 
 merchant_label = "Custom Credit Credit Payments App Extension"
 payment_session_url = "https://api.paymentprovider.com/endpoint"

--- a/payments-app-extension-custom-onsite/shopify.extension.toml.liquid
+++ b/payments-app-extension-custom-onsite/shopify.extension.toml.liquid
@@ -4,8 +4,9 @@ api_version = "2021-07"
 
 [[extensions]]
 name = "{{ name }}"
-type = "payments_extension"
 handle = "{{ handle }}"
+type = "payments_extension"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 
 merchant_label = "Custom Onsite Payments App Extension"
 payment_session_url = "https://api.paymentprovider.com/endpoint"

--- a/payments-app-extension-offsite/shopify.extension.toml.liquid
+++ b/payments-app-extension-offsite/shopify.extension.toml.liquid
@@ -4,8 +4,9 @@ api_version = "2021-07"
 
 [[extensions]]
 name = "{{ name }}"
-type = "payments_extension"
 handle = "{{ handle }}"
+type = "payments_extension"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 
 merchant_label = "Offsite Payments App Extension"
 payment_session_url = "https://api.paymentprovider.com/endpoint"

--- a/payments-app-extension-redeemable/shopify.extension.toml.liquid
+++ b/payments-app-extension-redeemable/shopify.extension.toml.liquid
@@ -4,8 +4,9 @@ api_version = "2023-07"
 
 [[extensions]]
 name = "{{ name }}"
-type = "payments_extension"
 handle = "{{ handle }}"
+type = "payments_extension"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 
 payment_session_url = "https://api.paymentprovider.com/endpoint"
 # List of ISO 3166 (alpha-2) country codes your app is available for installation by merchants. Learn more:

--- a/pos-ui-extension/shopify.extension.toml.liquid
+++ b/pos-ui-extension/shopify.extension.toml.liquid
@@ -1,5 +1,6 @@
-type = "pos_ui_extension"
 name = "{{ name }}"
+type = "pos_ui_extension"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 description = "{{ name }}"
 
 extension_points = [

--- a/product-configuration-extension/shopify.extension.toml.liquid
+++ b/product-configuration-extension/shopify.extension.toml.liquid
@@ -4,6 +4,7 @@ api_version = "2023-07"
 name = "t:name"
 handle = "{{ handle }}"
 type = "ui_extension"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 
 # Both extension points are required
 [[extensions.targeting]]

--- a/tax-calculation/shopify.extension.toml.liquid
+++ b/tax-calculation/shopify.extension.toml.liquid
@@ -1,5 +1,6 @@
-type = "tax_calculation"
 name = "{{ name }}"
+type = "tax_calculation"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 
 production_api_base_url = ""
 benchmark_api_base_url = ""

--- a/validation-settings/shopify.extension.toml.liquid
+++ b/validation-settings/shopify.extension.toml.liquid
@@ -10,6 +10,7 @@ name = "t:name"
 #   handle = "{{ handle }}"
 handle = "{{ handle }}"
 type = "ui_extension"
+{% if uid %}uid = "{{ uid }}"{% endif %}
 
 [[extensions.targeting]]
 module = "./src/ValidationSettings.{{ srcFileExtension }}"


### PR DESCRIPTION
### Background

Continuation of https://github.com/Shopify/cli/pull/3725/files

### Solution

Add the `uid` field if present to the TOML templates.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
