### PR TITLE
fix: Update name and description in TOML to use locale values

### DIFF
--- a/flow-template/shopify.extension.toml.liquid
+++ b/flow-template/shopify.extension.toml.liquid
@@ -1,8 +1,8 @@
 [[extensions]]
-name = "{{ name }}"
+name = "t:name"
 type = "flow_template"
 handle = "{{ handle }}"
-description = "A Template that helps increase merchant productivity"
+description = "t:description"
 
 [extensions.template]
 


### PR DESCRIPTION
### Background
Previously in the TOML we populated name and description by:
`name` - extension name from terminal input when generating template extension
`description` - placeholder value "A Template that helps increase merchant productivity"

This was found to be confusing during a convergence sync as to which actually gets used when displaying to the merchant since we also have a locale folder with name and description keys.

### Solution

Update name and description to use the same pattern as other extensions "t:name" and "t:description". With this the extension author will have one place to edit name and description values (in the locale folder).

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
