### PR TITLE
refactor: Remove post install note from locale examples

### DIFF
--- a/flow-template/locales/en.default.json
+++ b/flow-template/locales/en.default.json
@@ -1,6 +1,5 @@
 {
   "name": "My Awesome Template!",
   "description": "A Template that helps increase merchant productivity",
-  "preInstallNote": "You must disable automatic payment capture in the Shopify Admin before using this Template",
-  "postInstallNote": "Please ensure your have disabled automatic payment capture in the Shopify Admin before using this Template"
+  "preInstallNote": "You must disable automatic payment capture in the Shopify Admin before using this Template"
 }

--- a/flow-template/locales/fr.json
+++ b/flow-template/locales/fr.json
@@ -1,6 +1,5 @@
 {
   "name": "Mon modèle impressionnant!",
   "description": "Un modèle qui aide à augmenter la productivité des marchands",
-  "preInstallNote": "Vous devez désactiver la capture de paiement automatique dans l'administration de Shopify avant d'utiliser ce modèle",
-  "postInstallNote": "Veuillez vous assurer que vous avez désactivé la capture de paiement automatique dans l'administration de Shopify avant d'utiliser ce modèle"
+  "preInstallNote": "Vous devez désactiver la capture de paiement automatique dans l'administration de Shopify avant d'utiliser ce modèle"
 }


### PR DESCRIPTION
### Background

We only want to show pre install instructions for now.

### Solution

Remove example post install note from locale 

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
