### PR TITLE
Templates JSON

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -380,5 +380,237 @@
         ]
       }
     ]
+  },
+  {
+    "identifier": "customer_segment_template",
+    "name": "Customer segment template",
+    "defaultName": "customer-segment-template",
+    "group": "Admin",
+    "sortPriority": null,
+    "supportLinks": [],
+    "types": [
+      {
+        "url": "https://github.com/Shopify/extensions-templates",
+        "type": "ui_extension",
+        "extensionPoints": [],
+        "supportedFlavors": [
+          {
+            "name": "JavaScript React",
+            "value": "react",
+            "path": "customer-segment-template-extension"
+          },
+          {
+            "name": "JavaScript",
+            "value": "vanilla-js",
+            "path": "customer-segment-template-extension"
+          },
+          {
+            "name": "TypeScript React",
+            "value": "typescript-react",
+            "path": "customer-segment-template-extension"
+          },
+          {
+            "name": "TypeScript",
+            "value": "typescript",
+            "path": "customer-segment-template-extension"
+          }
+        ]
+      }
+    ],
+    "organizationBetaFlags": [
+      "enable_cli_customer_segment_template_extension"
+    ]
+  },
+  {
+    "identifier": "order_routing_location_rule_ui",
+    "name": "Order routing location rule - UI Extension",
+    "defaultName": "order-routing-location-rule-ui",
+    "group": "Discounts and checkout",
+    "sortPriority": null,
+    "supportLinks": [
+      "https://shopify.dev/docs/apps/fulfillment/order-routing-apps/location-rules"
+    ],
+    "types": [
+      {
+        "url": "https://github.com/Shopify/extensions-templates",
+        "type": "ui_extension",
+        "extensionPoints": [],
+        "supportedFlavors": [
+          {
+            "name": "JavaScript React",
+            "value": "react",
+            "path": "order-routing-location-rule"
+          },
+          {
+            "name": "JavaScript",
+            "value": "vanilla-js",
+            "path": "order-routing-location-rule"
+          },
+          {
+            "name": "TypeScript React",
+            "value": "typescript-react",
+            "path": "order-routing-location-rule"
+          },
+          {
+            "name": "TypeScript",
+            "value": "typescript",
+            "path": "order-routing-location-rule"
+          }
+        ]
+      }
+    ],
+    "organizationBetaFlags": [
+      "order_routing_extensibility_partner"
+    ]
+  },
+  {
+    "identifier": "editor_extension_collection",
+    "name": "Editor extension collection",
+    "defaultName": "Editor extension collection",
+    "group": "Admin",
+    "sortPriority": null,
+    "supportLinks": [],
+    "types": [
+      {
+        "url": "https://github.com/Shopify/extensions-templates",
+        "type": "editor_extension_collection",
+        "extensionPoints": [],
+        "supportedFlavors": [
+          {
+            "name": "Config only",
+            "value": "config-only",
+            "path": "editor-extension-collection"
+          }
+        ]
+      }
+    ],
+    "organizationBetaFlags": [
+      "editor_extension_collection"
+    ]
+  },
+  {
+    "identifier": "offsite_payments",
+    "name": "Offsite",
+    "defaultName": "Offsite",
+    "group": "Payments App Extension",
+    "sortPriority": null,
+    "supportLinks": [],
+    "types": [
+      {
+        "url": "https://github.com/Shopify/extensions-templates",
+        "type": "payments_extension",
+        "extensionPoints": [],
+        "supportedFlavors": [
+          {
+            "name": "Config only",
+            "value": "config-only",
+            "path": "payments-app-extension-offsite"
+          }
+        ]
+      }
+    ],
+    "organizationBetaFlags": [
+      "cli_payment_extensions"
+    ]
+  },
+  {
+    "identifier": "credit_card_payments",
+    "name": "Credit Card",
+    "defaultName": "Credit Card",
+    "group": "Payments App Extension",
+    "sortPriority": null,
+    "supportLinks": [],
+    "types": [
+      {
+        "url": "https://github.com/Shopify/extensions-templates",
+        "type": "payments_extension",
+        "extensionPoints": [],
+        "supportedFlavors": [
+          {
+            "name": "Config only",
+            "value": "config-only",
+            "path": "payments-app-extension-credit-card"
+          }
+        ]
+      }
+    ],
+    "organizationBetaFlags": [
+      "cli_payment_extensions"
+    ]
+  },
+  {
+    "identifier": "custom_credit_card_payments",
+    "name": "Custom Credit Card",
+    "defaultName": "Custom Credit Card",
+    "group": "Payments App Extension",
+    "sortPriority": null,
+    "supportLinks": [],
+    "types": [
+      {
+        "url": "https://github.com/Shopify/extensions-templates",
+        "type": "payments_extension",
+        "extensionPoints": [],
+        "supportedFlavors": [
+          {
+            "name": "Config only",
+            "value": "config-only",
+            "path": "payments-app-extension-custom-credit-card"
+          }
+        ]
+      }
+    ],
+    "organizationBetaFlags": [
+      "cli_payment_extensions"
+    ]
+  },
+  {
+    "identifier": "custom_onsite_payments",
+    "name": "Custom Onsite",
+    "defaultName": "Custom Onsite",
+    "group": "Payments App Extension",
+    "sortPriority": null,
+    "supportLinks": [],
+    "types": [
+      {
+        "url": "https://github.com/Shopify/extensions-templates",
+        "type": "payments_extension",
+        "extensionPoints": [],
+        "supportedFlavors": [
+          {
+            "name": "Config only",
+            "value": "config-only",
+            "path": "payments-app-extension-custom-onsite"
+          }
+        ]
+      }
+    ],
+    "organizationBetaFlags": [
+      "cli_payment_extensions"
+    ]
+  },
+  {
+    "identifier": "redeemable_payments",
+    "name": "Redeemable",
+    "defaultName": "Redeemable",
+    "group": "Payments App Extension",
+    "sortPriority": null,
+    "supportLinks": [],
+    "types": [
+      {
+        "url": "https://github.com/Shopify/extensions-templates",
+        "type": "payments_extension",
+        "extensionPoints": [],
+        "supportedFlavors": [
+          {
+            "name": "Config only",
+            "value": "config-only",
+            "path": "payments-app-extension-redeemable"
+          }
+        ]
+      }
+    ],
+    "organizationBetaFlags": [
+      "cli_payment_extensions"
+    ]
   }
 ]

--- a/templates.json
+++ b/templates.json
@@ -1,5 +1,73 @@
 [
   {
+    "identifier": "checkout_ui",
+    "name": "Checkout UI",
+    "defaultName": "checkout-ui",
+    "group": "Discounts and checkout",
+    "supportLinks": [
+      "https://shopify.dev/api/checkout-extensions/checkout/configuration"
+    ],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "checkout-extension"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "checkout-extension"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "checkout-extension"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "checkout-extension"
+      }
+    ]
+  },
+  {
+    "identifier": "post_purchase_ui",
+    "name": "Post-purchase UI",
+    "defaultName": "post-purchase-ui",
+    "group": "Discounts and checkout",
+    "supportLinks": [
+      "https://shopify.dev/docs/apps/checkout/post-purchase"
+    ],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "checkout_post_purchase",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "checkout-post-purchase"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "checkout-post-purchase"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "checkout-post-purchase"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "checkout-post-purchase"
+      }
+    ]
+  },
+  {
     "identifier": "admin_action",
     "name": "Admin action",
     "defaultName": "admin-action",
@@ -64,13 +132,564 @@
     ]
   },
   {
-    "identifier": "checkout_ui",
-    "name": "Checkout UI",
-    "defaultName": "checkout-ui",
+    "identifier": "cart_checkout_validation",
+    "name": "Cart and checkout validation - Function",
+    "defaultName": "cart-checkout-validation",
     "group": "Discounts and checkout",
-    "sortPriority": 0,
     "supportLinks": [
-      "https://shopify.dev/api/checkout-extensions/checkout/configuration"
+      "https://shopify.dev/docs/api/functions/reference/cart-checkout-validation"
+    ],
+    "url": "https://github.com/Shopify/function-examples",
+    "type": "function",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "checkout/javascript/cart-checkout-validation/default"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "checkout/javascript/cart-checkout-validation/default"
+      },
+      {
+        "name": "Rust",
+        "value": "rust",
+        "path": "checkout/rust/cart-checkout-validation/default"
+      },
+      {
+        "name": "Wasm",
+        "value": "wasm",
+        "path": "checkout/wasm/cart-checkout-validation/default"
+      }
+    ]
+  },
+  {
+    "identifier": "cart_transform",
+    "name": "Cart transformer - Function",
+    "defaultName": "cart-transformer",
+    "group": "Discounts and checkout",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/function-examples",
+    "type": "function",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "checkout/javascript/cart-transform/default"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "checkout/javascript/cart-transform/default"
+      },
+      {
+        "name": "Rust",
+        "value": "rust",
+        "path": "checkout/rust/cart-transform/default"
+      },
+      {
+        "name": "Wasm",
+        "value": "wasm",
+        "path": "checkout/wasm/cart-transform/default"
+      }
+    ]
+  },
+  {
+    "identifier": "credit_card_payments",
+    "name": "Credit Card",
+    "defaultName": "Credit Card",
+    "group": "Payments App Extension",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "payments_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "payments-app-extension-credit-card"
+      }
+    ],
+    "organizationBetaFlags": [
+      "cli_payment_extensions"
+    ]
+  },
+  {
+    "identifier": "custom_credit_card_payments",
+    "name": "Custom Credit Card",
+    "defaultName": "Custom Credit Card",
+    "group": "Payments App Extension",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "payments_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "payments-app-extension-custom-credit-card"
+      }
+    ],
+    "organizationBetaFlags": [
+      "cli_payment_extensions"
+    ]
+  },
+  {
+    "identifier": "custom_onsite_payments",
+    "name": "Custom Onsite",
+    "defaultName": "Custom Onsite",
+    "group": "Payments App Extension",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "payments_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "payments-app-extension-custom-onsite"
+      }
+    ],
+    "organizationBetaFlags": [
+      "cli_payment_extensions"
+    ]
+  },
+  {
+    "identifier": "customer_account_ui",
+    "name": "Customer account UI (preview for dev stores only)",
+    "defaultName": "customer-account-ui",
+    "group": "Customer account",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "customer-account-extension"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "customer-account-extension"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "customer-account-extension"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "customer-account-extension"
+      }
+    ]
+  },
+  {
+    "identifier": "customer_segment_template",
+    "name": "Customer segment template",
+    "defaultName": "customer-segment-template",
+    "group": "Admin",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "customer-segment-template-extension"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "customer-segment-template-extension"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "customer-segment-template-extension"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "customer-segment-template-extension"
+      }
+    ],
+    "organizationBetaFlags": [
+      "enable_cli_customer_segment_template_extension"
+    ]
+  },
+  {
+    "identifier": "delivery_customization",
+    "name": "Delivery customization - Function",
+    "defaultName": "delivery-customization",
+    "group": "Discounts and checkout",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/function-examples",
+    "type": "function",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "checkout/javascript/delivery-customization/default"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "checkout/javascript/delivery-customization/default"
+      },
+      {
+        "name": "Rust",
+        "value": "rust",
+        "path": "checkout/rust/delivery-customization/default"
+      },
+      {
+        "name": "Wasm",
+        "value": "wasm",
+        "path": "checkout/wasm/delivery-customization/default"
+      }
+    ]
+  },
+  {
+    "identifier": "order_discounts",
+    "name": "Discount orders - Function",
+    "defaultName": "order-discount",
+    "group": "Discounts and checkout",
+    "supportLinks": [
+      "https://shopify.dev/docs/apps/discounts"
+    ],
+    "url": "https://github.com/Shopify/function-examples",
+    "type": "function",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "discounts/javascript/order-discounts/default"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "discounts/javascript/order-discounts/default"
+      },
+      {
+        "name": "Rust",
+        "value": "rust",
+        "path": "discounts/rust/order-discounts/default"
+      },
+      {
+        "name": "Wasm",
+        "value": "wasm",
+        "path": "discounts/wasm/order-discounts/default"
+      }
+    ]
+  },
+  {
+    "identifier": "product_discounts",
+    "name": "Discount products - Function",
+    "defaultName": "product-discount",
+    "group": "Discounts and checkout",
+    "supportLinks": [
+      "https://shopify.dev/docs/apps/discounts"
+    ],
+    "url": "https://github.com/Shopify/function-examples",
+    "type": "function",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "discounts/javascript/product-discounts/default"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "discounts/javascript/product-discounts/default"
+      },
+      {
+        "name": "Rust",
+        "value": "rust",
+        "path": "discounts/rust/product-discounts/default"
+      },
+      {
+        "name": "Wasm",
+        "value": "wasm",
+        "path": "discounts/wasm/product-discounts/default"
+      }
+    ]
+  },
+  {
+    "identifier": "shipping_discounts",
+    "name": "Discount shipping - Function",
+    "defaultName": "shipping-discount",
+    "group": "Discounts and checkout",
+    "supportLinks": [
+      "https://shopify.dev/docs/apps/discounts"
+    ],
+    "url": "https://github.com/Shopify/function-examples",
+    "type": "function",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "discounts/javascript/shipping-discounts/default"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "discounts/javascript/shipping-discounts/default"
+      },
+      {
+        "name": "Rust",
+        "value": "rust",
+        "path": "discounts/rust/shipping-discounts/default"
+      },
+      {
+        "name": "Wasm",
+        "value": "wasm",
+        "path": "discounts/wasm/shipping-discounts/default"
+      }
+    ]
+  },
+  {
+    "identifier": "discounts_allocator",
+    "name": "Discounts allocator — Function",
+    "defaultName": "discounts-allocator",
+    "group": "Discounts and checkout",
+    "supportLinks": [
+      "https://shopify.dev/docs/apps/discounts"
+    ],
+    "url": "https://github.com/Shopify/function-examples",
+    "type": "function",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "discounts/javascript/discounts-allocator/default"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "discounts/javascript/discounts-allocator/default"
+      },
+      {
+        "name": "Rust",
+        "value": "rust",
+        "path": "discounts/rust/discounts-allocator/default"
+      },
+      {
+        "name": "Wasm",
+        "value": "wasm",
+        "path": "discounts/wasm/discounts-allocator/default"
+      }
+    ]
+  },
+  {
+    "identifier": "editor_extension_collection",
+    "name": "Editor extension collection",
+    "defaultName": "Editor extension collection",
+    "group": "Admin",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "editor_extension_collection",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "editor-extension-collection"
+      }
+    ],
+    "organizationBetaFlags": [
+      "editor_extension_collection"
+    ]
+  },
+  {
+    "identifier": "flow_action",
+    "name": "Flow action",
+    "defaultName": "Flow action",
+    "group": "Automations",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "flow_action",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "flow-action"
+      }
+    ]
+  },
+  {
+    "identifier": "flow_template",
+    "name": "Flow template",
+    "defaultName": "Flow template",
+    "group": "Automations",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "flow_template",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "flow-template"
+      }
+    ]
+  },
+  {
+    "identifier": "flow_trigger",
+    "name": "Flow trigger",
+    "defaultName": "Flow trigger",
+    "group": "Automations",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "flow_trigger",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "flow-trigger"
+      }
+    ]
+  },
+  {
+    "identifier": "fulfillment_constraints",
+    "name": "Fulfillment constraints - Function",
+    "defaultName": "fulfillment-constraints",
+    "group": "Discounts and checkout",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/function-examples",
+    "type": "function",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "order-routing/javascript/fulfillment-constraints/default"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "order-routing/javascript/fulfillment-constraints/default"
+      },
+      {
+        "name": "Rust",
+        "value": "rust",
+        "path": "order-routing/rust/fulfillment-constraints/default"
+      },
+      {
+        "name": "Wasm",
+        "value": "wasm",
+        "path": "order-routing/wasm/fulfillment-constraints/default"
+      }
+    ]
+  },
+  {
+    "identifier": "local_pickup_delivery_option_generator",
+    "name": "Local pickup delivery option generators — Function",
+    "defaultName": "local-pickup-delivery-option-generators",
+    "group": "Discounts and checkout",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/function-examples",
+    "type": "function",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "order-routing/javascript/local-pickup-delivery-option-generators/default"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "order-routing/javascript/local-pickup-delivery-option-generators/default"
+      },
+      {
+        "name": "Rust",
+        "value": "rust",
+        "path": "order-routing/rust/local-pickup-delivery-option-generators/default"
+      },
+      {
+        "name": "Wasm",
+        "value": "wasm",
+        "path": "order-routing/wasm/local-pickup-delivery-option-generators/default"
+      }
+    ]
+  },
+  {
+    "identifier": "offsite_payments",
+    "name": "Offsite",
+    "defaultName": "Offsite",
+    "group": "Payments App Extension",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "payments_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "payments-app-extension-offsite"
+      }
+    ],
+    "organizationBetaFlags": [
+      "cli_payment_extensions"
+    ]
+  },
+  {
+    "identifier": "order_routing_location_rule",
+    "name": "Order routing location rule - Function",
+    "defaultName": "order-routing-location-rule",
+    "group": "Discounts and checkout",
+    "sortPriority": null,
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/function-examples",
+    "type": "function",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "order-routing/javascript/location-rules/default"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "order-routing/javascript/location-rules/default"
+      },
+      {
+        "name": "Rust",
+        "value": "rust",
+        "path": "order-routing/rust/location-rules/default"
+      },
+      {
+        "name": "Wasm",
+        "value": "wasm",
+        "path": "order-routing/wasm/location-rules/default"
+      }
+    ],
+    "organizationBetaFlags": [
+      "order_routing_extensibility_partner"
+    ]
+  },
+  {
+    "identifier": "order_routing_location_rule_ui",
+    "name": "Order routing location rule - UI Extension",
+    "defaultName": "order-routing-location-rule-ui",
+    "group": "Discounts and checkout",
+    "supportLinks": [
+      "https://shopify.dev/docs/apps/fulfillment/order-routing-apps/location-rules"
     ],
     "url": "https://github.com/Shopify/extensions-templates",
     "type": "ui_extension",
@@ -79,22 +698,157 @@
       {
         "name": "JavaScript React",
         "value": "react",
-        "path": "checkout-extension"
+        "path": "order-routing-location-rule"
       },
       {
         "name": "JavaScript",
         "value": "vanilla-js",
-        "path": "checkout-extension"
+        "path": "order-routing-location-rule"
       },
       {
         "name": "TypeScript React",
         "value": "typescript-react",
-        "path": "checkout-extension"
+        "path": "order-routing-location-rule"
       },
       {
         "name": "TypeScript",
         "value": "typescript",
-        "path": "checkout-extension"
+        "path": "order-routing-location-rule"
+      }
+    ],
+    "organizationBetaFlags": [
+      "order_routing_extensibility_partner"
+    ]
+  },
+  {
+    "identifier": "order_submission_rule",
+    "name": "Order submission rule — Function",
+    "defaultName": "order-submission-rule",
+    "group": "Discounts and checkout",
+    "sortPriority": null,
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/function-examples",
+    "type": "function",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "checkout/javascript/order-submission-rule/default"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "checkout/javascript/order-submission-rule/default"
+      },
+      {
+        "name": "Rust",
+        "value": "rust",
+        "path": "checkout/rust/order-submission-rule/default"
+      },
+      {
+        "name": "Wasm",
+        "value": "wasm",
+        "path": "checkout/wasm/order-submission-rule/default"
+      }
+    ],
+    "organizationBetaFlags": [
+      "enable_cli_checkout_completion_target_function"
+    ]
+  },
+  {
+    "identifier": "payment_customization",
+    "name": "Payment customization - Function",
+    "defaultName": "payment-customization",
+    "group": "Discounts and checkout",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/function-examples",
+    "type": "function",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "checkout/javascript/payment-customization/default"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "checkout/javascript/payment-customization/default"
+      },
+      {
+        "name": "Rust",
+        "value": "rust",
+        "path": "checkout/rust/payment-customization/default"
+      },
+      {
+        "name": "Wasm",
+        "value": "wasm",
+        "path": "checkout/wasm/payment-customization/default"
+      }
+    ]
+  },
+  {
+    "identifier": "pickup_point_delivery_option_generator",
+    "name": "Pickup point delivery option generators — Function",
+    "defaultName": "pickup-point-delivery-option-generators",
+    "group": "Discounts and checkout",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/function-examples",
+    "type": "function",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "order-routing/javascript/pickup-point-delivery-option-generators/default"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "order-routing/typescript/pickup-point-delivery-option-generators/default"
+      },
+      {
+        "name": "Rust",
+        "value": "rust",
+        "path": "order-routing/rust/pickup-point-delivery-option-generators/default"
+      },
+      {
+        "name": "Wasm",
+        "value": "wasm",
+        "path": "order-routing/wasm/pickup-point-delivery-option-generators/default"
+      }
+    ]
+  },
+  {
+    "identifier": "pos_ui",
+    "name": "POS UI",
+    "defaultName": "pos-ui",
+    "group": "Point-of-Sale",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "pos_ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "pos-ui-extension"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "pos-ui-extension"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "pos-ui-extension"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "pos-ui-extension"
       }
     ]
   },
@@ -133,67 +887,23 @@
     ]
   },
   {
-    "identifier": "customer_account_ui",
-    "name": "Customer account UI (preview for dev stores only)",
-    "defaultName": "customer-account-ui",
-    "group": "Customer account",
+    "identifier": "redeemable_payments",
+    "name": "Redeemable",
+    "defaultName": "Redeemable",
+    "group": "Payments App Extension",
     "supportLinks": [],
     "url": "https://github.com/Shopify/extensions-templates",
-    "type": "ui_extension",
+    "type": "payments_extension",
     "extensionPoints": [],
     "supportedFlavors": [
       {
-        "name": "JavaScript React",
-        "value": "react",
-        "path": "customer-account-extension"
-      },
-      {
-        "name": "JavaScript",
-        "value": "vanilla-js",
-        "path": "customer-account-extension"
-      },
-      {
-        "name": "TypeScript React",
-        "value": "typescript-react",
-        "path": "customer-account-extension"
-      },
-      {
-        "name": "TypeScript",
-        "value": "typescript",
-        "path": "customer-account-extension"
+        "name": "Config only",
+        "value": "config-only",
+        "path": "payments-app-extension-redeemable"
       }
-    ]
-  },
-  {
-    "identifier": "pos_ui",
-    "name": "POS UI",
-    "defaultName": "pos-ui",
-    "group": "Point-of-Sale",
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "pos_ui_extension",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "JavaScript React",
-        "value": "react",
-        "path": "pos-ui-extension"
-      },
-      {
-        "name": "JavaScript",
-        "value": "vanilla-js",
-        "path": "pos-ui-extension"
-      },
-      {
-        "name": "TypeScript React",
-        "value": "typescript-react",
-        "path": "pos-ui-extension"
-      },
-      {
-        "name": "TypeScript",
-        "value": "typescript",
-        "path": "pos-ui-extension"
-      }
+    ],
+    "organizationBetaFlags": [
+      "cli_payment_extensions"
     ]
   },
   {
@@ -210,75 +920,6 @@
         "name": "Config only",
         "value": "config-only",
         "path": "tax-calculation"
-      }
-    ]
-  },
-  {
-    "identifier": "flow_action",
-    "name": "Flow action",
-    "defaultName": "Flow action",
-    "group": "Automations",
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "flow_action",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "Config only",
-        "value": "config-only",
-        "path": "flow-action"
-      }
-    ]
-  },
-  {
-    "identifier": "flow_trigger",
-    "name": "Flow trigger",
-    "defaultName": "Flow trigger",
-    "group": "Automations",
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "flow_trigger",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "Config only",
-        "value": "config-only",
-        "path": "flow-trigger"
-      }
-    ]
-  },
-  {
-    "identifier": "post_purchase_ui",
-    "name": "Post-purchase UI",
-    "defaultName": "post-purchase-ui",
-    "group": "Discounts and checkout",
-    "sortPriority": 1,
-    "supportLinks": [
-      "https://shopify.dev/docs/apps/checkout/post-purchase"
-    ],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "checkout_post_purchase",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "JavaScript React",
-        "value": "react",
-        "path": "checkout-post-purchase"
-      },
-      {
-        "name": "JavaScript",
-        "value": "vanilla-js",
-        "path": "checkout-post-purchase"
-      },
-      {
-        "name": "TypeScript React",
-        "value": "typescript-react",
-        "path": "checkout-post-purchase"
-      },
-      {
-        "name": "TypeScript",
-        "value": "typescript",
-        "path": "checkout-post-purchase"
       }
     ]
   },
@@ -314,223 +955,6 @@
         "value": "typescript",
         "path": "validation-settings"
       }
-    ]
-  },
-  {
-    "identifier": "flow_template",
-    "name": "Flow template",
-    "defaultName": "Flow template",
-    "group": "Automations",
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "flow_template",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "Config only",
-        "value": "config-only",
-        "path": "flow-template"
-      }
-    ]
-  },
-  {
-    "identifier": "customer_segment_template",
-    "name": "Customer segment template",
-    "defaultName": "customer-segment-template",
-    "group": "Admin",
-    "sortPriority": null,
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "ui_extension",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "JavaScript React",
-        "value": "react",
-        "path": "customer-segment-template-extension"
-      },
-      {
-        "name": "JavaScript",
-        "value": "vanilla-js",
-        "path": "customer-segment-template-extension"
-      },
-      {
-        "name": "TypeScript React",
-        "value": "typescript-react",
-        "path": "customer-segment-template-extension"
-      },
-      {
-        "name": "TypeScript",
-        "value": "typescript",
-        "path": "customer-segment-template-extension"
-      }
-    ],
-    "organizationBetaFlags": [
-      "enable_cli_customer_segment_template_extension"
-    ]
-  },
-  {
-    "identifier": "order_routing_location_rule_ui",
-    "name": "Order routing location rule - UI Extension",
-    "defaultName": "order-routing-location-rule-ui",
-    "group": "Discounts and checkout",
-    "sortPriority": null,
-    "supportLinks": [
-      "https://shopify.dev/docs/apps/fulfillment/order-routing-apps/location-rules"
-    ],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "ui_extension",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "JavaScript React",
-        "value": "react",
-        "path": "order-routing-location-rule"
-      },
-      {
-        "name": "JavaScript",
-        "value": "vanilla-js",
-        "path": "order-routing-location-rule"
-      },
-      {
-        "name": "TypeScript React",
-        "value": "typescript-react",
-        "path": "order-routing-location-rule"
-      },
-      {
-        "name": "TypeScript",
-        "value": "typescript",
-        "path": "order-routing-location-rule"
-      }
-    ],
-    "organizationBetaFlags": [
-      "order_routing_extensibility_partner"
-    ]
-  },
-  {
-    "identifier": "editor_extension_collection",
-    "name": "Editor extension collection",
-    "defaultName": "Editor extension collection",
-    "group": "Admin",
-    "sortPriority": null,
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "editor_extension_collection",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "Config only",
-        "value": "config-only",
-        "path": "editor-extension-collection"
-      }
-    ],
-    "organizationBetaFlags": [
-      "editor_extension_collection"
-    ]
-  },
-  {
-    "identifier": "offsite_payments",
-    "name": "Offsite",
-    "defaultName": "Offsite",
-    "group": "Payments App Extension",
-    "sortPriority": null,
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "payments_extension",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "Config only",
-        "value": "config-only",
-        "path": "payments-app-extension-offsite"
-      }
-    ],
-    "organizationBetaFlags": [
-      "cli_payment_extensions"
-    ]
-  },
-  {
-    "identifier": "credit_card_payments",
-    "name": "Credit Card",
-    "defaultName": "Credit Card",
-    "group": "Payments App Extension",
-    "sortPriority": null,
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "payments_extension",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "Config only",
-        "value": "config-only",
-        "path": "payments-app-extension-credit-card"
-      }
-    ],
-    "organizationBetaFlags": [
-      "cli_payment_extensions"
-    ]
-  },
-  {
-    "identifier": "custom_credit_card_payments",
-    "name": "Custom Credit Card",
-    "defaultName": "Custom Credit Card",
-    "group": "Payments App Extension",
-    "sortPriority": null,
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "payments_extension",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "Config only",
-        "value": "config-only",
-        "path": "payments-app-extension-custom-credit-card"
-      }
-    ],
-    "organizationBetaFlags": [
-      "cli_payment_extensions"
-    ]
-  },
-  {
-    "identifier": "custom_onsite_payments",
-    "name": "Custom Onsite",
-    "defaultName": "Custom Onsite",
-    "group": "Payments App Extension",
-    "sortPriority": null,
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "payments_extension",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "Config only",
-        "value": "config-only",
-        "path": "payments-app-extension-custom-onsite"
-      }
-    ],
-    "organizationBetaFlags": [
-      "cli_payment_extensions"
-    ]
-  },
-  {
-    "identifier": "redeemable_payments",
-    "name": "Redeemable",
-    "defaultName": "Redeemable",
-    "group": "Payments App Extension",
-    "sortPriority": null,
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "payments_extension",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "Config only",
-        "value": "config-only",
-        "path": "payments-app-extension-redeemable"
-      }
-    ],
-    "organizationBetaFlags": [
-      "cli_payment_extensions"
     ]
   }
 ]

--- a/templates.json
+++ b/templates.json
@@ -1,0 +1,384 @@
+[
+  {
+    "identifier": "admin_action",
+    "name": "Admin action",
+    "defaultName": "admin-action",
+    "group": "Admin",
+    "supportLinks": [],
+    "types": [
+      {
+        "url": "https://github.com/Shopify/extensions-templates",
+        "type": "ui_extension",
+        "extensionPoints": [],
+        "supportedFlavors": [
+          {
+            "name": "JavaScript React",
+            "value": "react",
+            "path": "admin-action"
+          },
+          {
+            "name": "JavaScript",
+            "value": "vanilla-js",
+            "path": "admin-action"
+          },
+          {
+            "name": "TypeScript React",
+            "value": "typescript-react",
+            "path": "admin-action"
+          },
+          {
+            "name": "TypeScript",
+            "value": "typescript",
+            "path": "admin-action"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "identifier": "admin_block",
+    "name": "Admin block",
+    "defaultName": "admin-block",
+    "group": "Admin",
+    "supportLinks": [],
+    "types": [
+      {
+        "url": "https://github.com/Shopify/extensions-templates",
+        "type": "ui_extension",
+        "extensionPoints": [],
+        "supportedFlavors": [
+          {
+            "name": "JavaScript React",
+            "value": "react",
+            "path": "admin-block"
+          },
+          {
+            "name": "JavaScript",
+            "value": "vanilla-js",
+            "path": "admin-block"
+          },
+          {
+            "name": "TypeScript React",
+            "value": "typescript-react",
+            "path": "admin-block"
+          },
+          {
+            "name": "TypeScript",
+            "value": "typescript",
+            "path": "admin-block"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "identifier": "checkout_ui",
+    "name": "Checkout UI",
+    "defaultName": "checkout-ui",
+    "group": "Discounts and checkout",
+    "sortPriority": 0,
+    "supportLinks": [
+      "https://shopify.dev/api/checkout-extensions/checkout/configuration"
+    ],
+    "types": [
+      {
+        "url": "https://github.com/Shopify/extensions-templates",
+        "type": "ui_extension",
+        "extensionPoints": [],
+        "supportedFlavors": [
+          {
+            "name": "JavaScript React",
+            "value": "react",
+            "path": "checkout-extension"
+          },
+          {
+            "name": "JavaScript",
+            "value": "vanilla-js",
+            "path": "checkout-extension"
+          },
+          {
+            "name": "TypeScript React",
+            "value": "typescript-react",
+            "path": "checkout-extension"
+          },
+          {
+            "name": "TypeScript",
+            "value": "typescript",
+            "path": "checkout-extension"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "identifier": "product_configuration",
+    "name": "Product configuration",
+    "defaultName": "product-configuration",
+    "group": "Admin",
+    "supportLinks": [
+      "https://shopify.dev/docs/apps/selling-strategies/bundles/product-config"
+    ],
+    "types": [
+      {
+        "url": "https://github.com/Shopify/extensions-templates",
+        "type": "ui_extension",
+        "extensionPoints": [],
+        "supportedFlavors": [
+          {
+            "name": "JavaScript React",
+            "value": "react",
+            "path": "product-configuration-extension"
+          },
+          {
+            "name": "JavaScript",
+            "value": "vanilla-js",
+            "path": "product-configuration-extension"
+          },
+          {
+            "name": "TypeScript React",
+            "value": "typescript-react",
+            "path": "product-configuration-extension"
+          },
+          {
+            "name": "TypeScript",
+            "value": "typescript",
+            "path": "product-configuration-extension"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "identifier": "customer_account_ui",
+    "name": "Customer account UI (preview for dev stores only)",
+    "defaultName": "customer-account-ui",
+    "group": "Customer account",
+    "supportLinks": [],
+    "types": [
+      {
+        "url": "https://github.com/Shopify/extensions-templates",
+        "type": "ui_extension",
+        "extensionPoints": [],
+        "supportedFlavors": [
+          {
+            "name": "JavaScript React",
+            "value": "react",
+            "path": "customer-account-extension"
+          },
+          {
+            "name": "JavaScript",
+            "value": "vanilla-js",
+            "path": "customer-account-extension"
+          },
+          {
+            "name": "TypeScript React",
+            "value": "typescript-react",
+            "path": "customer-account-extension"
+          },
+          {
+            "name": "TypeScript",
+            "value": "typescript",
+            "path": "customer-account-extension"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "identifier": "pos_ui",
+    "name": "POS UI",
+    "defaultName": "pos-ui",
+    "group": "Point-of-Sale",
+    "supportLinks": [],
+    "types": [
+      {
+        "url": "https://github.com/Shopify/extensions-templates",
+        "type": "pos_ui_extension",
+        "extensionPoints": [],
+        "supportedFlavors": [
+          {
+            "name": "JavaScript React",
+            "value": "react",
+            "path": "pos-ui-extension"
+          },
+          {
+            "name": "JavaScript",
+            "value": "vanilla-js",
+            "path": "pos-ui-extension"
+          },
+          {
+            "name": "TypeScript React",
+            "value": "typescript-react",
+            "path": "pos-ui-extension"
+          },
+          {
+            "name": "TypeScript",
+            "value": "typescript",
+            "path": "pos-ui-extension"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "identifier": "tax_calculation",
+    "name": "Tax calculation",
+    "defaultName": "tax-calculation",
+    "group": "Admin",
+    "supportLinks": [],
+    "types": [
+      {
+        "url": "https://github.com/Shopify/extensions-templates",
+        "type": "tax_calculation",
+        "extensionPoints": [],
+        "supportedFlavors": [
+          {
+            "name": "Config only",
+            "value": "config-only",
+            "path": "tax-calculation"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "identifier": "flow_action",
+    "name": "Flow action",
+    "defaultName": "Flow action",
+    "group": "Automations",
+    "supportLinks": [],
+    "types": [
+      {
+        "url": "https://github.com/Shopify/extensions-templates",
+        "type": "flow_action",
+        "extensionPoints": [],
+        "supportedFlavors": [
+          {
+            "name": "Config only",
+            "value": "config-only",
+            "path": "flow-action"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "identifier": "flow_trigger",
+    "name": "Flow trigger",
+    "defaultName": "Flow trigger",
+    "group": "Automations",
+    "supportLinks": [],
+    "types": [
+      {
+        "url": "https://github.com/Shopify/extensions-templates",
+        "type": "flow_trigger",
+        "extensionPoints": [],
+        "supportedFlavors": [
+          {
+            "name": "Config only",
+            "value": "config-only",
+            "path": "flow-trigger"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "identifier": "post_purchase_ui",
+    "name": "Post-purchase UI",
+    "defaultName": "post-purchase-ui",
+    "group": "Discounts and checkout",
+    "sortPriority": 1,
+    "supportLinks": [
+      "https://shopify.dev/docs/apps/checkout/post-purchase"
+    ],
+    "types": [
+      {
+        "url": "https://github.com/Shopify/extensions-templates",
+        "type": "checkout_post_purchase",
+        "extensionPoints": [],
+        "supportedFlavors": [
+          {
+            "name": "JavaScript React",
+            "value": "react",
+            "path": "checkout-post-purchase"
+          },
+          {
+            "name": "JavaScript",
+            "value": "vanilla-js",
+            "path": "checkout-post-purchase"
+          },
+          {
+            "name": "TypeScript React",
+            "value": "typescript-react",
+            "path": "checkout-post-purchase"
+          },
+          {
+            "name": "TypeScript",
+            "value": "typescript",
+            "path": "checkout-post-purchase"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "identifier": "validation_settings_ui",
+    "name": "Validation Settings - UI Extension",
+    "defaultName": "validation-settings-ui",
+    "group": "Admin",
+    "supportLinks": [
+      "https://shopify.dev/docs/apps/checkout/validation/server-side"
+    ],
+    "types": [
+      {
+        "url": "https://github.com/Shopify/extensions-templates",
+        "type": "ui_extension",
+        "extensionPoints": [],
+        "supportedFlavors": [
+          {
+            "name": "JavaScript React",
+            "value": "react",
+            "path": "validation-settings"
+          },
+          {
+            "name": "JavaScript",
+            "value": "vanilla-js",
+            "path": "validation-settings"
+          },
+          {
+            "name": "TypeScript React",
+            "value": "typescript-react",
+            "path": "validation-settings"
+          },
+          {
+            "name": "TypeScript",
+            "value": "typescript",
+            "path": "validation-settings"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "identifier": "flow_template",
+    "name": "Flow template",
+    "defaultName": "Flow template",
+    "group": "Automations",
+    "supportLinks": [],
+    "types": [
+      {
+        "url": "https://github.com/Shopify/extensions-templates",
+        "type": "flow_template",
+        "extensionPoints": [],
+        "supportedFlavors": [
+          {
+            "name": "Config only",
+            "value": "config-only",
+            "path": "flow-template"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/templates.json
+++ b/templates.json
@@ -5,33 +5,29 @@
     "defaultName": "admin-action",
     "group": "Admin",
     "supportLinks": [],
-    "types": [
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
       {
-        "url": "https://github.com/Shopify/extensions-templates",
-        "type": "ui_extension",
-        "extensionPoints": [],
-        "supportedFlavors": [
-          {
-            "name": "JavaScript React",
-            "value": "react",
-            "path": "admin-action"
-          },
-          {
-            "name": "JavaScript",
-            "value": "vanilla-js",
-            "path": "admin-action"
-          },
-          {
-            "name": "TypeScript React",
-            "value": "typescript-react",
-            "path": "admin-action"
-          },
-          {
-            "name": "TypeScript",
-            "value": "typescript",
-            "path": "admin-action"
-          }
-        ]
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "admin-action"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "admin-action"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "admin-action"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "admin-action"
       }
     ]
   },
@@ -41,33 +37,29 @@
     "defaultName": "admin-block",
     "group": "Admin",
     "supportLinks": [],
-    "types": [
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
       {
-        "url": "https://github.com/Shopify/extensions-templates",
-        "type": "ui_extension",
-        "extensionPoints": [],
-        "supportedFlavors": [
-          {
-            "name": "JavaScript React",
-            "value": "react",
-            "path": "admin-block"
-          },
-          {
-            "name": "JavaScript",
-            "value": "vanilla-js",
-            "path": "admin-block"
-          },
-          {
-            "name": "TypeScript React",
-            "value": "typescript-react",
-            "path": "admin-block"
-          },
-          {
-            "name": "TypeScript",
-            "value": "typescript",
-            "path": "admin-block"
-          }
-        ]
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "admin-block"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "admin-block"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "admin-block"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "admin-block"
       }
     ]
   },
@@ -80,33 +72,29 @@
     "supportLinks": [
       "https://shopify.dev/api/checkout-extensions/checkout/configuration"
     ],
-    "types": [
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
       {
-        "url": "https://github.com/Shopify/extensions-templates",
-        "type": "ui_extension",
-        "extensionPoints": [],
-        "supportedFlavors": [
-          {
-            "name": "JavaScript React",
-            "value": "react",
-            "path": "checkout-extension"
-          },
-          {
-            "name": "JavaScript",
-            "value": "vanilla-js",
-            "path": "checkout-extension"
-          },
-          {
-            "name": "TypeScript React",
-            "value": "typescript-react",
-            "path": "checkout-extension"
-          },
-          {
-            "name": "TypeScript",
-            "value": "typescript",
-            "path": "checkout-extension"
-          }
-        ]
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "checkout-extension"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "checkout-extension"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "checkout-extension"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "checkout-extension"
       }
     ]
   },
@@ -118,33 +106,29 @@
     "supportLinks": [
       "https://shopify.dev/docs/apps/selling-strategies/bundles/product-config"
     ],
-    "types": [
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
       {
-        "url": "https://github.com/Shopify/extensions-templates",
-        "type": "ui_extension",
-        "extensionPoints": [],
-        "supportedFlavors": [
-          {
-            "name": "JavaScript React",
-            "value": "react",
-            "path": "product-configuration-extension"
-          },
-          {
-            "name": "JavaScript",
-            "value": "vanilla-js",
-            "path": "product-configuration-extension"
-          },
-          {
-            "name": "TypeScript React",
-            "value": "typescript-react",
-            "path": "product-configuration-extension"
-          },
-          {
-            "name": "TypeScript",
-            "value": "typescript",
-            "path": "product-configuration-extension"
-          }
-        ]
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "product-configuration-extension"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "product-configuration-extension"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "product-configuration-extension"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "product-configuration-extension"
       }
     ]
   },
@@ -154,33 +138,29 @@
     "defaultName": "customer-account-ui",
     "group": "Customer account",
     "supportLinks": [],
-    "types": [
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
       {
-        "url": "https://github.com/Shopify/extensions-templates",
-        "type": "ui_extension",
-        "extensionPoints": [],
-        "supportedFlavors": [
-          {
-            "name": "JavaScript React",
-            "value": "react",
-            "path": "customer-account-extension"
-          },
-          {
-            "name": "JavaScript",
-            "value": "vanilla-js",
-            "path": "customer-account-extension"
-          },
-          {
-            "name": "TypeScript React",
-            "value": "typescript-react",
-            "path": "customer-account-extension"
-          },
-          {
-            "name": "TypeScript",
-            "value": "typescript",
-            "path": "customer-account-extension"
-          }
-        ]
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "customer-account-extension"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "customer-account-extension"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "customer-account-extension"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "customer-account-extension"
       }
     ]
   },
@@ -190,33 +170,29 @@
     "defaultName": "pos-ui",
     "group": "Point-of-Sale",
     "supportLinks": [],
-    "types": [
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "pos_ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
       {
-        "url": "https://github.com/Shopify/extensions-templates",
-        "type": "pos_ui_extension",
-        "extensionPoints": [],
-        "supportedFlavors": [
-          {
-            "name": "JavaScript React",
-            "value": "react",
-            "path": "pos-ui-extension"
-          },
-          {
-            "name": "JavaScript",
-            "value": "vanilla-js",
-            "path": "pos-ui-extension"
-          },
-          {
-            "name": "TypeScript React",
-            "value": "typescript-react",
-            "path": "pos-ui-extension"
-          },
-          {
-            "name": "TypeScript",
-            "value": "typescript",
-            "path": "pos-ui-extension"
-          }
-        ]
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "pos-ui-extension"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "pos-ui-extension"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "pos-ui-extension"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "pos-ui-extension"
       }
     ]
   },
@@ -226,18 +202,14 @@
     "defaultName": "tax-calculation",
     "group": "Admin",
     "supportLinks": [],
-    "types": [
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "tax_calculation",
+    "extensionPoints": [],
+    "supportedFlavors": [
       {
-        "url": "https://github.com/Shopify/extensions-templates",
-        "type": "tax_calculation",
-        "extensionPoints": [],
-        "supportedFlavors": [
-          {
-            "name": "Config only",
-            "value": "config-only",
-            "path": "tax-calculation"
-          }
-        ]
+        "name": "Config only",
+        "value": "config-only",
+        "path": "tax-calculation"
       }
     ]
   },
@@ -247,18 +219,14 @@
     "defaultName": "Flow action",
     "group": "Automations",
     "supportLinks": [],
-    "types": [
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "flow_action",
+    "extensionPoints": [],
+    "supportedFlavors": [
       {
-        "url": "https://github.com/Shopify/extensions-templates",
-        "type": "flow_action",
-        "extensionPoints": [],
-        "supportedFlavors": [
-          {
-            "name": "Config only",
-            "value": "config-only",
-            "path": "flow-action"
-          }
-        ]
+        "name": "Config only",
+        "value": "config-only",
+        "path": "flow-action"
       }
     ]
   },
@@ -268,18 +236,14 @@
     "defaultName": "Flow trigger",
     "group": "Automations",
     "supportLinks": [],
-    "types": [
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "flow_trigger",
+    "extensionPoints": [],
+    "supportedFlavors": [
       {
-        "url": "https://github.com/Shopify/extensions-templates",
-        "type": "flow_trigger",
-        "extensionPoints": [],
-        "supportedFlavors": [
-          {
-            "name": "Config only",
-            "value": "config-only",
-            "path": "flow-trigger"
-          }
-        ]
+        "name": "Config only",
+        "value": "config-only",
+        "path": "flow-trigger"
       }
     ]
   },
@@ -292,33 +256,29 @@
     "supportLinks": [
       "https://shopify.dev/docs/apps/checkout/post-purchase"
     ],
-    "types": [
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "checkout_post_purchase",
+    "extensionPoints": [],
+    "supportedFlavors": [
       {
-        "url": "https://github.com/Shopify/extensions-templates",
-        "type": "checkout_post_purchase",
-        "extensionPoints": [],
-        "supportedFlavors": [
-          {
-            "name": "JavaScript React",
-            "value": "react",
-            "path": "checkout-post-purchase"
-          },
-          {
-            "name": "JavaScript",
-            "value": "vanilla-js",
-            "path": "checkout-post-purchase"
-          },
-          {
-            "name": "TypeScript React",
-            "value": "typescript-react",
-            "path": "checkout-post-purchase"
-          },
-          {
-            "name": "TypeScript",
-            "value": "typescript",
-            "path": "checkout-post-purchase"
-          }
-        ]
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "checkout-post-purchase"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "checkout-post-purchase"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "checkout-post-purchase"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "checkout-post-purchase"
       }
     ]
   },
@@ -330,33 +290,29 @@
     "supportLinks": [
       "https://shopify.dev/docs/apps/checkout/validation/server-side"
     ],
-    "types": [
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
       {
-        "url": "https://github.com/Shopify/extensions-templates",
-        "type": "ui_extension",
-        "extensionPoints": [],
-        "supportedFlavors": [
-          {
-            "name": "JavaScript React",
-            "value": "react",
-            "path": "validation-settings"
-          },
-          {
-            "name": "JavaScript",
-            "value": "vanilla-js",
-            "path": "validation-settings"
-          },
-          {
-            "name": "TypeScript React",
-            "value": "typescript-react",
-            "path": "validation-settings"
-          },
-          {
-            "name": "TypeScript",
-            "value": "typescript",
-            "path": "validation-settings"
-          }
-        ]
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "validation-settings"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "validation-settings"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "validation-settings"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "validation-settings"
       }
     ]
   },
@@ -366,18 +322,14 @@
     "defaultName": "Flow template",
     "group": "Automations",
     "supportLinks": [],
-    "types": [
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "flow_template",
+    "extensionPoints": [],
+    "supportedFlavors": [
       {
-        "url": "https://github.com/Shopify/extensions-templates",
-        "type": "flow_template",
-        "extensionPoints": [],
-        "supportedFlavors": [
-          {
-            "name": "Config only",
-            "value": "config-only",
-            "path": "flow-template"
-          }
-        ]
+        "name": "Config only",
+        "value": "config-only",
+        "path": "flow-template"
       }
     ]
   },
@@ -388,33 +340,29 @@
     "group": "Admin",
     "sortPriority": null,
     "supportLinks": [],
-    "types": [
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
       {
-        "url": "https://github.com/Shopify/extensions-templates",
-        "type": "ui_extension",
-        "extensionPoints": [],
-        "supportedFlavors": [
-          {
-            "name": "JavaScript React",
-            "value": "react",
-            "path": "customer-segment-template-extension"
-          },
-          {
-            "name": "JavaScript",
-            "value": "vanilla-js",
-            "path": "customer-segment-template-extension"
-          },
-          {
-            "name": "TypeScript React",
-            "value": "typescript-react",
-            "path": "customer-segment-template-extension"
-          },
-          {
-            "name": "TypeScript",
-            "value": "typescript",
-            "path": "customer-segment-template-extension"
-          }
-        ]
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "customer-segment-template-extension"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "customer-segment-template-extension"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "customer-segment-template-extension"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "customer-segment-template-extension"
       }
     ],
     "organizationBetaFlags": [
@@ -430,33 +378,29 @@
     "supportLinks": [
       "https://shopify.dev/docs/apps/fulfillment/order-routing-apps/location-rules"
     ],
-    "types": [
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
       {
-        "url": "https://github.com/Shopify/extensions-templates",
-        "type": "ui_extension",
-        "extensionPoints": [],
-        "supportedFlavors": [
-          {
-            "name": "JavaScript React",
-            "value": "react",
-            "path": "order-routing-location-rule"
-          },
-          {
-            "name": "JavaScript",
-            "value": "vanilla-js",
-            "path": "order-routing-location-rule"
-          },
-          {
-            "name": "TypeScript React",
-            "value": "typescript-react",
-            "path": "order-routing-location-rule"
-          },
-          {
-            "name": "TypeScript",
-            "value": "typescript",
-            "path": "order-routing-location-rule"
-          }
-        ]
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "order-routing-location-rule"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "order-routing-location-rule"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "order-routing-location-rule"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "order-routing-location-rule"
       }
     ],
     "organizationBetaFlags": [
@@ -470,18 +414,14 @@
     "group": "Admin",
     "sortPriority": null,
     "supportLinks": [],
-    "types": [
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "editor_extension_collection",
+    "extensionPoints": [],
+    "supportedFlavors": [
       {
-        "url": "https://github.com/Shopify/extensions-templates",
-        "type": "editor_extension_collection",
-        "extensionPoints": [],
-        "supportedFlavors": [
-          {
-            "name": "Config only",
-            "value": "config-only",
-            "path": "editor-extension-collection"
-          }
-        ]
+        "name": "Config only",
+        "value": "config-only",
+        "path": "editor-extension-collection"
       }
     ],
     "organizationBetaFlags": [
@@ -495,18 +435,14 @@
     "group": "Payments App Extension",
     "sortPriority": null,
     "supportLinks": [],
-    "types": [
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "payments_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
       {
-        "url": "https://github.com/Shopify/extensions-templates",
-        "type": "payments_extension",
-        "extensionPoints": [],
-        "supportedFlavors": [
-          {
-            "name": "Config only",
-            "value": "config-only",
-            "path": "payments-app-extension-offsite"
-          }
-        ]
+        "name": "Config only",
+        "value": "config-only",
+        "path": "payments-app-extension-offsite"
       }
     ],
     "organizationBetaFlags": [
@@ -520,18 +456,14 @@
     "group": "Payments App Extension",
     "sortPriority": null,
     "supportLinks": [],
-    "types": [
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "payments_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
       {
-        "url": "https://github.com/Shopify/extensions-templates",
-        "type": "payments_extension",
-        "extensionPoints": [],
-        "supportedFlavors": [
-          {
-            "name": "Config only",
-            "value": "config-only",
-            "path": "payments-app-extension-credit-card"
-          }
-        ]
+        "name": "Config only",
+        "value": "config-only",
+        "path": "payments-app-extension-credit-card"
       }
     ],
     "organizationBetaFlags": [
@@ -545,18 +477,14 @@
     "group": "Payments App Extension",
     "sortPriority": null,
     "supportLinks": [],
-    "types": [
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "payments_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
       {
-        "url": "https://github.com/Shopify/extensions-templates",
-        "type": "payments_extension",
-        "extensionPoints": [],
-        "supportedFlavors": [
-          {
-            "name": "Config only",
-            "value": "config-only",
-            "path": "payments-app-extension-custom-credit-card"
-          }
-        ]
+        "name": "Config only",
+        "value": "config-only",
+        "path": "payments-app-extension-custom-credit-card"
       }
     ],
     "organizationBetaFlags": [
@@ -570,18 +498,14 @@
     "group": "Payments App Extension",
     "sortPriority": null,
     "supportLinks": [],
-    "types": [
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "payments_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
       {
-        "url": "https://github.com/Shopify/extensions-templates",
-        "type": "payments_extension",
-        "extensionPoints": [],
-        "supportedFlavors": [
-          {
-            "name": "Config only",
-            "value": "config-only",
-            "path": "payments-app-extension-custom-onsite"
-          }
-        ]
+        "name": "Config only",
+        "value": "config-only",
+        "path": "payments-app-extension-custom-onsite"
       }
     ],
     "organizationBetaFlags": [
@@ -595,18 +519,14 @@
     "group": "Payments App Extension",
     "sortPriority": null,
     "supportLinks": [],
-    "types": [
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "payments_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
       {
-        "url": "https://github.com/Shopify/extensions-templates",
-        "type": "payments_extension",
-        "extensionPoints": [],
-        "supportedFlavors": [
-          {
-            "name": "Config only",
-            "value": "config-only",
-            "path": "payments-app-extension-redeemable"
-          }
-        ]
+        "name": "Config only",
+        "value": "config-only",
+        "path": "payments-app-extension-redeemable"
       }
     ],
     "organizationBetaFlags": [

--- a/templates.json
+++ b/templates.json
@@ -1,5 +1,291 @@
 [
   {
+    "identifier": "admin_action",
+    "name": "Admin action",
+    "defaultName": "admin-action",
+    "group": "Admin",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "admin-action"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "admin-action"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "admin-action"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "admin-action"
+      }
+    ]
+  },
+  {
+    "identifier": "admin_block",
+    "name": "Admin block",
+    "defaultName": "admin-block",
+    "group": "Admin",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "admin-block"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "admin-block"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "admin-block"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "admin-block"
+      }
+    ]
+  },
+  {
+    "identifier": "product_configuration",
+    "name": "Product configuration",
+    "defaultName": "product-configuration",
+    "group": "Admin",
+    "supportLinks": [
+      "https://shopify.dev/docs/apps/selling-strategies/bundles/product-config"
+    ],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "product-configuration-extension"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "product-configuration-extension"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "product-configuration-extension"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "product-configuration-extension"
+      }
+    ]
+  },
+  {
+    "identifier": "subscription_ui",
+    "name": "Subscription UI",
+    "defaultName": "subscription-ui",
+    "group": "Admin",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/cli",
+    "type": "product_subscription",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "templates/ui-extensions/projects/product_subscription"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "templates/ui-extensions/projects/product_subscription"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "templates/ui-extensions/projects/product_subscription"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "templates/ui-extensions/projects/product_subscription"
+      }
+    ]
+  },
+  {
+    "identifier": "tax_calculation",
+    "name": "Tax calculation",
+    "defaultName": "tax-calculation",
+    "group": "Admin",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "tax_calculation",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "tax-calculation"
+      }
+    ]
+  },
+  {
+    "identifier": "validation_settings_ui",
+    "name": "Validation Settings - UI Extension",
+    "defaultName": "validation-settings-ui",
+    "group": "Admin",
+    "supportLinks": [
+      "https://shopify.dev/docs/apps/checkout/validation/server-side"
+    ],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "validation-settings"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "validation-settings"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "validation-settings"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "validation-settings"
+      }
+    ]
+  },
+  {
+    "identifier": "web_pixel",
+    "name": "Web pixel",
+    "defaultName": "web-pixel",
+    "group": "Analytics",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/cli",
+    "type": "web_pixel_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "templates/ui-extensions/projects/web_pixel_extension"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "templates/ui-extensions/projects/web_pixel_extension"
+      }
+    ]
+  },
+  {
+    "identifier": "flow_action",
+    "name": "Flow action",
+    "defaultName": "Flow action",
+    "group": "Automations",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "flow_action",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "flow-action"
+      }
+    ]
+  },
+  {
+    "identifier": "flow_template",
+    "name": "Flow template",
+    "defaultName": "Flow template",
+    "group": "Automations",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "flow_template",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "flow-template"
+      }
+    ]
+  },
+  {
+    "identifier": "flow_trigger",
+    "name": "Flow trigger",
+    "defaultName": "Flow trigger",
+    "group": "Automations",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "flow_trigger",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "flow-trigger"
+      }
+    ]
+  },
+  {
+    "identifier": "customer_account_ui",
+    "name": "Customer account UI (preview for dev stores only)",
+    "defaultName": "customer-account-ui",
+    "group": "Customer account",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "customer-account-extension"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "customer-account-extension"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "customer-account-extension"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "customer-account-extension"
+      }
+    ]
+  },
+  {
     "identifier": "checkout_ui",
     "name": "Checkout UI",
     "defaultName": "checkout-ui",
@@ -68,70 +354,6 @@
     ]
   },
   {
-    "identifier": "admin_action",
-    "name": "Admin action",
-    "defaultName": "admin-action",
-    "group": "Admin",
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "ui_extension",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "JavaScript React",
-        "value": "react",
-        "path": "admin-action"
-      },
-      {
-        "name": "JavaScript",
-        "value": "vanilla-js",
-        "path": "admin-action"
-      },
-      {
-        "name": "TypeScript React",
-        "value": "typescript-react",
-        "path": "admin-action"
-      },
-      {
-        "name": "TypeScript",
-        "value": "typescript",
-        "path": "admin-action"
-      }
-    ]
-  },
-  {
-    "identifier": "admin_block",
-    "name": "Admin block",
-    "defaultName": "admin-block",
-    "group": "Admin",
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "ui_extension",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "JavaScript React",
-        "value": "react",
-        "path": "admin-block"
-      },
-      {
-        "name": "JavaScript",
-        "value": "vanilla-js",
-        "path": "admin-block"
-      },
-      {
-        "name": "TypeScript React",
-        "value": "typescript-react",
-        "path": "admin-block"
-      },
-      {
-        "name": "TypeScript",
-        "value": "typescript",
-        "path": "admin-block"
-      }
-    ]
-  },
-  {
     "identifier": "cart_checkout_validation",
     "name": "Cart and checkout validation - Function",
     "defaultName": "cart-checkout-validation",
@@ -195,133 +417,6 @@
         "value": "wasm",
         "path": "checkout/wasm/cart-transform/default"
       }
-    ]
-  },
-  {
-    "identifier": "credit_card_payments",
-    "name": "Credit Card",
-    "defaultName": "Credit Card",
-    "group": "Payments App Extension",
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "payments_extension",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "Config only",
-        "value": "config-only",
-        "path": "payments-app-extension-credit-card"
-      }
-    ],
-    "organizationBetaFlags": [
-      "cli_payment_extensions"
-    ]
-  },
-  {
-    "identifier": "custom_credit_card_payments",
-    "name": "Custom Credit Card",
-    "defaultName": "Custom Credit Card",
-    "group": "Payments App Extension",
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "payments_extension",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "Config only",
-        "value": "config-only",
-        "path": "payments-app-extension-custom-credit-card"
-      }
-    ],
-    "organizationBetaFlags": [
-      "cli_payment_extensions"
-    ]
-  },
-  {
-    "identifier": "custom_onsite_payments",
-    "name": "Custom Onsite",
-    "defaultName": "Custom Onsite",
-    "group": "Payments App Extension",
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "payments_extension",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "Config only",
-        "value": "config-only",
-        "path": "payments-app-extension-custom-onsite"
-      }
-    ],
-    "organizationBetaFlags": [
-      "cli_payment_extensions"
-    ]
-  },
-  {
-    "identifier": "customer_account_ui",
-    "name": "Customer account UI (preview for dev stores only)",
-    "defaultName": "customer-account-ui",
-    "group": "Customer account",
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "ui_extension",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "JavaScript React",
-        "value": "react",
-        "path": "customer-account-extension"
-      },
-      {
-        "name": "JavaScript",
-        "value": "vanilla-js",
-        "path": "customer-account-extension"
-      },
-      {
-        "name": "TypeScript React",
-        "value": "typescript-react",
-        "path": "customer-account-extension"
-      },
-      {
-        "name": "TypeScript",
-        "value": "typescript",
-        "path": "customer-account-extension"
-      }
-    ]
-  },
-  {
-    "identifier": "customer_segment_template",
-    "name": "Customer segment template",
-    "defaultName": "customer-segment-template",
-    "group": "Admin",
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "ui_extension",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "JavaScript React",
-        "value": "react",
-        "path": "customer-segment-template-extension"
-      },
-      {
-        "name": "JavaScript",
-        "value": "vanilla-js",
-        "path": "customer-segment-template-extension"
-      },
-      {
-        "name": "TypeScript React",
-        "value": "typescript-react",
-        "path": "customer-segment-template-extension"
-      },
-      {
-        "name": "TypeScript",
-        "value": "typescript",
-        "path": "customer-segment-template-extension"
-      }
-    ],
-    "organizationBetaFlags": [
-      "enable_cli_customer_segment_template_extension"
     ]
   },
   {
@@ -493,77 +588,6 @@
     ]
   },
   {
-    "identifier": "editor_extension_collection",
-    "name": "Editor extension collection",
-    "defaultName": "Editor extension collection",
-    "group": "Admin",
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "editor_extension_collection",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "Config only",
-        "value": "config-only",
-        "path": "editor-extension-collection"
-      }
-    ],
-    "organizationBetaFlags": [
-      "editor_extension_collection"
-    ]
-  },
-  {
-    "identifier": "flow_action",
-    "name": "Flow action",
-    "defaultName": "Flow action",
-    "group": "Automations",
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "flow_action",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "Config only",
-        "value": "config-only",
-        "path": "flow-action"
-      }
-    ]
-  },
-  {
-    "identifier": "flow_template",
-    "name": "Flow template",
-    "defaultName": "Flow template",
-    "group": "Automations",
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "flow_template",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "Config only",
-        "value": "config-only",
-        "path": "flow-template"
-      }
-    ]
-  },
-  {
-    "identifier": "flow_trigger",
-    "name": "Flow trigger",
-    "defaultName": "Flow trigger",
-    "group": "Automations",
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "flow_trigger",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "Config only",
-        "value": "config-only",
-        "path": "flow-trigger"
-      }
-    ]
-  },
-  {
     "identifier": "fulfillment_constraints",
     "name": "Fulfillment constraints - Function",
     "defaultName": "fulfillment-constraints",
@@ -628,23 +652,58 @@
     ]
   },
   {
-    "identifier": "offsite_payments",
-    "name": "Offsite",
-    "defaultName": "Offsite",
-    "group": "Payments App Extension",
+    "identifier": "customer_segment_template",
+    "name": "Customer segment template",
+    "defaultName": "customer-segment-template",
+    "group": "Admin",
     "supportLinks": [],
     "url": "https://github.com/Shopify/extensions-templates",
-    "type": "payments_extension",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "customer-segment-template-extension"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "customer-segment-template-extension"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "customer-segment-template-extension"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "customer-segment-template-extension"
+      }
+    ],
+    "organizationBetaFlags": [
+      "enable_cli_customer_segment_template_extension"
+    ]
+  },
+  {
+    "identifier": "editor_extension_collection",
+    "name": "Editor extension collection",
+    "defaultName": "Editor extension collection",
+    "group": "Admin",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "editor_extension_collection",
     "extensionPoints": [],
     "supportedFlavors": [
       {
         "name": "Config only",
         "value": "config-only",
-        "path": "payments-app-extension-offsite"
+        "path": "editor-extension-collection"
       }
     ],
     "organizationBetaFlags": [
-      "cli_payment_extensions"
+      "editor_extension_collection"
     ]
   },
   {
@@ -757,67 +816,120 @@
     ]
   },
   {
-    "identifier": "payment_customization",
-    "name": "Payment customization - Function",
-    "defaultName": "payment-customization",
-    "group": "Discounts and checkout",
+    "identifier": "theme_app_extension",
+    "name": "Theme app extension",
+    "defaultName": "theme-extension",
+    "group": "Online store",
     "supportLinks": [],
-    "url": "https://github.com/Shopify/function-examples",
-    "type": "function",
+    "url": "https://github.com/Shopify/cli",
+    "type": "theme",
     "extensionPoints": [],
     "supportedFlavors": [
       {
-        "name": "JavaScript",
-        "value": "vanilla-js",
-        "path": "checkout/javascript/payment-customization/default"
-      },
-      {
-        "name": "TypeScript",
-        "value": "typescript",
-        "path": "checkout/javascript/payment-customization/default"
-      },
-      {
-        "name": "Rust",
-        "value": "rust",
-        "path": "checkout/rust/payment-customization/default"
-      },
-      {
-        "name": "Wasm",
-        "value": "wasm",
-        "path": "checkout/wasm/payment-customization/default"
+        "name": "Liquid",
+        "value": "liquid",
+        "path": "templates/theme-extension"
       }
     ]
   },
   {
-    "identifier": "pickup_point_delivery_option_generator",
-    "name": "Pickup point delivery option generators — Function",
-    "defaultName": "pickup-point-delivery-option-generators",
-    "group": "Discounts and checkout",
+    "identifier": "credit_card_payments",
+    "name": "Credit Card",
+    "defaultName": "Credit Card",
+    "group": "Payments App Extension",
     "supportLinks": [],
-    "url": "https://github.com/Shopify/function-examples",
-    "type": "function",
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "payments_extension",
     "extensionPoints": [],
     "supportedFlavors": [
       {
-        "name": "JavaScript",
-        "value": "vanilla-js",
-        "path": "order-routing/javascript/pickup-point-delivery-option-generators/default"
-      },
-      {
-        "name": "TypeScript",
-        "value": "typescript",
-        "path": "order-routing/typescript/pickup-point-delivery-option-generators/default"
-      },
-      {
-        "name": "Rust",
-        "value": "rust",
-        "path": "order-routing/rust/pickup-point-delivery-option-generators/default"
-      },
-      {
-        "name": "Wasm",
-        "value": "wasm",
-        "path": "order-routing/wasm/pickup-point-delivery-option-generators/default"
+        "name": "Config only",
+        "value": "config-only",
+        "path": "payments-app-extension-credit-card"
       }
+    ],
+    "organizationBetaFlags": [
+      "cli_payment_extensions"
+    ]
+  },
+  {
+    "identifier": "custom_credit_card_payments",
+    "name": "Custom Credit Card",
+    "defaultName": "Custom Credit Card",
+    "group": "Payments App Extension",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "payments_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "payments-app-extension-custom-credit-card"
+      }
+    ],
+    "organizationBetaFlags": [
+      "cli_payment_extensions"
+    ]
+  },
+  {
+    "identifier": "custom_onsite_payments",
+    "name": "Custom Onsite",
+    "defaultName": "Custom Onsite",
+    "group": "Payments App Extension",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "payments_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "payments-app-extension-custom-onsite"
+      }
+    ],
+    "organizationBetaFlags": [
+      "cli_payment_extensions"
+    ]
+  },
+  {
+    "identifier": "offsite_payments",
+    "name": "Offsite",
+    "defaultName": "Offsite",
+    "group": "Payments App Extension",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "payments_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "payments-app-extension-offsite"
+      }
+    ],
+    "organizationBetaFlags": [
+      "cli_payment_extensions"
+    ]
+  },
+  {
+    "identifier": "redeemable_payments",
+    "name": "Redeemable",
+    "defaultName": "Redeemable",
+    "group": "Payments App Extension",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "payments_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "payments-app-extension-redeemable"
+      }
+    ],
+    "organizationBetaFlags": [
+      "cli_payment_extensions"
     ]
   },
   {
@@ -849,111 +961,6 @@
         "name": "TypeScript",
         "value": "typescript",
         "path": "pos-ui-extension"
-      }
-    ]
-  },
-  {
-    "identifier": "product_configuration",
-    "name": "Product configuration",
-    "defaultName": "product-configuration",
-    "group": "Admin",
-    "supportLinks": [
-      "https://shopify.dev/docs/apps/selling-strategies/bundles/product-config"
-    ],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "ui_extension",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "JavaScript React",
-        "value": "react",
-        "path": "product-configuration-extension"
-      },
-      {
-        "name": "JavaScript",
-        "value": "vanilla-js",
-        "path": "product-configuration-extension"
-      },
-      {
-        "name": "TypeScript React",
-        "value": "typescript-react",
-        "path": "product-configuration-extension"
-      },
-      {
-        "name": "TypeScript",
-        "value": "typescript",
-        "path": "product-configuration-extension"
-      }
-    ]
-  },
-  {
-    "identifier": "redeemable_payments",
-    "name": "Redeemable",
-    "defaultName": "Redeemable",
-    "group": "Payments App Extension",
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "payments_extension",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "Config only",
-        "value": "config-only",
-        "path": "payments-app-extension-redeemable"
-      }
-    ],
-    "organizationBetaFlags": [
-      "cli_payment_extensions"
-    ]
-  },
-  {
-    "identifier": "tax_calculation",
-    "name": "Tax calculation",
-    "defaultName": "tax-calculation",
-    "group": "Admin",
-    "supportLinks": [],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "tax_calculation",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "Config only",
-        "value": "config-only",
-        "path": "tax-calculation"
-      }
-    ]
-  },
-  {
-    "identifier": "validation_settings_ui",
-    "name": "Validation Settings - UI Extension",
-    "defaultName": "validation-settings-ui",
-    "group": "Admin",
-    "supportLinks": [
-      "https://shopify.dev/docs/apps/checkout/validation/server-side"
-    ],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "ui_extension",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "JavaScript React",
-        "value": "react",
-        "path": "validation-settings"
-      },
-      {
-        "name": "JavaScript",
-        "value": "vanilla-js",
-        "path": "validation-settings"
-      },
-      {
-        "name": "TypeScript React",
-        "value": "typescript-react",
-        "path": "validation-settings"
-      },
-      {
-        "name": "TypeScript",
-        "value": "typescript",
-        "path": "validation-settings"
       }
     ]
   }


### PR DESCRIPTION
### Background

For the App Management API, we are moving to a system with template specifications in a static JSON file + client-side enforcement of feature gating. More details [here](https://github.com/Shopify/cli/pull/3923)

### Solution

Created a static JSON file with the templates. This will currently live side-by-side with Partners but will eventually replace it.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
