### PR TITLE
Clarify the single target limit for Admin UI extensions

### DIFF
--- a/admin-action/shopify.extension.toml.liquid
+++ b/admin-action/shopify.extension.toml.liquid
@@ -6,6 +6,8 @@ name = "t:name"
 handle = "{{ handle }}"
 type = "ui_extension"
 {% if uid %}uid = "{{ uid }}"{% endif %}
+
+# Only 1 target can be specified for each Admin action extension
 [[extensions.targeting]]
 module = "./src/ActionExtension.{{ srcFileExtension }}"
 # The target used here must match the target used in the module file (./src/ActionExtension.{{ srcFileExtension }})

--- a/admin-block/shopify.extension.toml.liquid
+++ b/admin-block/shopify.extension.toml.liquid
@@ -6,6 +6,8 @@ name = "t:name"
 handle = "{{ handle }}"
 type = "ui_extension"
 {% if uid %}uid = "{{ uid }}"{% endif %}
+
+# Only 1 target can be specified for each Admin block extension
 [[extensions.targeting]]
 module = "./src/BlockExtension.{{ srcFileExtension }}"
 # The target used here must match the target used in the module file (./src/BlockExtension.{{ srcFileExtension }})

--- a/admin-print-action/shopify.extension.toml.liquid
+++ b/admin-print-action/shopify.extension.toml.liquid
@@ -1,16 +1,16 @@
 api_version = "2024-04"
 
 [[extensions]]
-# Change the merchant-facing name of the extension in locales/en.default.json
-name = "t:name"
+name = "{{ handle }}"
 handle = "{{ handle }}"
 type = "ui_extension"
 {% if uid %}uid = "{{ uid }}"{% endif %}
+
+# Only 1 target can be specified for each Admin print action extension
 [[extensions.targeting]]
 module = "./src/PrintActionExtension.{{ srcFileExtension }}"
 # The target used here must match the target used in the module file (./src/PrintActionExtension.{{ srcFileExtension }})
 target = "admin.order-details.print-action.render"
-
 
 # Valid extension targets:
 


### PR DESCRIPTION
Use handle as default name for the Print Action extension

### Background

[(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)](https://github.com/Shopify/app-ui/issues/1272)

### Solution

Update TOML files to be more clear that only a single target is supported per Admin UI extension. Also updated the template for Print extension to use the handle as the default name.