### PR TITLE
Pin unstable version for print extension

### DIFF
--- a/admin-print-action/package.json.liquid
+++ b/admin-print-action/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "unstable",
-    "@shopify/ui-extensions-react": "unstable"
+    "@shopify/ui-extensions": "0.0.0-unstable-20240614182926",
+    "@shopify/ui-extensions-react": "0.0.0-unstable-20240614182926"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "unstable"
+    "@shopify/ui-extensions": "0.0.0-unstable-20240614182926"
   }
 }
 {%- endif -%}


### PR DESCRIPTION
### Background

Using the `unstable` version of `ui-extensions` in the print extension breaks when a previous version is also installed (for another extension). 

### Solution

Pin specific unstable version of `ui-extensions`.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
