### PR TITLE
Remove name translateions and add comment in toml

### DIFF
--- a/admin-print-action/locales/en.default.json.liquid
+++ b/admin-print-action/locales/en.default.json.liquid
@@ -1,5 +1,4 @@
 {
-  "name": "{{ name }}",
   "warningTitle": "Title",
   "warningBody": "Show warning banner when form is in an invalid state.",
   "documents": "Documents",

--- a/admin-print-action/locales/fr.json.liquid
+++ b/admin-print-action/locales/fr.json.liquid
@@ -1,5 +1,4 @@
 {
-  "name": "{{ name }}",
   "warningTitle": "Titre",
   "warningBody": "Afficher une bannière d'avertissement lorsque le formulaire est dans un état invalide.",
   "documents": "Documents",

--- a/admin-print-action/shopify.extension.toml.liquid
+++ b/admin-print-action/shopify.extension.toml.liquid
@@ -1,12 +1,12 @@
 api_version = "2024-04"
 
 [[extensions]]
-name = "{{ handle }}"
+name = ""
 handle = "{{ handle }}"
 type = "ui_extension"
 {% if uid %}uid = "{{ uid }}"{% endif %}
 
-# Only 1 target can be specified for each Admin print action extension
+# Only 1 target can be specified for each admin print action extension
 [[extensions.targeting]]
 module = "./src/PrintActionExtension.{{ srcFileExtension }}"
 # The target used here must match the target used in the module file (./src/PrintActionExtension.{{ srcFileExtension }})


### PR DESCRIPTION
### Background

We do not use `name` in the print extension but we can't remove it from the `toml` because we use it to validate ui-extensions.  

### Solution

This PR adds a comment in the `toml` and removes the translations. 

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
