### PR TITLE
Update collection name for editor extension collection

### DIFF
--- a/editor-extension-collection/locales/en.default.json
+++ b/editor-extension-collection/locales/en.default.json
@@ -1,4 +1,4 @@
 {
-  "collection_one_name": "My awesome collection one name!",
-  "collection_two_name": "My awesome collection two name!"
+  "collection_one_name": "Collection one!",
+  "collection_two_name": "Collection two!"
 }

--- a/editor-extension-collection/locales/fr.json
+++ b/editor-extension-collection/locales/fr.json
@@ -1,4 +1,4 @@
 {
-  "collection_one_name": "Ma superbe collection un nom!",
-  "collection_two_name": "Ma superbe collection deux noms!"
+  "collection_one_name": "Première collection!",
+  "collection_two_name": "Collection deux!"
 }


### PR DESCRIPTION
### Background

Updating the collection names of the default editor extension collection to be shorter

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
