### PR TITLE
Update checkout UI extension template (2024-07)

### DIFF
--- a/checkout-extension/README.md.liquid
+++ b/checkout-extension/README.md.liquid
@@ -19,18 +19,18 @@ By default, your extension is configured to target the `purchase.checkout.block.
 
 To build your extension, you will need to use APIs provided by Shopify that let you render content, and to read and write data in the checkout. The following resources will help you get started with checkout extensions:
 
-- [Available components and their properties](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/components)
-- APIs for [reading](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/apis/standardapi) and [writing checkout data](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/apis/checkoutapi)
-- [APIs by extension target](https://shopify.dev/docs/api/checkout-ui-extensions/unstable/apis/extensiontargets)
+- [APIs by extension target](https://shopify.dev/docs/api/checkout-ui-extensions/targets)
+- [All APIs for reading and writing checkout data](https://shopify.dev/docs/api/checkout-ui-extensions/apis)
+- [Available components and their properties](https://shopify.dev/docs/api/checkout-ui-extensions/components)
 
 ## Useful Links
 
 - [Checkout app documentation](https://shopify.dev/apps/checkout)
 - [Checkout UI extension documentation](https://shopify.dev/api/checkout-extensions)
   - [Configuration](https://shopify.dev/docs/api/checkout-ui-extensions/configuration)
+  - [Extension Targets](https://shopify.dev/docs/api/checkout-ui-extensions/targets)
   - [API Reference](https://shopify.dev/docs/api/checkout-ui-extensions/apis)
   - [UI Components](https://shopify.dev/docs/api/checkout-ui-extensions/components)
-  - [Available React Hooks](https://shopify.dev/docs/api/checkout-ui-extensions/react-hooks)
 - [Checkout UI extension tutorials](https://shopify.dev/docs/apps/checkout)
   - [Enable extended delivery instructions](https://shopify.dev/apps/checkout/delivery-instructions)
   - [Creating a custom banner](https://shopify.dev/apps/checkout/custom-banners)

--- a/checkout-extension/locales/en.default.json
+++ b/checkout-extension/locales/en.default.json
@@ -1,3 +1,5 @@
 {
-  "welcome": "Welcome to the {{target}} extension!"
+  "welcome": "Welcome to the {{target}} extension!",
+  "iWouldLikeAFreeGiftWithMyOrder": "I would like to receive a free gift with my order",
+  "attributeChangesAreNotSupported": "Attribute changes are not supported in this checkout"
 }

--- a/checkout-extension/locales/fr.json
+++ b/checkout-extension/locales/fr.json
@@ -1,3 +1,5 @@
 {
-  "welcome": "Bienvenue dans l'extension {{target}}!"
+  "welcome": "Bienvenue dans l'extension {{target}}!",
+  "iWouldLikeAFreeGiftWithMyOrder": "Je souhaite recevoir un cadeau gratuit avec ma commande",
+  "attributeChangesAreNotSupported": "Les modifications d'attribut ne sont pas prises en charge dans cette commande"
 }

--- a/checkout-extension/package.json.liquid
+++ b/checkout-extension/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2024.4.x",
-    "@shopify/ui-extensions-react": "2024.4.x"
+    "@shopify/ui-extensions": "2024.7.x",
+    "@shopify/ui-extensions-react": "2024.7.x"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2024.4.x"
+    "@shopify/ui-extensions": "2024.7.x"
   }
 }
 {%- endif -%}

--- a/checkout-extension/shopify.extension.toml.liquid
+++ b/checkout-extension/shopify.extension.toml.liquid
@@ -3,7 +3,7 @@
 
 # The version of APIs your extension will receive. Learn more:
 # https://shopify.dev/docs/api/usage/versioning
-api_version = "2024-04"
+api_version = "2024-07"
 
 [[extensions]]
 name = "{{ name }}"

--- a/checkout-extension/src/Checkout.liquid
+++ b/checkout-extension/src/Checkout.liquid
@@ -1,39 +1,126 @@
 {%- if flavor contains "react" -%}
 import {
-  Banner,
-  useApi,
-  useTranslate,
   reactExtension,
-} from '@shopify/ui-extensions-react/checkout';
+  Banner,
+  BlockStack,
+  Checkbox,
+  Text,
+  useApi,
+  useApplyAttributeChange,
+  useInstructions,
+  useTranslate,
+} from "@shopify/ui-extensions-react/checkout";
 
-export default reactExtension(
-  'purchase.checkout.block.render',
-  () => <Extension />,
-);
+// 1. Choose an extension target
+export default reactExtension("purchase.checkout.block.render", () => (
+  <Extension />
+));
 
 function Extension() {
   const translate = useTranslate();
   const { extension } = useApi();
+  const instructions = useInstructions();
+  const applyAttributeChange = useApplyAttributeChange();
 
+
+  // 2. Check instructions for feature availability, see https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions for details
+  if (!instructions.attributes.canUpdateAttributes) {
+    // For checkouts such as draft order invoices, cart attributes may not be allowed
+    // Consider rendering a fallback UI or nothing at all, if the feature is unavailable
+    return (
+      <Banner title="{{ name }}" status="warning">
+        {translate("attributeChangesAreNotSupported")}
+      </Banner>
+    );
+  }
+
+  // 3. Render a UI
   return (
-    <Banner title="{{ name }}">
-      {translate('welcome', {target: extension.target})}
-    </Banner>
+    <BlockStack border={"dotted"} padding={"tight"}>
+      <Banner title="{{ name }}">
+        {translate("welcome", {
+          target: <Text emphasis="italic">{extension.target}</Text>,
+        })}
+      </Banner>
+      <Checkbox onChange={onCheckboxChange}>
+        {translate("iWouldLikeAFreeGiftWithMyOrder")}
+      </Checkbox>
+    </BlockStack>
   );
+
+  async function onCheckboxChange(isChecked) {
+    // 4. Call the API to modify checkout
+    const result = await applyAttributeChange({
+      key: "requestedFreeGift",
+      type: "updateAttribute",
+      value: isChecked ? "yes" : "no",
+    });
+    console.log("applyAttributeChange result", result);
+  }
 }
 
 {%- else -%}
-import { extension, Banner } from "@shopify/ui-extensions/checkout";
+import {
+  extension,
+  Banner,
+  BlockStack,
+  Checkbox,
+  Text,
+} from "@shopify/ui-extensions/checkout";
 
+// 1. Choose an extension target
 export default extension("purchase.checkout.block.render", (root, api) => {
-  const { extension, i18n } = api;
+  // 2. Check instructions for feature availability, see https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions for details
+  api.instructions.subscribe((instructions) => {
+    if (!instructions.attributes.canUpdateAttributes) {
+      // For checkouts such as draft order invoices, cart attributes may not be allowed
+      // Consider rendering a fallback UI or nothing at all, if the feature is unavailable
+      root.replaceChildren(
+        root.createComponent(
+          Banner,
+          { title: "{{ name }}", status: "warning" },
+          api.i18n.translate("attributeChangesAreNotSupported")
+        )
+      );
+    } else {
+      // 3. Render a UI
+      root.replaceChildren(
+        root.createComponent(
+          BlockStack,
+          { border: "dotted", padding: "tight" },
+          [
+            root.createComponent(
+              Banner,
+              { title: "{{ name }}" },
+              api.i18n.translate("welcome", {
+                target: root.createComponent(
+                  Text,
+                  { emphasis: "italic" },
+                  api.extension.target
+                ),
+              })
+            ),
+            root.createComponent(
+              Checkbox,
+              {
+                onChange: onCheckboxChange,
+              },
+              api.i18n.translate("iWouldLikeAFreeGiftWithMyOrder")
+            ),
+          ]
+        )
+      );
+    }
 
-  root.appendChild(
-    root.createComponent(
-      Banner,
-      { title: "{{ name }}" },
-      i18n.translate('welcome', {target: extension.target})
-    )
-  );
+    async function onCheckboxChange(isChecked) {
+      // 4. Call the API to modify checkout
+      const result = await api.applyAttributeChange({
+        key: "requestedFreeGift",
+        type: "updateAttribute",
+        value: isChecked ? "yes" : "no",
+      });
+      console.log("applyAttributeChange result", result);
+    }
+  });
 });
 {%- endif -%}


### PR DESCRIPTION
### Background

Part of https://github.com/Shopify/checkout-web/issues/35555

Now that [2024-07 has been released](https://shopify.dev/docs/api/checkout-ui-extensions/2024-07/instructions-update). It is important that 3p devs check for [cart instructions](https://shopify.dev/docs/api/checkout-ui-extensions/2024-07/apis/cart-instructions) before using certain APIs. Failure to do so could mean they are rendering UI extensions in certain contexts where they won't work as expected.

### Solution

This updates the template used to generate the code for checkout UI extensions. Instead of simply rendering a banner as it did before, this will now render that same banner in addition to a "checkbox" to request a free gift (saved using checkout attributes). This uses **cart instructions** to check whether attributes are available. If they are not, it renders a warning banner for demonstration purposes.

**Before:**
![Screenshot 2024-07-08 at 12 51 52 PM](https://github.com/Shopify/extensions-templates/assets/12719665/ef0a67d4-da94-4587-932c-da6a1a738e85)


**After (`canUpdateCartAttributes===true`):**
![Screenshot 2024-07-08 at 12 48 50 PM](https://github.com/Shopify/extensions-templates/assets/12719665/467e9ded-87fc-4345-b85a-3212d3a4ccb8)

**After (`canUpdateCartAttributes===false`):**
![Screenshot 2024-07-08 at 12 49 23 PM](https://github.com/Shopify/extensions-templates/assets/12719665/c53fd558-5f05-4762-86df-aec727565623)


### Checklist

- [X] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
