### PR TITLE
Fix word order on comment in print action extension template

### DIFF
--- a/admin-print-action/src/PrintActionExtension.liquid
+++ b/admin-print-action/src/PrintActionExtension.liquid
@@ -21,7 +21,7 @@ function App() {
   // The useApi hook provides access to several useful APIs like i18n and data.
   const {i18n, data} = useApi(TARGET);
   const [src, setSrc] = useState(null);
-  // It's best practice to load a printable src when launching first the extension.
+  // It's best practice to load a printable src when first launching the extension.
   const [document1, setDocument1] = useState(true);
   const [document2, setDocument2] = useState(false);
   // data has information about the resource to be printed.


### PR DESCRIPTION
### Background

Awkward wording in comment.

### Solution

Fix word order in comment in print extension template.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
