### PR TITLE
Add buyer label translation examples to payment extensions

### DIFF
--- a/payments-app-extension-custom-credit-card/shopify.extension.toml.liquid
+++ b/payments-app-extension-custom-credit-card/shopify.extension.toml.liquid
@@ -24,6 +24,15 @@ test_mode_available = true
 encryption_certificate_fingerprint = ""
 multiple_capture = false
 
+# buyer_label = ""
+# [[extensions.buyer_label_translations]]
+# label = "translation"
+# locale = "fr"
+
+# [[extensions.buyer_label_translations]]
+# label = "translation"
+# locale = "da"
+
 # UI Extension
 # ui_extension_handle = "ui-ext-handle"
 

--- a/payments-app-extension-custom-onsite/shopify.extension.toml.liquid
+++ b/payments-app-extension-custom-onsite/shopify.extension.toml.liquid
@@ -22,6 +22,15 @@ supports_installments = false
 supports_deferred_payments = false
 test_mode_available = true
 
+# buyer_label = ""
+# [[extensions.buyer_label_translations]]
+# label = "translation"
+# locale = "fr"
+
+# [[extensions.buyer_label_translations]]
+# label = "translation"
+# locale = "da"
+
 # UI Extension
 # ui_extension_handle = "ui-ext-handle"
 

--- a/payments-app-extension-offsite/shopify.extension.toml.liquid
+++ b/payments-app-extension-offsite/shopify.extension.toml.liquid
@@ -22,5 +22,14 @@ supports_installments = false
 supports_deferred_payments = false
 test_mode_available = true
 
+# buyer_label = ""
+# [[extensions.buyer_label_translations]]
+# label = "translation"
+# locale = "fr"
+
+# [[extensions.buyer_label_translations]]
+# label = "translation"
+# locale = "da"
+
 [[extensions.targeting]]
 target = "payments.offsite.render"

--- a/payments-app-extension-redeemable/shopify.extension.toml.liquid
+++ b/payments-app-extension-redeemable/shopify.extension.toml.liquid
@@ -19,6 +19,15 @@ test_mode_available = true
 merchant_label = "Redeemable Payments App Extension"
 balance_url = "https://api.paymentprovider.com/balance"
 
+# buyer_label = ""
+# [[extensions.buyer_label_translations]]
+# label = "translation"
+# locale = "fr"
+
+# [[extensions.buyer_label_translations]]
+# label = "translation"
+# locale = "da"
+
 # UI Extension
 # ui_extension_handle = "ui-ext-handle"
 


### PR DESCRIPTION
### Background

Adds `buyer_label` and `buyer_label_translations` example values into the example templates for all payment extension types except for credit card. 

Slack thread: https://shopify.slack.com/archives/C066SQUMP16/p1720545043454769

### Solution

As they're optional, commented the examples out

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
