### PR TITLE
Add marketing activity extension template

### DIFF
--- a/marketing-activity/shopify.extension.toml.liquid
+++ b/marketing-activity/shopify.extension.toml.liquid
@@ -1,0 +1,27 @@
+[[extensions]]
+type = "marketing_activity"
+name = "{{ name }}"
+handle = "{{ handle }}"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+title = "Your title"
+description = "Your description"
+api_path = "/replace_me"
+tactic = ""
+marketing_channel = ""
+referring_domain = ""
+is_automation = false
+
+[[extensions.preview_data.types]]
+label = "Desktop"
+value = "desktop"
+
+[[extensions.preview_data.types]]
+label = "Mobile"
+value = "mobile"
+
+[[extensions.fields]]
+name = "example_field"
+heading = "Example Title"
+body = "Example body"
+ui_type = "paragraph"
+

--- a/templates.json
+++ b/templates.json
@@ -64,6 +64,23 @@
     ]
   },
   {
+    "identifier": "marketing_activity",
+    "name": "Marketing Activity",
+    "defaultName": "Marketing Activity",
+    "group": "Admin",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "marketing_activity",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "marketing-activity"
+      }
+    ]
+  },
+  {
     "identifier": "product_configuration",
     "name": "Product configuration",
     "defaultName": "product-configuration",


### PR DESCRIPTION
### Background
<img width="613" alt="Screenshot 2024-08-06 at 4 48 28 PM" src="https://github.com/user-attachments/assets/35cc56e5-a415-4653-be37-e9599010a32e">

Add marketing activity extension template

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
