### PR TITLE
Update Admin UI extensions to use stable API version

### DIFF
--- a/customer-segment-template-extension/package.json.liquid
+++ b/customer-segment-template-extension/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "unstable",
-    "@shopify/ui-extensions-react": "unstable"
+    "@shopify/ui-extensions": "2024.7.x",
+    "@shopify/ui-extensions-react": "2024.7.x"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "unstable"
+    "@shopify/ui-extensions": "2024.7.x"
   }
 }
 {%- endif -%}

--- a/customer-segment-template-extension/shopify.extension.toml.liquid
+++ b/customer-segment-template-extension/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "unstable"
+api_version = "2024-07"
 
 [[extensions]]
 # Change the merchant-facing name of the extension in locales/en.default.json

--- a/validation-settings/package.json.liquid
+++ b/validation-settings/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "unstable",
-    "@shopify/ui-extensions-react": "unstable"
+    "@shopify/ui-extensions": "2024.7.x",
+    "@shopify/ui-extensions-react": "2024.7.x"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "unstable"
+    "@shopify/ui-extensions": "2024.7.x"
   }
 }
 {%- endif -%}

--- a/validation-settings/shopify.extension.toml.liquid
+++ b/validation-settings/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "unstable"
+api_version = "2024-07"
 
 [[extensions]]
 # change the merchant-facing name of the extension in locales/en.default.json


### PR DESCRIPTION
### Background

These extensions are unnecessarily using the `unstable` API version, as they have each been released in a [public API version](https://shopify.dev/docs/api/admin-extensions/2024-07/extension-targets). This PR switches them to use the `2024-07` API version instead.
