### PR TITLE
use stable version for customer-account extensions

### DIFF
--- a/customer-account-extension/package.json.liquid
+++ b/customer-account-extension/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "unstable",
-    "@shopify/ui-extensions-react": "unstable"
+    "@shopify/ui-extensions": "2024.10.x",
+    "@shopify/ui-extensions-react": "2024.10.x"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "unstable"
+    "@shopify/ui-extensions": "2024.10.x"
   }
 }
 {%- endif -%}

--- a/customer-account-extension/shopify.extension.toml.liquid
+++ b/customer-account-extension/shopify.extension.toml.liquid
@@ -3,7 +3,7 @@
 
 # The version of APIs your extension will receive. Learn more:
 # https://shopify.dev/docs/api/usage/versioning
-api_version = "unstable"
+api_version = "2024-10"
 
 [[extensions]]
 name = "{{ name }}"


### PR DESCRIPTION
### Background

We now have a stable version. Let's use it.


### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
