### PR TITLE
Updates order_routing_location_rule template api_version to 2024-10

### DIFF
--- a/order-routing-location-rule/package.json.liquid
+++ b/order-routing-location-rule/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "unstable",
-    "@shopify/ui-extensions-react": "unstable"
+    "@shopify/ui-extensions": "2024-10.x",
+    "@shopify/ui-extensions-react": "2024-10.x"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "unstable"
+    "@shopify/ui-extensions": "2024-10.x"
   }
 }
 {%- endif -%}

--- a/order-routing-location-rule/shopify.extension.toml.liquid
+++ b/order-routing-location-rule/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "unstable"
+api_version = "2024-10"
 
 [[extensions]]
 # Change the merchant-facing name of the extension in locales/en.default.json


### PR DESCRIPTION
### Background

From @vividviolet in this [slack conversation](https://shopify.slack.com/archives/C04848YTM0F/p1727804020083779):
> [...] we shouldn't have unstable in the template once the extension is made available to partners

### Solution

Update default `api_version` to the latest `2024-10` version

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
