### PR TITLE
Create Link Extension v2 template

### DIFF
--- a/admin-link/README.md.liquid
+++ b/admin-link/README.md.liquid
@@ -7,59 +7,49 @@ When configuring your Admin Link extensions, you can specify various targeting o
 Here’s an example of how to configure your Admin Link extension in the configuration file:
 
 ```toml
-api_version = "2024-10"
-
 [[extensions]]
-text = "t:name"
+name = "Link Extension"
 handle = "{{ handle }}"
-type = "ui_extension"
+type = "admin_link"
 
 [[extensions.targeting]]
-target = "admin.product-details.action.render"
+target = "admin.product.item.link"
+url = "app://product"
+text = "t:text"
 
 ### Valid Extension Targets
 
 - **Abandoned Checkout Details Page**
-  - `admin.abandoned-checkout-details.action.render`
-
-- **Catalog Detail Page**
-  - `admin.catalog-details.action.render`
+  - `admin.abandoned-checkout.item.link`
 
 - **Collection Index and Detail Pages**
-  - `admin.collection-details.action.render`
-  - `admin.collection-index.action.render`
-
-- **Company Detail Page**
-  - `admin.company-details.action.render`
+  - `admin.collection.index.link`
+  - `admin.collection.item.link`
 
 - **Customer Index and Detail Pages**
-  - `admin.customer-index.action.render`
-  - `admin.customer-index.selection-action.render`
-  - `admin.customer-details.action.render`
-  - `admin.customer-segment-details.action.render`
+  - `admin.customer.index.link`
+  - `admin.customer.item.link`
+  - `admin.customer.selection.link`
 
 - **Discount Index and Detail Pages**
-  - `admin.discount-index.action.render`
-  - `admin.discount-details.action.render`
+  - `admin.discount.index.link`
+  - `admin.discount.item.link`
 
 - **Draft Order Index and Detail Pages**
-  - `admin.draft-order-details.action.render`
-  - `admin.draft-order-index.action.render`
-  - `admin.draft-order-index.selection-action.render`
-
-- **Gift Card Detail Page**
-  - `admin.gift-card-details.action.render`
+  - `admin.draft-order.index.link`
+  - `admin.draft-order.item.link`
+  - `admin.draft-order.selection.link`
 
 - **Order Index, Detail Pages, and Order Fulfilled Card**
-  - `admin.order-index.action.render`
-  - `admin.order-index.selection-action.render`
-  - `admin.order-details.action.render`
-  - `admin.order-fulfilled-card.action.render`
+  - `admin.order.index.link`
+  - `admin.order.item.link`
+  - `admin.order.selection.link`
+  - `admin.order.fulfilled-card.link`
 
 - **Product Index and Detail Pages**
-  - `admin.product-index.action.render`
-  - `admin.product-index.selection-action.render`
-  - `admin.product-details.action.render`
+  - `admin.product.index.link`
+  - `admin.product.item.link`
+  - `admin.product.selection.link`
 
 - **Product Variant Detail Pages**
-  - `admin.product-variant-details.action.render`
+  - `admin.variant.item.link`

--- a/admin-link/locales/en.default.json.liquid
+++ b/admin-link/locales/en.default.json.liquid
@@ -1,3 +1,3 @@
 {
-  "text": "Link Extension Title",
+  "text": "Link Extension tex",
 }

--- a/admin-link/shopify.extension.toml.liquid
+++ b/admin-link/shopify.extension.toml.liquid
@@ -1,17 +1,56 @@
-api_version = "2024-10"
-
 [[extensions]]
-# Change the text of the link in locales/en.default.json
-text = "t:name"
+name = "Link Extension"
 handle = "{{ handle }}"
-type = "ui_extension"
+type = "admin_link"
 
 # Link to an external source
-# url = "https://yourappdomain.com/path"
+#   url = "https://yourappdomain.com/path"
 # OR
 # Link to your embedded app
-# url = "$app://path"
+#   url = "app://path"
+#   OR
+#   url = "/path"
 
 # Only 1 target can be specified for each Admink Link extension
 [[extensions.targeting]]
 target = "admin.product-details.action.render"
+# Change the text of the link in locales/en.default.json
+text = "t:text"
+url = "/"
+
+# Valid Extension Targets
+#
+# Abandoned Checkout Details Page
+#  - admin.abandoned-checkout.item.link
+#
+# Collection Index and Detail Pages
+#  - admin.collection.index.link
+#  - admin.collection.item.link
+#
+# Customer Index and Detail Pages
+#  - admin.customer.index.link
+#  - admin.customer.item.link
+#  - admin.customer.selection.link
+#
+# Discount Index and Detail Pages
+#  - admin.discount.index.link
+#  - admin.discount.item.link
+#
+# Draft Order Index and Detail Pages
+#  - admin.draft-order.index.link
+#  - admin.draft-order.item.link
+#  - admin.draft-order.selection.link
+#
+# Order Index, Detail Pages, and Order Fulfilled Card
+#  - admin.order.index.link
+#  - admin.order.item.link
+#  - admin.order.selection.link
+#  - admin.order.fulfilled-card.link
+#
+# Product Index and Detail Pages
+#  - admin.product.index.link
+#  - admin.product.item.link
+#  - admin.product.selection.link
+#
+# Product Variant Detail Pages
+#  - admin.variant.item.link

--- a/templates.json
+++ b/templates.json
@@ -1048,5 +1048,22 @@
         "path": "pos-ui-extension"
       }
     ]
+  },
+  {
+    "identifier": "admin_link",
+    "name": "Admin link",
+    "defaultName": "admin-link",
+    "group": "Admin",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "admin_link",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "admin-link"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
### Background

We are in the process of migrating the Link Extensions out of partners into the CLI tool. This requires us to include a template for developers to utilize on creation.

https://vault.shopify.io/gsd/projects/42594-Migrate-link-extension-creation-and-management-to-the-CLI

### Solution

The implementation requires:
```
[[extensions]]
text = "t:name" # text of the link
# url = "https://yourappdomain.com/path" || "$app://path" # url either external or app
[[extensions.targeting]]
target = "admin.product-details.action.render" # target
```

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
