### PR TITLE
Update extend -> extension

### DIFF
--- a/admin-action/src/ActionExtension.liquid
+++ b/admin-action/src/ActionExtension.liquid
@@ -79,13 +79,13 @@ function App() {
 }
 
 {%- else -%}
-import { extend, AdminAction, BlockStack, Button, Text } from "@shopify/ui-extensions/admin";
+import { extension, AdminAction, BlockStack, Button, Text } from "@shopify/ui-extensions/admin";
 
 // The target used here must match the target used in the extension's toml file (./shopify.extension.toml)
 const TARGET = 'admin.product-details.action.render';
 
 // The second argument to the render callback provides access to several useful APIs like i18n, close, and data.
-extend(TARGET, (root, { i18n, close, data }) => {
+export default extension(TARGET, (root, { i18n, close, data }) => {
   const productTitle = root.createText('');
 
   getProductInfo(data).then((title) => {

--- a/admin-block/src/BlockExtension.liquid
+++ b/admin-block/src/BlockExtension.liquid
@@ -29,7 +29,7 @@ function App() {
 
 {%- else -%}
 import {
-  extend,
+  extension,
   AdminBlock,
   BlockStack,
   Text
@@ -38,7 +38,7 @@ import {
 // The target used here must match the target used in the extension's toml file (./shopify.extension.toml)
 const TARGET = 'admin.product-details.block.render';
 
-extend(TARGET, (root, { i18n, data }) => {
+export default extension(TARGET, (root, { i18n, data }) => {
   console.log({data});
 
   root.append(

--- a/admin-print-action/src/PrintActionExtension.liquid
+++ b/admin-print-action/src/PrintActionExtension.liquid
@@ -92,7 +92,7 @@ function App() {
 
 {%- else -%}
 import {
-  extend,
+  extension,
   AdminPrintAction,
   Banner,
   BlockStack,
@@ -107,7 +107,7 @@ const TARGET = "admin.order-details.print-action.render";
 const baseSrc = "https://cdn.shopify.com/static/extensibility/print-example";
 
 // The second argument to the render callback provides access to several useful APIs like i18n and data.
-extend(TARGET, (root, { i18n, data }) => {
+export default extension(TARGET, (root, { i18n, data }) => {
   // data has information about the resource to be printed.
   console.log({ data });
 

--- a/checkout-post-purchase/src/index.liquid
+++ b/checkout-post-purchase/src/index.liquid
@@ -133,7 +133,7 @@ import {
  * optionally allows data to be stored on the client for use in the `Render`
  * extension point.
  */
- extend("Checkout::PostPurchase::ShouldRender", async ({ storage }) => {
+extend("Checkout::PostPurchase::ShouldRender", async ({ storage }) => {
   const initialState = await getRenderData();
   const render = true;
 

--- a/customer-segment-template-extension/src/CustomerSegmentTemplate.liquid
+++ b/customer-segment-template-extension/src/CustomerSegmentTemplate.liquid
@@ -30,11 +30,11 @@ function App() {
 }
 
 {%- else -%}
-import { extend, CustomerSegmentTemplate } from "@shopify/ui-extensions/admin";
+import { extension, CustomerSegmentTemplate } from "@shopify/ui-extensions/admin";
 
 // The target used here must match the target used in the extension's toml file (./shopify.extension.toml)
 // The second argument to the render callback provides access to several useful APIs like i18n.
-extend("admin.customers.segmentation-templates.render", (root, { i18n }) => {
+export default extension("admin.customers.segmentation-templates.render", (root, { i18n }) => {
   root.appendChild(
     root.createComponent(
       // The CustomerSegmentTemplate component provides an API for setting the title, description, date, query, and query to insert of the segmentation template.

--- a/order-routing-location-rule/src/OrderRoutingLocationRule.liquid
+++ b/order-routing-location-rule/src/OrderRoutingLocationRule.liquid
@@ -58,7 +58,7 @@ function App() {
 }
 
 {%- else -%}
-import { extend, Box, Form, Text } from "@shopify/ui-extensions/admin";
+import { extension, Box, Form, Text } from "@shopify/ui-extensions/admin";
 
 // Transform your state into metafields and send them back to the admin to batch the
 // changes together with the rest of merchant updates to the routing strategy
@@ -88,7 +88,7 @@ const handleOnReset = () => {
 };
 
 // The target used here must match the target used in the extension's toml file (./shopify.extension.toml)
-extend("admin.settings.order-routing-rule.render", (root, { extension: {target}, i18n, data, applyMetafieldsChange }) => {
+export default extension("admin.settings.order-routing-rule.render", (root, { extension: {target}, i18n, data, applyMetafieldsChange }) => {
   console.log({data});
   root.appendChild(
     root.createComponent(

--- a/product-configuration-extension/src/ProductDetailsConfigurationExtension.liquid
+++ b/product-configuration-extension/src/ProductDetailsConfigurationExtension.liquid
@@ -25,9 +25,9 @@ function App() {
 }
 
 {%- else -%}
-import { extend, Banner } from "@shopify/ui-extensions/admin";
+import { extension, Banner } from "@shopify/ui-extensions/admin";
 
-extend("admin.product-details.configuration.render", (root, { extension: {target}, i18n }) => {
+export default extension("admin.product-details.configuration.render", (root, { extension: {target}, i18n }) => {
   root.appendChild(
     root.createComponent(
       Text,

--- a/product-configuration-extension/src/ProductVariantDetailsConfigurationExtension.liquid
+++ b/product-configuration-extension/src/ProductVariantDetailsConfigurationExtension.liquid
@@ -25,9 +25,9 @@ function App() {
 }
 
 {%- else -%}
-import { extend, Banner } from "@shopify/ui-extensions/admin";
+import { extension, Banner } from "@shopify/ui-extensions/admin";
 
-extend("admin.product-variant-details.configuration.render", (root, { extension: {target}, i18n }) => {
+export default extension("admin.product-variant-details.configuration.render", (root, { extension: {target}, i18n }) => {
   root.appendChild(
     root.createComponent(
       Text,


### PR DESCRIPTION
### Background

Many templates were using old `extend` method to register extensions. 

### Solution

Update to current method for registering extensions. 

`extend` -> `extension`

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
