### PR TITLE
Rename translation key from percentage to description

### DIFF
--- a/discount-details-function-settings-block/locales/en.default.json.liquid
+++ b/discount-details-function-settings-block/locales/en.default.json.liquid
@@ -1,16 +1,14 @@
 {%- if flavor contains "react" -%}
 {
   "name": "Discount function settings",
-  "welcome": "Discount function settings",
-  "percentage": "Offer a discount on all collections except the ones selected",
+  "description": "Offer a discount on all collections except the ones selected",
   "discountPercentage": "Discount percentage",
   "addCollections": "Add collections"
 }
 {%- else -%}
 {
   "name": "Discount function settings",
-  "welcome": "Discount function settings",
-  "percentage": "Offer a discount on all collections except the ones selected",
+  "description": "Offer a discount on all collections except the ones selected",
   "discountPercentage": "Discount percentage",
   "addCollections": "Add collections"
 }

--- a/discount-details-function-settings-block/src/DiscountFunctionSettings.liquid
+++ b/discount-details-function-settings-block/src/DiscountFunctionSettings.liquid
@@ -23,7 +23,7 @@ function PercentageField({ defaultValue, value, onChange, i18n }) {
     <Box paddingBlockEnd="300">
       <BlockStack gap="base">
         <Text variant="headingMd" as="h2">
-          {i18n.translate('percentage')}
+          {i18n.translate('description')}
         </Text>
         <NumberField
           label={i18n.translate('discountPercentage')}
@@ -203,7 +203,7 @@ export default extension(TARGET, async (root, api) => {
     {
       fontVariant: 'bold-200',
     },
-    i18n.translate('percentage'),
+    i18n.translate('description'),
   );
   const numberFieldFragment = root.createComponent(NumberField, {
     onChange: onPercentageValueChange,


### PR DESCRIPTION
### Background

We determined that `description` is a better name than `percentage` for this translation key.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
