### PR TITLE
Remove beta flag from editor extension collections

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -740,8 +740,7 @@
         "value": "config-only",
         "path": "editor-extension-collection"
       }
-    ],
-    "organizationBetaFlags": ["editor_extension_collection"]
+    ]
   },
   {
     "identifier": "order_routing_location_rule",


### PR DESCRIPTION
These are now rolled out 100% on Partners and I'm currently blocked from testing them.
