### PR TITLE
Remove support for appBetaFlags in extension templates configs

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -670,9 +670,6 @@
         "value": "typescript",
         "path": "discount-details-function-settings-block"
       }
-    ],
-    "appBetaFlags": [
-      "extensions_only_discounts_app"
     ]
   },
   {


### PR DESCRIPTION
### Background
- The new app management API that powers dev dash and the new apps platform does not offer support for app beta flags. Therefore, any extension templates gated on `appBetaFlags` will not work as such within the CLI when talking to the new APIs.
- The only reference to an `appBetaFlag` in the extensions templates config is for [this flag](https://experiments.shopify.com/flags/extensions_only_discounts_app), which is rolled out to 100% already.
- Therefore, dropping this outright should be fine. This means the template is available to everyone.

### Solution
- Drop the only consumer of `appBetaFlags` from the templates file.
