### PR TITLE
Fixing spelling error in Admin Link template

### DIFF
--- a/admin-link/shopify.extension.toml.liquid
+++ b/admin-link/shopify.extension.toml.liquid
@@ -11,7 +11,7 @@ type = "admin_link"
 #   url = "https://yourappdomain.com/path"
 #
 
-# Only 1 target can be specified for each Admink Link extension
+# Only 1 target can be specified for each Admin Link extension
 [[extensions.targeting]]
 target = "admin.product.item.link"
 # Change the text of the link in locales/en.default.json

--- a/admin-link/shopify.extension.toml.liquid
+++ b/admin-link/shopify.extension.toml.liquid
@@ -56,4 +56,4 @@ url = "/"
 #  - admin.variant.item.link
 #
 # Get Support Buttons
-#  -admin.app.default-help.link
+#  - admin.app.default-help.link


### PR DESCRIPTION
### Background

<img width="941" alt="image" src="https://github.com/user-attachments/assets/3cccda2c-be58-4e41-a1de-68aac6224244">

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
