### PR TITLE
Adding support link template

### DIFF
--- a/admin-link/README.md.liquid
+++ b/admin-link/README.md.liquid
@@ -40,4 +40,4 @@ When configuring your Admin Link extensions, you can specify various targeting o
   - `admin.variant.item.link`
 
 - **Get Support Button**
-  -`admin.app.defatul-help.link`
+  -`admin.app.support.link`

--- a/admin-link/shopify.extension.toml.liquid
+++ b/admin-link/shopify.extension.toml.liquid
@@ -5,7 +5,7 @@ type = "admin_link"
 
 # For embedded apps URIs are defined relative to your embedded app's home page
 #   url = "app://path"
-# For non embedded apps URIs an absolute path to your app
+# For non embedded apps URIs are an absolute path to your app
 #   url = "https://yourappdomain.com/path"
 [[extensions.targeting]]
 target = "admin.product.item.link"
@@ -51,4 +51,4 @@ url = "/"
 #  - admin.variant.item.link
 #
 # Get Support Buttons
-#  - admin.app.default-help.link
+#  - admin.app.support.link

--- a/support-link/locales/en.default.json.liquid
+++ b/support-link/locales/en.default.json.liquid
@@ -1,0 +1,3 @@
+{
+  "text": "link-extension"
+}

--- a/support-link/locales/fr.json.liquid
+++ b/support-link/locales/fr.json.liquid
@@ -1,0 +1,3 @@
+{
+  "text": "link-extension"
+}

--- a/support-link/shopify.extension.toml.liquid
+++ b/support-link/shopify.extension.toml.liquid
@@ -1,0 +1,11 @@
+[[extensions]]
+name = "Support Extension"
+handle = "{{ handle }}"
+type = "admin_link"
+
+# For embedded apps URIs are defined relative to your embedded app's home page
+#   url = "app://path"
+[[extensions.targeting]]
+target = "admin.app.support.link"
+text = "t:text"
+url = "app://"


### PR DESCRIPTION
### Background

Adding support link extension template to improve DX when creating support link extension

### Solution

Created new folder `support-link` folder (a copy of `admin-link`) and modified the target to be `admin.app.support.link`

This provides a slightly better DX, as we can tell devs to use the command `shopify app generate extension --template support_link --name support-link`. With the target pre-set, they will only need to update the `url`

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
