### PR TITLE
Update Admin Link template to align with Action Links

### DIFF
--- a/admin-link/locales/en.default.json.liquid
+++ b/admin-link/locales/en.default.json.liquid
@@ -1,3 +1,3 @@
 {
-  "text": "link-extension"
+  "name": "Extension Link Text"
 }

--- a/admin-link/locales/fr.json.liquid
+++ b/admin-link/locales/fr.json.liquid
@@ -1,3 +1,3 @@
 {
-  "text": "link-extension"
+  "name": "Texte du lien d'extension"
 }

--- a/admin-link/shopify.extension.toml.liquid
+++ b/admin-link/shopify.extension.toml.liquid
@@ -1,5 +1,7 @@
 [[extensions]]
-name = "Link Extension"
+# Name will be used for your link text and is defined in locales/en.default.json and other locale files
+name = "t:name"
+
 handle = "{{ handle }}"
 type = "admin_link"
 
@@ -9,8 +11,6 @@ type = "admin_link"
 #   url = "https://yourappdomain.com/path"
 [[extensions.targeting]]
 target = "admin.product-details.action.link"
-# The link text is defined in locales/en.default.json and other locale files
-text = "t:text"
 url = "/"
 
 # Valid Extension Targets


### PR DESCRIPTION
### Background

Admin Link's previously have used `title` as the text of the link. Going forward we've decided to align with action extensions which uses the extension `name` property as the text of the link.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
