### PR TITLE
Update global extend method and add tsconfig

### DIFF
--- a/conditional-action-extension-js/src/condition/shouldRender.js
+++ b/conditional-action-extension-js/src/condition/shouldRender.js
@@ -3,7 +3,7 @@
 const TARGET = 'admin.product-details.action.should-render';
 
 // The second argument to the render callback provides access to the resource ID.
-export default shopify.extension(TARGET, async ({ data }) => {
+export default shopify.extend(TARGET, async ({ data }) => {
   const variantCount = await getVariantsCount(data.selected[0].id);
 
   return {display: variantCount > 1 }

--- a/conditional-action-extension-ts/src/condition/shouldRender.ts
+++ b/conditional-action-extension-ts/src/condition/shouldRender.ts
@@ -5,7 +5,7 @@
 const TARGET = 'admin.product-details.action.should-render';
 
 // The second argument to the render callback provides access to the resource ID.
-export default shopify.extension(TARGET, async ({ data }) => {
+export default shopify.extend(TARGET, async ({ data }) => {
   const variantCount = await getVariantsCount(data.selected[0].id);
 
   return {display: variantCount > 1 }

--- a/conditional-action-extension-ts/tsconfig.json
+++ b/conditional-action-extension-ts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  // This tsconfig.json file is only needed to inform the IDE
+  // About the `react-jsx` tsconfig option, so IDE doesn't complain about missing react import
+  // Changing options here won't affect the build of your extension
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": ["./src"]
+}


### PR DESCRIPTION
### Background

We were using the wrong method on the `shopify` global. It should be `shopify.extend`
Also adding a `tsconfig` to the `ts` example

### Solution

Update method and add `tsconfig`.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
