### PR TITLE
Use unstable version of ui-extensions

### DIFF
--- a/conditional-action-extension-ts/package.json.liquid
+++ b/conditional-action-extension-ts/package.json.liquid
@@ -6,7 +6,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2024.10.x",
+    "@shopify/ui-extensions": "0.0.0-unstable",
     "@shopify/ui-extensions-react": "2024.10.x"
   },
   "devDependencies": {


### PR DESCRIPTION
### Background

The conditional-rendering APIs are in the unstable version. 

### Solution

Modify the `ui-extensions` version in the conditional action extension template. 

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
