### PR TITLE
Fix ui-extensions versions

### DIFF
--- a/conditional-action-extension-js/package.json.liquid
+++ b/conditional-action-extension-js/package.json.liquid
@@ -6,7 +6,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2024.10.x",
+    "@shopify/ui-extensions": "0.0.0-unstable-20241206154103",
     "@shopify/ui-extensions-react": "2024.10.x"
   },
   "devDependencies": {

--- a/conditional-action-extension-ts/package.json.liquid
+++ b/conditional-action-extension-ts/package.json.liquid
@@ -6,7 +6,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "0.0.0-unstable",
+    "@shopify/ui-extensions": "0.0.0-unstable-20241206154103",
     "@shopify/ui-extensions-react": "2024.10.x"
   },
   "devDependencies": {


### PR DESCRIPTION
### Background

Follow up to https://github.com/Shopify/extensions-templates/pull/184. We need a specific version of `unstable`. We also need to add it to both flavors of the template. 

### Solution

Update unstable version and add to JS flavor of the template.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
