### PR TITLE
Removing text field from support link template to prevent validation errors

### DIFF
--- a/support-link/shopify.extension.toml.liquid
+++ b/support-link/shopify.extension.toml.liquid
@@ -7,5 +7,4 @@ type = "admin_link"
 #   url = "app://path"
 [[extensions.targeting]]
 target = "admin.app.support.link"
-text = "t:text"
 url = "app://"


### PR DESCRIPTION
### Background

The text field was removed so it also needs to be removed from the template; leaving it in will cause validation errors when devs try to run their app.

### Solution

Removing `text` field from support link template

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
