### PR TITLE
move react-reconciler to dependencies

### DIFF
--- a/admin-action/package.json.liquid
+++ b/admin-action/package.json.liquid
@@ -7,11 +7,11 @@
   "dependencies": {
     "react": "^18.0.0",
     "@shopify/ui-extensions": "2024.10.x",
-    "@shopify/ui-extensions-react": "2024.10.x"
+    "@shopify/ui-extensions-react": "2024.10.x",
+    "react-reconciler": "0.29.0"
   },
   "devDependencies": {
-    "@types/react": "^18.0.0",
-    "react-reconciler": "0.29.0"
+    "@types/react": "^18.0.0"
   }
 }
 {%- else -%}

--- a/admin-block/package.json.liquid
+++ b/admin-block/package.json.liquid
@@ -7,11 +7,11 @@
   "dependencies": {
     "react": "^18.0.0",
     "@shopify/ui-extensions": "2024.10.x",
-    "@shopify/ui-extensions-react": "2024.10.x"
+    "@shopify/ui-extensions-react": "2024.10.x",
+    "react-reconciler": "0.29.0"
   },
   "devDependencies": {
-    "@types/react": "^18.0.0",
-    "react-reconciler": "0.29.0"
+    "@types/react": "^18.0.0"
   }
 }
 {%- else -%}

--- a/admin-print-action/package.json.liquid
+++ b/admin-print-action/package.json.liquid
@@ -7,11 +7,11 @@
   "dependencies": {
     "react": "^18.0.0",
     "@shopify/ui-extensions": "2024.10.x",
-    "@shopify/ui-extensions-react": "2024.10.x"
+    "@shopify/ui-extensions-react": "2024.10.x",
+    "react-reconciler": "0.29.0"
   },
   "devDependencies": {
-    "@types/react": "^18.0.0",
-    "react-reconciler": "0.29.0"
+    "@types/react": "^18.0.0"
   }
 }
 {%- else -%}

--- a/admin-purchase-options-action/package.json.liquid
+++ b/admin-purchase-options-action/package.json.liquid
@@ -7,11 +7,11 @@
   "dependencies": {
     "react": "^18.0.0",
     "@shopify/ui-extensions": "unstable",
-    "@shopify/ui-extensions-react": "unstable"
+    "@shopify/ui-extensions-react": "unstable",
+    "react-reconciler": "0.29.0"
   },
   "devDependencies": {
-    "@types/react": "^18.0.0",
-    "react-reconciler": "0.29.0"
+    "@types/react": "^18.0.0"
   }
 }
 {%- else -%}

--- a/checkout-extension/package.json.liquid
+++ b/checkout-extension/package.json.liquid
@@ -7,11 +7,11 @@
   "dependencies": {
     "react": "^18.0.0",
     "@shopify/ui-extensions": "2024.10.x",
-    "@shopify/ui-extensions-react": "2024.10.x"
+    "@shopify/ui-extensions-react": "2024.10.x",
+    "react-reconciler": "0.29.0"
   },
   "devDependencies": {
-    "@types/react": "^18.0.0",
-    "react-reconciler": "0.29.0"
+    "@types/react": "^18.0.0"
   }
 }
 {%- else -%}

--- a/conditional-action-extension-js/package.json.liquid
+++ b/conditional-action-extension-js/package.json.liquid
@@ -7,11 +7,11 @@
   "dependencies": {
     "react": "^18.0.0",
     "@shopify/ui-extensions": "0.0.0-unstable-20241206154103",
-    "@shopify/ui-extensions-react": "2024.10.x"
+    "@shopify/ui-extensions-react": "2024.10.x",
+    "react-reconciler": "0.29.0"
   },
   "devDependencies": {
-    "@types/react": "^18.0.0",
-    "react-reconciler": "0.29.0"
+    "@types/react": "^18.0.0"
   }
 }
 {%- else -%}

--- a/conditional-action-extension-ts/package.json.liquid
+++ b/conditional-action-extension-ts/package.json.liquid
@@ -7,11 +7,11 @@
   "dependencies": {
     "react": "^18.0.0",
     "@shopify/ui-extensions": "0.0.0-unstable-20241206154103",
-    "@shopify/ui-extensions-react": "2024.10.x"
+    "@shopify/ui-extensions-react": "2024.10.x",
+    "react-reconciler": "0.29.0"
   },
   "devDependencies": {
-    "@types/react": "^18.0.0",
-    "react-reconciler": "0.29.0"
+    "@types/react": "^18.0.0"
   }
 }
 {%- else -%}

--- a/customer-account-extension/package.json.liquid
+++ b/customer-account-extension/package.json.liquid
@@ -7,11 +7,11 @@
   "dependencies": {
     "react": "^18.0.0",
     "@shopify/ui-extensions": "2024.10.x",
-    "@shopify/ui-extensions-react": "2024.10.x"
+    "@shopify/ui-extensions-react": "2024.10.x",
+    "react-reconciler": "0.29.0"
   },
   "devDependencies": {
-    "@types/react": "^18.0.0",
-    "react-reconciler": "0.29.0"
+    "@types/react": "^18.0.0"
   }
 }
 {%- else -%}

--- a/customer-segment-template-extension/package.json.liquid
+++ b/customer-segment-template-extension/package.json.liquid
@@ -7,11 +7,11 @@
   "dependencies": {
     "react": "^18.0.0",
     "@shopify/ui-extensions": "2024.7.x",
-    "@shopify/ui-extensions-react": "2024.7.x"
+    "@shopify/ui-extensions-react": "2024.7.x",
+    "react-reconciler": "0.29.0"
   },
   "devDependencies": {
-    "@types/react": "^18.0.0",
-    "react-reconciler": "0.29.0"
+    "@types/react": "^18.0.0"
   }
 }
 {%- else -%}

--- a/discount-details-function-settings-block/package.json.liquid
+++ b/discount-details-function-settings-block/package.json.liquid
@@ -7,11 +7,11 @@
   "dependencies": {
     "react": "^18.0.0",
     "@shopify/ui-extensions": "2024.10.x",
-    "@shopify/ui-extensions-react": "2024.10.x"
+    "@shopify/ui-extensions-react": "2024.10.x",
+    "react-reconciler": "0.29.0"
   },
   "devDependencies": {
-    "@types/react": "^18.0.0",
-    "react-reconciler": "0.29.0"
+    "@types/react": "^18.0.0"
   }
 }
 {%- else -%}

--- a/order-routing-location-rule/package.json.liquid
+++ b/order-routing-location-rule/package.json.liquid
@@ -7,11 +7,11 @@
   "dependencies": {
     "react": "^18.0.0",
     "@shopify/ui-extensions": "2024-10.x",
-    "@shopify/ui-extensions-react": "2024-10.x"
+    "@shopify/ui-extensions-react": "2024-10.x",
+    "react-reconciler": "0.29.0"
   },
   "devDependencies": {
-    "@types/react": "^18.0.0",
-    "react-reconciler": "0.29.0"
+    "@types/react": "^18.0.0"
   }
 }
 {%- else -%}

--- a/pos-ui-extension/package.json.liquid
+++ b/pos-ui-extension/package.json.liquid
@@ -7,11 +7,11 @@
   "dependencies": {
     "react": "^18.0.0",
     "@shopify/ui-extensions": "2024.10.x",
-    "@shopify/ui-extensions-react": "2024.10.x"
+    "@shopify/ui-extensions-react": "2024.10.x",
+    "react-reconciler": "0.29.0"
   },
   "devDependencies": {
-    "@types/react": "^18.0.0",
-    "react-reconciler": "0.29.0"
+    "@types/react": "^18.0.0"
   }
 }
 {%- else -%}

--- a/validation-settings/package.json.liquid
+++ b/validation-settings/package.json.liquid
@@ -7,11 +7,11 @@
   "dependencies": {
     "react": "^18.0.0",
     "@shopify/ui-extensions": "2024.10.x",
-    "@shopify/ui-extensions-react": "2024.10.x"
+    "@shopify/ui-extensions-react": "2024.10.x",
+    "react-reconciler": "0.29.0"
   },
   "devDependencies": {
-    "@types/react": "^18.0.0",
-    "react-reconciler": "0.29.0"
+    "@types/react": "^18.0.0"
   }
 }
 {%- else -%}


### PR DESCRIPTION
react-reconciler being in `devDependencies` [is causing issues](https://community.shopify.dev/t/could-not-resolve-react-reconciler/4443) when a partner generates a new extension in an app that doesn’t use workspaces.

I looked into this a bit and if an app uses workspaces, the `generate` command creates a `package.json` for each extension, masking this issue.

If an app doesn’t use workspaces, the cli adds dependencies declared in the template to the main package.json, but only `dependencies` and not `devDependencies`
I think react-reconciler should have always been part of dependencies in the first place, but perhaps I’m missing something.