### PR TITLE
updates checkout extension versions to 2025.1.x

### DIFF
--- a/checkout-extension/package.json.liquid
+++ b/checkout-extension/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2024.10.x",
-    "@shopify/ui-extensions-react": "2024.10.x",
+    "@shopify/ui-extensions": "2025.1.x",
+    "@shopify/ui-extensions-react": "2025.1.x",
     "react-reconciler": "0.29.0"
   },
   "devDependencies": {
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2024.10.x"
+    "@shopify/ui-extensions": "2025.1.x"
   }
 }
 {%- endif -%}

--- a/checkout-extension/shopify.extension.toml.liquid
+++ b/checkout-extension/shopify.extension.toml.liquid
@@ -3,7 +3,7 @@
 
 # The version of APIs your extension will receive. Learn more:
 # https://shopify.dev/docs/api/usage/versioning
-api_version = "2024-10"
+api_version = "2025-01"
 
 [[extensions]]
 name = "{{ name }}"


### PR DESCRIPTION
### Background

This PR updates the version in the templates to the latest available now that the `2025-01` stable versions of `ui-extensions` and `ui-extensions-react` have been released.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
