### PR TITLE
Update ui-extensions versions in templates

### DIFF
--- a/admin-action/package.json.liquid
+++ b/admin-action/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2024.10.x",
-    "@shopify/ui-extensions-react": "2024.10.x",
+    "@shopify/ui-extensions": "2025.1.x",
+    "@shopify/ui-extensions-react": "2025.1.x",
     "react-reconciler": "0.29.0"
   },
   "devDependencies": {
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2024.10.x"
+    "@shopify/ui-extensions": "2025.1.x"
   }
 }
 {%- endif -%}

--- a/admin-block/package.json.liquid
+++ b/admin-block/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2024.10.x",
-    "@shopify/ui-extensions-react": "2024.10.x",
+    "@shopify/ui-extensions": "2025.1.x",
+    "@shopify/ui-extensions-react": "2025.1.x",
     "react-reconciler": "0.29.0"
   },
   "devDependencies": {
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2024.10.x"
+    "@shopify/ui-extensions": "2025.1.x"
   }
 }
 {%- endif -%}

--- a/admin-print-action/package.json.liquid
+++ b/admin-print-action/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2024.10.x",
-    "@shopify/ui-extensions-react": "2024.10.x",
+    "@shopify/ui-extensions": "2025.1.x",
+    "@shopify/ui-extensions-react": "2025.1.x",
     "react-reconciler": "0.29.0"
   },
   "devDependencies": {
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2024.10.x"
+    "@shopify/ui-extensions": "2025.1.x"
   }
 }
 {%- endif -%}

--- a/conditional-action-extension-js/package.json.liquid
+++ b/conditional-action-extension-js/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "0.0.0-unstable-20241206154103",
-    "@shopify/ui-extensions-react": "2024.10.x",
+    "@shopify/ui-extensions": "2025.1.x",
+    "@shopify/ui-extensions-react": "2025.1.x",
     "react-reconciler": "0.29.0"
   },
   "devDependencies": {
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2024.10.x"
+    "@shopify/ui-extensions": "2025.1.x"
   }
 }
 {%- endif -%}

--- a/conditional-action-extension-ts/package.json.liquid
+++ b/conditional-action-extension-ts/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "0.0.0-unstable-20241206154103",
-    "@shopify/ui-extensions-react": "2024.10.x",
+    "@shopify/ui-extensions": "2025.1.x",
+    "@shopify/ui-extensions-react": "2025.1.x",
     "react-reconciler": "0.29.0"
   },
   "devDependencies": {
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2024.10.x"
+    "@shopify/ui-extensions": "2025.1.x"
   }
 }
 {%- endif -%}


### PR DESCRIPTION
### Background

We just released the [`2025.1.0`](https://www.npmjs.com/package/@shopify/ui-extensions) versions of `ui-extensions` and `ui-extensions-react`. This updates our templates to use the latest versions. 

### Solution

Update versions to latest

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
