### PR TITLE
Change unstable version to 2025-01 for the purchase options extensions template

### DIFF
--- a/admin-purchase-options-action/package.json.liquid
+++ b/admin-purchase-options-action/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "unstable",
-    "@shopify/ui-extensions-react": "unstable",
+    "@shopify/ui-extensions": "2025.1.x",
+    "@shopify/ui-extensions-react": "2025.1.x",
     "react-reconciler": "0.29.0"
   },
   "devDependencies": {
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "unstable"
+    "@shopify/ui-extensions": "2025.1.x"
   }
 }
 {%- endif -%}

--- a/admin-purchase-options-action/shopify.extension.toml.liquid
+++ b/admin-purchase-options-action/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "unstable"
+api_version = "2025-01"
 
 [[extensions]]
 # Change the merchant-facing name of the extension in locales/en.default.json


### PR DESCRIPTION
### Background

Update the version of the Purchase options extensions template

### Solution

Change the api_version

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
