### PR TITLE
Update to version 2025-01 for pos ui ext

### DIFF
--- a/pos-ui-extension/package.json.liquid
+++ b/pos-ui-extension/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2024.10.x",
-    "@shopify/ui-extensions-react": "2024.10.x",
+    "@shopify/ui-extensions": "2025.1.x",
+    "@shopify/ui-extensions-react": "2025.1.x",
     "react-reconciler": "0.29.0"
   },
   "devDependencies": {
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2024.10.x"
+    "@shopify/ui-extensions": "2025.1.x"
   }
 }
 {%- endif -%}

--- a/pos-ui-extension/shopify.extension.toml.liquid
+++ b/pos-ui-extension/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 # The version of APIs your extension will receive. Learn more:
 # https://shopify.dev/docs/api/usage/versioning
-api_version = "2024-10"
+api_version = "2025-01"
 
 [[extensions]]
 type = "ui_extension"


### PR DESCRIPTION
Resolves https://github.com/Shopify/pos-next-react-native/issues/43316

### Background

Now that 2025-01 is out for ui-extensions, we can update the default templates for POS.
