### PR TITLE
Add Extension URL Config

### DIFF
--- a/product-configuration-extension/shopify.extension.toml.liquid
+++ b/product-configuration-extension/shopify.extension.toml.liquid
@@ -11,12 +11,13 @@ type = "ui_extension"
 module = "./src/ProductDetailsConfigurationExtension.{{ srcFileExtension }}"
 # The target used here must match the target used in the module file (./src/ProductDetailsConfigurationExtension.{{ srcFileExtension }})
 target = "admin.product-details.configuration.render"
+[[extensions.targeting.urls]]
+edit = "/bundles/products/{product_id}"
 
 
 [[extensions.targeting]]
 module = "./src/ProductVariantDetailsConfigurationExtension.{{ srcFileExtension }}"
 # The target used here must match the target used in the module file (./src/ProductVariantDetailsConfigurationExtension.{{ srcFileExtension }})
 target = "admin.product-variant-details.configuration.render"
-
-[extensions.targeting.urls]
+[[extensions.targeting.urls]]
 edit = "/bundles/products/{product_id}"

--- a/product-configuration-extension/shopify.extension.toml.liquid
+++ b/product-configuration-extension/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2023-07"
+api_version = "2025-01"
 
 [[extensions]]
 name = "t:name"
@@ -17,3 +17,6 @@ target = "admin.product-details.configuration.render"
 module = "./src/ProductVariantDetailsConfigurationExtension.{{ srcFileExtension }}"
 # The target used here must match the target used in the module file (./src/ProductVariantDetailsConfigurationExtension.{{ srcFileExtension }})
 target = "admin.product-variant-details.configuration.render"
+
+[extensions.targeting.urls]
+edit = "/bundles/products/{product_id}"

--- a/product-configuration-extension/shopify.extension.toml.liquid
+++ b/product-configuration-extension/shopify.extension.toml.liquid
@@ -11,7 +11,7 @@ type = "ui_extension"
 module = "./src/ProductDetailsConfigurationExtension.{{ srcFileExtension }}"
 # The target used here must match the target used in the module file (./src/ProductDetailsConfigurationExtension.{{ srcFileExtension }})
 target = "admin.product-details.configuration.render"
-[[extensions.targeting.urls]]
+[extensions.targeting.urls]
 edit = "/bundles/products/{product_id}"
 
 
@@ -19,5 +19,5 @@ edit = "/bundles/products/{product_id}"
 module = "./src/ProductVariantDetailsConfigurationExtension.{{ srcFileExtension }}"
 # The target used here must match the target used in the module file (./src/ProductVariantDetailsConfigurationExtension.{{ srcFileExtension }})
 target = "admin.product-variant-details.configuration.render"
-[[extensions.targeting.urls]]
+[extensions.targeting.urls]
 edit = "/bundles/products/{product_id}"


### PR DESCRIPTION
### Background

Finishes this issue: https://github.com/Shopify/bundles-app/issues/2953?issue=Shopify%7Cextensions-templates%7C197

by adding the appropriate config

### Solution

Following the thread in https://github.com/Shopify/ui-api-design/pull/798#issuecomment-2602692529 with the most recent suggestions implemented

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
