### PR TITLE
Skeleton channel config template

### DIFF
--- a/channel-config/README.md.liquid
+++ b/channel-config/README.md.liquid
@@ -1,0 +1,4 @@
+## Extension Configuration
+
+The Channel Config Extension allows channel apps to provide channel details and
+product requirements needed by Shopify's Common Listing Management Experience.

--- a/channel-config/shopify.extension.toml.liquid
+++ b/channel-config/shopify.extension.toml.liquid
@@ -1,0 +1,8 @@
+[[extensions]]
+type = "channel_config"
+handle = "{{ handle }}"
+name = "{{ name }}"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+
+[channel_requirements]
+channel_handle = "Shop"

--- a/templates.json
+++ b/templates.json
@@ -1156,5 +1156,22 @@
         "path": "admin-link"
       }
     ]
+  },
+  {
+    "identifier": "channel_config",
+    "name": "Sales channel configuration",
+    "defaultName": "channel-config",
+    "group": "Sales channels",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "channel_config",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "channel-config"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
### Background

As part of the [Common channel listing management](https://vault.shopify.io/gsd/projects/43512-Common-channel-listing-management-experience) project we're building a [Channel config extension](https://github.com/Shopify/shopify/pull/573560) to allow configuring product requirements for sales channels. This is a skeleton version of the extension template, to be filled out in future PRs.

This will be gated behind the [common_channel_listing_management_experience](https://github.com/Shopify/business-platform/pull/24187/files) org feature flag.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
