### PR TITLE
Removes edit url config from product variant target point

### DIFF
--- a/product-configuration-extension/shopify.extension.toml.liquid
+++ b/product-configuration-extension/shopify.extension.toml.liquid
@@ -19,5 +19,3 @@ edit = "/bundles/products/{product_id}"
 module = "./src/ProductVariantDetailsConfigurationExtension.{{ srcFileExtension }}"
 # The target used here must match the target used in the module file (./src/ProductVariantDetailsConfigurationExtension.{{ srcFileExtension }})
 target = "admin.product-variant-details.configuration.render"
-[extensions.targeting.urls]
-edit = "/bundles/products/{product_id}"


### PR DESCRIPTION
### Background

Removes the edit url from the product variant configuration extension point as setting the url on the product variant configuration card is not yet supported.

### Solution

Quick fix for small oversight in https://github.com/Shopify/extensions-templates/pull/199

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
