### PR TITLE
Update API version for all admin extensions

### DIFF
--- a/admin-action/shopify.extension.toml.liquid
+++ b/admin-action/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2024-10"
+api_version = "2025-01"
 
 [[extensions]]
 # Change the merchant-facing name of the extension in locales/en.default.json

--- a/admin-block/shopify.extension.toml.liquid
+++ b/admin-block/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2024-10"
+api_version = "2025-01"
 
 [[extensions]]
 # Change the merchant-facing name of the extension in locales/en.default.json

--- a/admin-print-action/shopify.extension.toml.liquid
+++ b/admin-print-action/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2024-10"
+api_version = "2025-01"
 
 [[extensions]]
 name = "{{ handle }}"

--- a/conditional-action-extension-js/shopify.extension.toml.liquid
+++ b/conditional-action-extension-js/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "unstable"
+api_version = "2025-01"
 
 [[extensions]]
 name = "t:name"

--- a/conditional-action-extension-ts/shopify.extension.toml.liquid
+++ b/conditional-action-extension-ts/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "unstable"
+api_version = "2025-01"
 
 [[extensions]]
 name = "t:name"


### PR DESCRIPTION
### Background

All admin templates should be using the latest API versions. 

### Solution

Update API versions in toml files. 

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
