### PR TITLE
feat(products): Update product configuration extensions to include GraphQL Query sample and support React 18 and latest UI extensions

### DIFF
--- a/product-configuration-extension/package.json.liquid
+++ b/product-configuration-extension/package.json.liquid
@@ -5,12 +5,13 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "react": "^17.0.0",
-    "@shopify/ui-extensions": "2023.7.x",
-    "@shopify/ui-extensions-react": "2023.7.x"
+    "react": "^18.0.0",
+    "@shopify/ui-extensions": "2025.1.x",
+    "@shopify/ui-extensions-react": "2025.1.x",
+    "react-reconciler": "0.29.0"
   },
   "devDependencies": {
-    "@types/react": "^17.0.0"
+    "@types/react": "^18.0.0"
   }
 }
 {%- else -%}
@@ -20,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2023.7.x"
+    "@shopify/ui-extensions": "2025.1.x"
   }
 }
 {%- endif -%}

--- a/product-configuration-extension/src/ProductDetailsConfigurationExtension.liquid
+++ b/product-configuration-extension/src/ProductDetailsConfigurationExtension.liquid
@@ -2,38 +2,186 @@
 import {
   reactExtension,
   useApi,
+  BlockStack,
   Text,
 } from '@shopify/ui-extensions-react/admin';
+import {useState, useEffect} from 'react';
 
 // The target used here must match the target used in the extension's toml file (./shopify.extension.toml)
-{% if flavor contains "typescript" %}
-export default reactExtension<any>('admin.product-details.configuration.render', () => <App />);
-{% else %}
 export default reactExtension('admin.product-details.configuration.render', () => <App />);
-{% endif %}
+
 function App() {
   {% if flavor contains "typescript" %}
   const {extension: {target}, i18n} = useApi<'admin.product-details.configuration.render'>();
   {% else %}
   const {extension: {target}, i18n} = useApi();
   {% endif %}
+  const product = useProduct();
   return (
-    <Text>
-      {i18n.translate('welcome', {target})}
-    </Text>
+    <BlockStack>
+      <Text>
+        {i18n.translate('welcome', {target})}
+      </Text>
+      {product?.bundleComponents.map((component) =>
+        <Text key={component.id}>{component.title}</Text>
+      )}
+    </BlockStack>
   );
 }
 
-{%- else -%}
-import { extension, Banner } from "@shopify/ui-extensions/admin";
+function useProduct() {
+  {% if flavor contains "typescript" %}
+  const {data, query} = useApi<'admin.product-details.configuration.render'>();
+  const productId = (data as any)?.selected[0].id;
+  const [product, setProduct] = useState<{
+    id: string;
+    title: string;
+    bundleComponents: {
+      id: string;
+      title: string;
+    }[];
+  }>(null);
+  {% else %}
+  const {data, query} = useApi();
+  const productId = data?.selected[0].id;
+  const [product, setProduct] = useState(null);
+  {% endif %}
 
-export default extension("admin.product-details.configuration.render", (root, { extension: {target}, i18n }) => {
-  root.appendChild(
+  useEffect(() => {
+    query(
+      `#graphql
+      query GetProduct($id: ID!) {
+        product(id: $id) {
+          id
+          title
+          bundleComponents(first: 100) {
+            nodes {
+              componentProduct {
+                id
+                title
+              }
+            }
+          }
+        }
+      }
+      `,
+      {variables: {id: productId}}
+    ).then(({data, errors}) => {
+      if (errors) {
+        console.error(errors);
+      } else {
+        {% if flavor contains "typescript" %}
+        const {bundleComponents, ...product} = (data as any).product;
+        {% else %}
+        const {bundleComponents, ...product} = data.product;
+        {% endif %}
+        setProduct({
+          ...product,
+          {% if flavor contains "typescript" %}
+          bundleComponents: bundleComponents.nodes.map(({componentProduct}: any) => ({
+          {% else %}
+          bundleComponents: bundleComponents.nodes.map(({componentProduct}) => ({
+          {% endif %}
+            ...componentProduct
+          }))
+        })
+      }
+    })
+  }, [productId]);
+
+  return product;
+}
+
+{%- else -%}
+import {
+  extension,
+  StandardApi,
+  BlockStack,
+  Text
+} from "@shopify/ui-extensions/admin";
+
+export default extension("admin.product-details.configuration.render", async (root, { extension: {target}, data, i18n, query }) => {
+  {% if flavor contains "typescript" %}
+  const productId = (data as any)?.selected[0].id;
+  {% else %}
+  const productId = data?.selected[0].id;
+  {% endif %}
+  const product = await fetchProduct(productId, query);
+
+  root.append(
     root.createComponent(
-      Text,
+      BlockStack,
       {},
-      i18n.translate('welcome', {target})
-    )
+      root.createComponent(
+        Text,
+        {},
+        i18n.translate('welcome', {target}),
+        ...product?.bundleComponents.map((component) =>
+          root.createComponent(
+            Text,
+            {},
+            component.title
+          ),
+        ),
+      ),
+    ),
   );
 });
+
+{% if flavor contains "typescript" %}
+async function fetchProduct(
+  productId: string,
+  query: StandardApi<any>['query'],
+): Promise<{
+  id: string;
+  title: string;
+  bundleComponents: {
+    id: string;
+    title: string;
+  }[];
+} | null> {
+{% else %}
+async function fetchProduct(productId, query) {
+{% endif %}
+  const {data, errors} = await query(
+    `#graphql
+    query GetProduct($id: ID!) {
+      product(id: $id) {
+        id
+        title
+        bundleComponents(first: 100) {
+          nodes {
+            componentProduct {
+              id
+              title
+            }
+          }
+        }
+      }
+    }
+    `,
+    {variables: {id: productId}}
+  );
+
+  if (errors) {
+    console.error(errors);
+    return null;
+  }
+
+  {% if flavor contains "typescript" %}
+  const {bundleComponents, ...product} = (data as any).product;
+  {% else %}
+  const {bundleComponents, ...product} = data.product;
+  {% endif %}
+  return {
+    ...product,
+    {% if flavor contains "typescript" %}
+    bundleComponents: bundleComponents.nodes.map(({componentProduct}: any) => ({
+    {% else %}
+    bundleComponents: bundleComponents.nodes.map(({componentProduct}) => ({
+    {% endif %}
+      ...componentProduct
+    }))
+  };
+}
 {%- endif -%}

--- a/product-configuration-extension/src/ProductDetailsConfigurationExtension.liquid
+++ b/product-configuration-extension/src/ProductDetailsConfigurationExtension.liquid
@@ -71,23 +71,32 @@ function useProduct() {
         console.error(errors);
       } else {
         {% if flavor contains "typescript" %}
-        const {bundleComponents, ...product} = (data as any).product;
+        const {bundleComponents, ...product} = (data as {
+          product: {
+            id: string;
+            title: string;
+            bundleComponents: {
+              nodes: {
+                componentProduct: {
+                  id: string;
+                  title: string;
+                }
+              }[]
+            }
+          }
+        }).product;
         {% else %}
         const {bundleComponents, ...product} = data.product;
         {% endif %}
         setProduct({
           ...product,
-          {% if flavor contains "typescript" %}
-          bundleComponents: bundleComponents.nodes.map(({componentProduct}: any) => ({
-          {% else %}
           bundleComponents: bundleComponents.nodes.map(({componentProduct}) => ({
-          {% endif %}
             ...componentProduct
           }))
         })
       }
     })
-  }, [productId]);
+  }, [productId, query]);
 
   return product;
 }
@@ -169,17 +178,26 @@ async function fetchProduct(productId, query) {
   }
 
   {% if flavor contains "typescript" %}
-  const {bundleComponents, ...product} = (data as any).product;
+  const {bundleComponents, ...product} = (data as {
+    product: {
+      id: string;
+      title: string;
+      bundleComponents: {
+        nodes: {
+          componentProduct: {
+            id: string;
+            title: string;
+          }
+        }[]
+      }
+    }
+  }).product;
   {% else %}
   const {bundleComponents, ...product} = data.product;
   {% endif %}
   return {
     ...product,
-    {% if flavor contains "typescript" %}
-    bundleComponents: bundleComponents.nodes.map(({componentProduct}: any) => ({
-    {% else %}
     bundleComponents: bundleComponents.nodes.map(({componentProduct}) => ({
-    {% endif %}
       ...componentProduct
     }))
   };

--- a/product-configuration-extension/src/ProductVariantDetailsConfigurationExtension.liquid
+++ b/product-configuration-extension/src/ProductVariantDetailsConfigurationExtension.liquid
@@ -2,38 +2,186 @@
 import {
   reactExtension,
   useApi,
+  BlockStack,
   Text,
 } from '@shopify/ui-extensions-react/admin';
+import {useState, useEffect} from 'react';
 
 // The target used here must match the target used in the extension's toml file (./shopify.extension.toml)
-{% if flavor contains "typescript" %}
-export default reactExtension<any>('admin.product-variant-details.configuration.render', () => <App />);
-{% else %}
 export default reactExtension('admin.product-variant-details.configuration.render', () => <App />);
-{% endif %}
+
 function App() {
   {% if flavor contains "typescript" %}
   const {extension: {target}, i18n} = useApi<'admin.product-variant-details.configuration.render'>();
   {% else %}
   const {extension: {target}, i18n} = useApi();
   {% endif %}
+  const productVariant = useProductVariant();
   return (
-    <Text>
-      {i18n.translate('welcome', {target})}
-    </Text>
+    <BlockStack>
+      <Text>
+        {i18n.translate('welcome', {target})}
+      </Text>
+      {productVariant?.productVariantComponents.map((component) =>
+        <Text key={component.id}>{component.title}</Text>
+      )}
+    </BlockStack>
   );
 }
 
-{%- else -%}
-import { extension, Banner } from "@shopify/ui-extensions/admin";
+function useProductVariant() {
+  {% if flavor contains "typescript" %}
+  const {data, query} = useApi<'admin.product-variant-details.configuration.render'>();
+  const productVariantId = (data as any)?.selected[0].id;
+  const [productVariant, setProductVariant] = useState<{
+    id: string;
+    title: string;
+    productVariantComponents: {
+      id: string;
+      title: string;
+    }[];
+  }>(null);
+  {% else %}
+  const {data, query} = useApi();
+  const productId = data?.selected[0].id;
+  const [product, setProduct] = useState(null);
+  {% endif %}
 
-export default extension("admin.product-variant-details.configuration.render", (root, { extension: {target}, i18n }) => {
-  root.appendChild(
+  useEffect(() => {
+    query(
+      `#graphql
+      query GetProductVariant($id: ID!) {
+        productVariant(id: $id) {
+          id
+          title
+          productVariantComponents(first: 100) {
+            nodes {
+              productVariant {
+                id
+                title
+              }
+            }
+          }
+        }
+      }
+      `,
+      {variables: {id: productVariantId}}
+    ).then(({data, errors}) => {
+      if (errors) {
+        console.error(errors);
+      } else {
+        {% if flavor contains "typescript" %}
+        const {productVariantComponents, ...productVariant} = (data as any).productVariant;
+        {% else %}
+        const {productVariantComponents, ...productVariant} = data.productVariant;
+        {% endif %}
+        setProductVariant({
+          ...productVariant,
+          {% if flavor contains "typescript" %}
+          productVariantComponents: productVariantComponents.nodes.map(({productVariant}: any) => ({
+          {% else %}
+          productVariantComponents: productVariantComponents.nodes.map(({productVariant}) => ({
+          {% endif %}
+            ...productVariant
+          }))
+        })
+      }
+    })
+  }, [productVariantId])
+
+  return productVariant;
+}
+
+{%- else -%}
+import {
+  extension,
+  StandardApi,
+  BlockStack,
+  Text
+} from "@shopify/ui-extensions/admin";
+
+export default extension("admin.product-variant-details.configuration.render", async (root, { extension: {target}, data, i18n, query }) => {
+  {% if flavor contains "typescript" %}
+  const productVariantId = (data as any)?.selected[0].id;
+  {% else %}
+  const productVariantId = data?.selected[0].id;
+  {% endif %}
+  const productVariant = await fetchProductVariant(productVariantId, query);
+
+  root.append(
     root.createComponent(
-      Text,
+      BlockStack,
       {},
-      i18n.translate('welcome', {target})
-    )
+      root.createComponent(
+        Text,
+        {},
+        i18n.translate('welcome', {target}),
+        ...productVariant?.productVariantComponents.map((component) =>
+          root.createComponent(
+            Text,
+            {},
+            component.title
+          ),
+        ),
+      ),
+    ),
   );
 });
+
+{% if flavor contains "typescript" %}
+async function fetchProductVariant(
+  productVariantId: string,
+  query: StandardApi<any>['query'],
+): Promise<{
+  id: string;
+  title: string;
+  productVariantComponents: {
+    id: string;
+    title: string;
+  }[];
+} | null> {
+{% else %}
+async function fetchProductVariant(productVariantId, query) {
+{% endif %}
+  const {data, errors} = await query(
+    `#graphql
+    query GetProductVariant($id: ID!) {
+      productVariant(id: $id) {
+        id
+        title
+        productVariantComponents(first: 100) {
+          nodes {
+            productVariant {
+              id
+              title
+            }
+          }
+        }
+      }
+    }
+    `,
+    {variables: {id: productVariantId}}
+  );
+
+  if (errors) {
+    console.error(errors);
+    return null;
+  }
+
+  {% if flavor contains "typescript" %}
+  const {productVariantComponents, ...productVariant} = (data as any).productVariant;
+  {% else %}
+  const {productVariantComponents, ...productVariant} = data.productVariant;
+  {% endif %}
+  return {
+    ...productVariant,
+    {% if flavor contains "typescript" %}
+    productVariantComponents: productVariantComponents.nodes.map(({productVariant}: any) => ({
+    {% else %}
+    productVariantComponents: productVariantComponents.nodes.map(({productVariant}) => ({
+    {% endif %}
+      ...productVariant
+    }))
+  };
+}
 {%- endif -%}

--- a/product-configuration-extension/src/ProductVariantDetailsConfigurationExtension.liquid
+++ b/product-configuration-extension/src/ProductVariantDetailsConfigurationExtension.liquid
@@ -71,23 +71,32 @@ function useProductVariant() {
         console.error(errors);
       } else {
         {% if flavor contains "typescript" %}
-        const {productVariantComponents, ...productVariant} = (data as any).productVariant;
+        const {productVariantComponents, ...productVariant} = (data as {
+          productVariant: {
+            id: string;
+            title: string;
+            productVariantComponents: {
+              nodes: {
+                productVariant: {
+                  id: string;
+                  title: string;
+                }
+              }[]
+            }
+          }
+        }).productVariant;
         {% else %}
         const {productVariantComponents, ...productVariant} = data.productVariant;
         {% endif %}
         setProductVariant({
           ...productVariant,
-          {% if flavor contains "typescript" %}
-          productVariantComponents: productVariantComponents.nodes.map(({productVariant}: any) => ({
-          {% else %}
           productVariantComponents: productVariantComponents.nodes.map(({productVariant}) => ({
-          {% endif %}
             ...productVariant
           }))
         })
       }
     })
-  }, [productVariantId])
+  }, [productVariantId, query])
 
   return productVariant;
 }
@@ -169,17 +178,26 @@ async function fetchProductVariant(productVariantId, query) {
   }
 
   {% if flavor contains "typescript" %}
-  const {productVariantComponents, ...productVariant} = (data as any).productVariant;
+  const {productVariantComponents, ...productVariant} = (data as {
+    productVariant: {
+      id: string;
+      title: string;
+      productVariantComponents: {
+        nodes: {
+          productVariant: {
+            id: string;
+            title: string;
+          }
+        }[]
+      }
+    }
+  }).productVariant;
   {% else %}
   const {productVariantComponents, ...productVariant} = data.productVariant;
   {% endif %}
   return {
     ...productVariant,
-    {% if flavor contains "typescript" %}
-    productVariantComponents: productVariantComponents.nodes.map(({productVariant}: any) => ({
-    {% else %}
     productVariantComponents: productVariantComponents.nodes.map(({productVariant}) => ({
-    {% endif %}
       ...productVariant
     }))
   };

--- a/product-configuration-extension/tsconfig.json
+++ b/product-configuration-extension/tsconfig.json
@@ -3,7 +3,10 @@
   // About the `react-jsx` tsconfig option, so IDE doesn't complain about missing react import
   // Changing options here won't affect the build of your extension
   "compilerOptions": {
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "target": "ES2020",
+    "moduleResolution": "node",
+    "esModuleInterop": true
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
### Background

This PR:
- adds graphql querying for product/variant + components (in place of the existing (& deprecated) `data.product`/`data.variant` json blob that is passed in.
- includes a bare minimal list of components
- updates dependencies

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
