### PR TITLE
[DO NOT MERGE UNTIL 4/9] Update to version to 2025-04

### DIFF
--- a/pos-ui-extension/package.json.liquid
+++ b/pos-ui-extension/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2025.1.x",
-    "@shopify/ui-extensions-react": "2025.1.x",
+    "@shopify/ui-extensions": "2025.4.x",
+    "@shopify/ui-extensions-react": "2025.4.x",
     "react-reconciler": "0.29.0"
   },
   "devDependencies": {
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2025.1.x"
+    "@shopify/ui-extensions": "2025.4.x"
   }
 }
 {%- endif -%}

--- a/pos-ui-extension/shopify.extension.toml.liquid
+++ b/pos-ui-extension/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 # The version of APIs your extension will receive. Learn more:
 # https://shopify.dev/docs/api/usage/versioning
-api_version = "2025-01"
+api_version = "2025-04"
 
 [[extensions]]
 type = "ui_extension"


### PR DESCRIPTION
### Background

This won't merge until 4/9 which is 100% rollout for 9.31

This updates the base template version to 2025-04 for POS UI Extensions

