### PR TITLE
Fix toml for remote dom extensions

### DIFF
--- a/admin-block/shopify.extension.toml.liquid
+++ b/admin-block/shopify.extension.toml.liquid
@@ -1,8 +1,9 @@
 {%- if flavor contains "preact" -%}
 api_version = "2025-07"
-{%- else %}
+
+{%- else -%}
 api_version = "2025-04"
-{% endif -%}
+{% endif %}
 
 [[extensions]]
 # Change the merchant-facing name of the extension in locales/en.default.json

--- a/admin-print-action/shopify.extension.toml.liquid
+++ b/admin-print-action/shopify.extension.toml.liquid
@@ -1,8 +1,9 @@
 {%- if flavor contains "preact" -%}
 api_version = "2025-07"
-{%- else %}
+
+{%- else -%}
 api_version = "2025-04"
-{% endif -%}
+{% endif %}
 
 [[extensions]]
 name = "{{ handle }}"

--- a/admin-purchase-options-action/shopify.extension.toml.liquid
+++ b/admin-purchase-options-action/shopify.extension.toml.liquid
@@ -1,8 +1,9 @@
 {%- if flavor contains "preact" -%}
 api_version = "2025-07"
-{%- else %}
+
+{%- else -%}
 api_version = "2025-04"
-{% endif -%}
+{% endif %}
 
 [[extensions]]
 # Change the merchant-facing name of the extension in locales/en.default.json

--- a/conditional-action-extension-js/shopify.extension.toml.liquid
+++ b/conditional-action-extension-js/shopify.extension.toml.liquid
@@ -1,8 +1,9 @@
 {%- if flavor contains "preact" -%}
 api_version = "2025-07"
-{%- else %}
+
+{%- else -%}
 api_version = "2025-04"
-{% endif -%}
+{% endif %}
 
 [[extensions]]
 name = "t:name"

--- a/product-configuration-extension/shopify.extension.toml.liquid
+++ b/product-configuration-extension/shopify.extension.toml.liquid
@@ -1,8 +1,9 @@
 {%- if flavor contains "preact" -%}
 api_version = "2025-07"
-{%- else %}
+
+{%- else -%}
 api_version = "2025-04"
-{% endif -%}
+{% endif %}
 
 [[extensions]]
 name = "t:name"


### PR DESCRIPTION
### Background

Fix malformed toml file.

### Test
- Run `REMOTE_DOM_EXPERIMENT=true shopify app generate extension --clone-url https://github.com/Shopify/extensions-templates#fix-toml` and test all of these options:
    - Admin block
    - Admin print action
    - Admin purchase options action
    - Conditional admin action
    - Product configuration
- Verify the extension is generated correctly

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
