### PR TITLE
Update checkout UI templates for 2025-07 RC

### DIFF
--- a/checkout-extension/locales/en.default.json
+++ b/checkout-extension/locales/en.default.json
@@ -1,5 +1,6 @@
 {
   "welcome": "Welcome to the {{target}} extension!",
   "iWouldLikeAFreeGiftWithMyOrder": "I would like to receive a free gift with my order",
+  "addAFreeGiftToMyOrder": "Add a free gift to my order",
   "attributeChangesAreNotSupported": "Attribute changes are not supported in this checkout"
 }

--- a/checkout-extension/locales/fr.json
+++ b/checkout-extension/locales/fr.json
@@ -1,5 +1,6 @@
 {
   "welcome": "Bienvenue dans l'extension {{target}}!",
   "iWouldLikeAFreeGiftWithMyOrder": "Je souhaite recevoir un cadeau gratuit avec ma commande",
+  "addAFreeGiftToMyOrder": "Ajouter un cadeau gratuit à ma commande",
   "attributeChangesAreNotSupported": "Les modifications d'attribut ne sont pas prises en charge dans cette commande"
 }

--- a/checkout-extension/package.json.liquid
+++ b/checkout-extension/package.json.liquid
@@ -1,27 +1,26 @@
-{%- if flavor contains "react" -%}
 {
   "name": "{{ handle }}",
   "private": true,
   "version": "1.0.0",
   "license": "UNLICENSED",
+{%- if flavor contains "preact" %}
+  "dependencies": {
+    "preact": "^10.10.x",
+    "@shopify/ui-extensions": "2025-07-rc"
+  }
+{%- elsif flavor contains "react" %}
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2025.1.x",
-    "@shopify/ui-extensions-react": "2025.1.x",
+    "@shopify/ui-extensions": "2025.4.x",
+    "@shopify/ui-extensions-react": "2025.4.x",
     "react-reconciler": "0.29.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.0"
   }
-}
-{%- else -%}
-{
-  "name": "{{ handle }}",
-  "private": true,
-  "version": "1.0.0",
-  "license": "UNLICENSED",
+{%- else %}
   "dependencies": {
-    "@shopify/ui-extensions": "2025.1.x"
+    "@shopify/ui-extensions": "2025.4.x"
   }
+{%- endif %}
 }
-{%- endif -%}

--- a/checkout-extension/shopify.extension.toml.liquid
+++ b/checkout-extension/shopify.extension.toml.liquid
@@ -3,7 +3,11 @@
 
 # The version of APIs your extension will receive. Learn more:
 # https://shopify.dev/docs/api/usage/versioning
-api_version = "2025-01"
+{%- if flavor contains "preact" %}
+api_version = "2025-07"
+{%- else %}
+api_version = "2025-04"
+{%- endif %}
 
 [[extensions]]
 name = "{{ name }}"

--- a/checkout-extension/src/Checkout.liquid
+++ b/checkout-extension/src/Checkout.liquid
@@ -1,4 +1,66 @@
-{%- if flavor contains "react" -%}
+{%- if flavor contains "preact" -%}
+import {render} from "preact";
+import {useState, useEffect} from "preact/hooks";
+
+// 1. Export the extension
+export default function() {
+  render(<Extension />, document.body)
+}
+
+function Extension() {
+  const instructions = useSubscription(shopify.instructions);
+
+  // 2. Check instructions for feature availability, see https://shopify.dev/docs/api/checkout-ui-extensions/apis/cart-instructions for details
+  if (!instructions.attributes.canUpdateAttributes) {
+    // For checkouts such as draft order invoices, cart attributes may not be allowed
+    // Consider rendering a fallback UI or nothing at all, if the feature is unavailable
+    return (
+      <s-banner title="{{ name }}" tone="warning">
+        {shopify.i18n.translate("attributeChangesAreNotSupported")}
+      </s-banner>
+    );
+  }
+
+  // 3. Render a UI
+  return (
+    <s-banner title="{{ name }}">
+      <s-stack gap="base">
+        <s-text>
+          {shopify.i18n.translate("welcome", {
+            target: <s-text type="emphasis">{shopify.extension.target}</s-text>,
+          })}
+        </s-text>
+        <s-button onClick={handleClick}>
+          {shopify.i18n.translate("addAFreeGiftToMyOrder")}
+        </s-button>
+      </s-stack>
+    </s-banner>
+  );
+
+  async function handleClick() {
+    // 4. Call the API to modify checkout
+    const result = await shopify.applyAttributeChange({
+      key: "requestedFreeGift",
+      type: "updateAttribute",
+      value: "yes",
+    });
+    console.log("applyAttributeChange result", result);
+  }
+}
+
+function useSubscription(subscribable) {
+  const [value, setValue] = useState(subscribable.current);
+
+  useEffect(() => {
+    const subscription = subscribable.subscribe(
+      () => setValue(subscribable.current)
+    );
+    return () => subscription.destroy();
+  }, [subscribable]);
+
+  return value;
+}
+{%- elsif flavor contains "react" -%}
 import {
   reactExtension,
   Banner,

--- a/checkout-extension/tsconfig.json.liquid
+++ b/checkout-extension/tsconfig.json.liquid
@@ -1,3 +1,17 @@
+{%- if flavor contains "preact" -%}
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "target": "ES2020",
+    "checkJs": true,
+    "allowJs": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true
+  },
+  "include": ["./src"]
+}
+{%- else -%}
 {
   // This tsconfig.json file is only needed to inform the IDE
   // About the `react-jsx` tsconfig option, so IDE doesn't complain about missing react import
@@ -7,3 +21,5 @@
   },
   "include": ["./src"]
 }
+{%- endif -%}
+


### PR DESCRIPTION
Fixes https://github.com/Shopify/checkout-web/issues/44281

This updates the template for newly generated Checkout UI extensions.

# 🎩 Instructions

Make sure `pnpm` is up to date

Use [this CLI snapshot](https://github.com/Shopify/cli/pull/5633)

```
pnpm i -g @shopify/cli@0.0.0-snapshot-20250410123718 --@shopify:registry=https://registry.npmjs.org
```

Check the version

```
% shopify --version
@shopify/cli/0.0.0-snapshot-20250410123718 darwin-arm64 node-v23.10.0
```

Create an app. Select _Remix_ and _TypeScript_.

```
shopify app init
```

Change into the app directory and generate an extension with this template

```
POLARIS_UNIFIED=true shopify app generate extension --clone-url https://github.com/Shopify/extensions-templates#km-checkout-templates   
```

Run the app

```
shopify app dev
```

Here's what it should look like

<details>
<summary>📸 Screenshot</summary>

<img width="873" alt="Screenshot 2025-04-10 at 5 59 59 PM" src="https://github.com/user-attachments/assets/dd0f5ca1-f990-4d17-9cb9-84a68cef5dc2" />

</details>

### Background

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
