### PR TITLE
Update customer account UI templates for 2025-07 RC

### DIFF
--- a/customer-account-extension/package.json.liquid
+++ b/customer-account-extension/package.json.liquid
@@ -1,4 +1,15 @@
-{%- if flavor contains "react" -%}
+{%- if flavor contains "preact" -%}
+{
+  "name": "{{ handle }}",
+  "private": true,
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "preact": "^10.10.x",
+    "@shopify/ui-extensions": "2025-07-rc"
+  }
+}
+{%- elsif flavor contains "react" -%}
 {
   "name": "{{ handle }}",
   "private": true,
@@ -6,8 +17,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2025.04.x",
-    "@shopify/ui-extensions-react": "2025.04.x",
+    "@shopify/ui-extensions": "2025.4.x",
+    "@shopify/ui-extensions-react": "2025.4.x",
     "react-reconciler": "0.29.0"
   },
   "devDependencies": {
@@ -21,7 +32,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2025.04.x"
+    "@shopify/ui-extensions": "2025.4.x"
   }
 }
 {%- endif -%}

--- a/customer-account-extension/shopify.extension.toml.liquid
+++ b/customer-account-extension/shopify.extension.toml.liquid
@@ -3,7 +3,11 @@
 
 # The version of APIs your extension will receive. Learn more:
 # https://shopify.dev/docs/api/usage/versioning
+{%- if flavor contains "preact" -%}
+api_version = "2025-07"
+{% else %}
 api_version = "2025-04"
+{% endif %}
 
 [[extensions]]
 name = "{{ name }}"

--- a/customer-account-extension/src/OrderStatusBlock.liquid
+++ b/customer-account-extension/src/OrderStatusBlock.liquid
@@ -1,4 +1,23 @@
-{%- if flavor contains "react" -%}
+{%- if flavor contains "preact" -%}
+
+import {render} from "preact";
+
+export default function() {
+  render(<Extension />, document.body)
+}
+
+function Extension() {
+  return (
+    <s-banner>
+      <s-stack gap="base" alignment="center">
+        <s-text>
+          {shopify.i18n.translate("earnPoints")}
+        </s-text>
+      </s-stack>
+    </s-banner>
+  );
+}
+{%- elsif flavor contains "react" -%}
 import {
   BlockStack,
   reactExtension,
@@ -25,7 +44,6 @@ function PromotionBanner() {
     </Banner>
   );
 }
-
 
 {%- else -%}
 import { extension, Banner, BlockStack, TextBlock } from '@shopify/ui-extensions/customer-account';

--- a/customer-account-extension/tsconfig.json.liquid
+++ b/customer-account-extension/tsconfig.json.liquid
@@ -1,3 +1,17 @@
+{%- if flavor contains "preact" -%}
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "target": "ES2020",
+    "checkJs": true,
+    "allowJs": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true
+  },
+  "include": ["./src"]
+}
+{%- else -%}
 {
   // This tsconfig.json file is only needed to inform the IDE
   // About the `react-jsx` tsconfig option, so IDE doesn't complain about missing react import
@@ -7,3 +21,5 @@
   },
   "include": ["./src"]
 }
+{%- endif -%}
+


### PR DESCRIPTION
This updates the template for newly generated customer account UI extensions.

# 🎩 Instructions

Make sure `pnpm` is up to date

Use [this CLI snapshot](https://github.com/Shopify/cli/pull/5633)

```
pnpm i -g @shopify/cli@0.0.0-snapshot-20250410123718 --@shopify:registry=https://registry.npmjs.org
or
npm i -g @shopify/cli@0.0.0-snapshot-20250410123718 --registry=https://registry.npmjs.org
```

Check the version

```
% shopify --version
@shopify/cli/0.0.0-snapshot-20250410123718 darwin-arm64 node-v23.10.0
```

Create an app. Select _Remix_ and _TypeScript_.

```
shopify app init
```

Change into the app directory and generate an extension with this template

```
POLARIS_UNIFIED=true shopify app generate extension --clone-url https://github.com/Shopify/extensions-templates#Update-customer-account-UI-templates-for-2025-07-RC
```

See the generated files ( cannot run for now, need checkout eomponents )
<img width="928" alt="Screenshot 2025-04-11 at 11 12 18 AM" src="https://github.com/user-attachments/assets/7fa4488b-fcee-44c4-9e06-cad5f5d63937" />


### Background

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages