### PR TITLE
Add description to ui extension sample

### DIFF
--- a/discount-details-function-settings-block/shopify.extension.toml.liquid
+++ b/discount-details-function-settings-block/shopify.extension.toml.liquid
@@ -3,6 +3,7 @@ api_version = "2024-10"
 [[extensions]]
 # Change the merchant-facing name of the extension in locales/en.default.json
 name = "t:name"
+description = "t:description"
 handle = "{{ handle }}"
 type = "ui_extension"
 {% if uid %}uid = "{{ uid }}"{% endif %}


### PR DESCRIPTION
### Background

Our [tutorial docs](https://shopify-dev.multi-class-tutorials.thomas-devisscher.us.spin.dev/docs/apps/build/discounts/build-ui-extension?extension=javascript#associate-your-discount-function-with-the-admin-ui-extension) show a sample toml file that contains a `description` entry. However, our sample is missing it which will result in a discrepancy between the tutorial and generated code.

### Solution

Adding the entry in the generated toml file.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
