### PR TITLE
Fix customer account template

### DIFF
--- a/customer-account-extension/shopify.extension.toml.liquid
+++ b/customer-account-extension/shopify.extension.toml.liquid
@@ -3,11 +3,11 @@
 
 # The version of APIs your extension will receive. Learn more:
 # https://shopify.dev/docs/api/usage/versioning
-{%- if flavor contains "preact" -%}
+{%- if flavor contains "preact" %}
 api_version = "2025-07"
-{% else %}
+{%- else %}
 api_version = "2025-04"
-{% endif %}
+{%- endif %}
 
 [[extensions]]
 name = "{{ name }}"


### PR DESCRIPTION
### Background

Fix the api version turning into

`# https://shopify.dev/docs/api/usage/versioningapi_version = "2025-07"`

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
