### PR TITLE
Remove the multi_class_discounts organizational flag

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -719,9 +719,6 @@
         "value": "wasm",
         "path": "discounts/wasm/discount/default"
       }
-    ],
-    "organizationBetaFlags": [
-      "multi_class_discounts"
     ]
   },
   {


### PR DESCRIPTION
### Background

Part of the fix for https://github.com/shop/core-issues/issues/89804.

### Solution

Removes the `multi_class_discounts` flag from the discount function template now that it has been rolled out to 100% on both:
* ExP: https://experiments.shopify.com/flags/multi_class_discounts
* Business Platform: https://business-platform.shopifycloud.com/internal/feature_flags/120/edit

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
