### PR TITLE
Import useSubscription() from ui-extensions/checkout/preact

### DIFF
--- a/checkout-extension/src/Checkout.liquid
+++ b/checkout-extension/src/Checkout.liquid
@@ -1,6 +1,6 @@
 {%- if flavor contains "preact" -%}
 import {render} from "preact";
-import {useState, useEffect} from "preact/hooks";
+import {useSubscription} from "@shopify/ui-extensions/checkout/preact"
 
 // 1. Export the extension
 export default function() {
@@ -46,19 +46,6 @@ function Extension() {
     });
     console.log("applyAttributeChange result", result);
   }
-}
-
-function useSubscription(subscribable) {
-  const [value, setValue] = useState(subscribable.current);
-
-  useEffect(() => {
-    const subscription = subscribable.subscribe(
-      () => setValue(subscribable.current)
-    );
-    return () => subscription.destroy();
-  }, [subscribable]);
-
-  return value;
 }
 {%- elsif flavor contains "react" -%}
 import {


### PR DESCRIPTION
Fixes https://github.com/Shopify/temp-project-mover-Archetypically-20250512095102/issues/190

This updates the template for newly generated Checkout UI extensions.

# 🎩 Instructions

Make sure `pnpm` is `10.9.0` or higher

Use [this CLI snapshot](https://github.com/Shopify/cli/pull/5683) from `main`.

```
pnpm i -g @shopify/cli@0.0.0-snapshot-20250423103846 --@shopify:registry=https://registry.npmjs.org
```

Check the version

```
% shopify --version
@shopify/cli@0.0.0-snapshot-20250423103846 darwin-arm64 node-v23.10.0
```

Create an app. Select _Remix_ and _TypeScript_.

```
shopify app init
```

Change into the app directory and generate a _Checkout UI_ extension with this template

```
POLARIS_UNIFIED=true shopify app generate extension --clone-url https://github.com/Shopify/extensions-templates#km-subscription-lib
```

Run the app

```
shopify app dev
```

Here's what it should look like

<details>
<summary>📸 Screenshot</summary>

<img width="865" alt="Screenshot 2025-04-23 at 12 02 42 PM" src="https://github.com/user-attachments/assets/3575b08d-1599-4c2a-b68e-f5af99d2114e" />


</details>

### Background

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
