### PR TITLE
Add preact templates for dev dash

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -32,6 +32,44 @@
     ]
   },
   {
+    "identifier": "admin_action_preact",
+    "name": "Admin action",
+    "defaultName": "admin-action",
+    "group": "Admin",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "admin-action"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "admin-action"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "admin-action"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "admin-action"
+      },
+      {
+        "name": "Preact",
+        "value": "preact",
+        "path": "admin-action"
+      }
+    ],
+    "minimumCliVersion": "3.78.1"
+  },
+  {
     "identifier": "admin_block",
     "name": "Admin block",
     "defaultName": "admin-block",
@@ -62,6 +100,44 @@
         "path": "admin-block"
       }
     ]
+  },
+  {
+    "identifier": "admin_block_preact",
+    "name": "Admin block",
+    "defaultName": "admin-block",
+    "group": "Admin",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "admin-action"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "admin-action"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "admin-action"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "admin-action"
+      },
+      {
+        "name": "Preact",
+        "value": "preact",
+        "path": "admin-block"
+      }
+    ],
+    "minimumCliVersion": "3.78.1"
   },
   {
     "identifier": "admin_print",
@@ -96,6 +172,44 @@
     ]
   },
   {
+    "identifier": "admin_print_preact",
+    "name": "Admin print action",
+    "defaultName": "admin-print",
+    "group": "Admin",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "admin-action"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "admin-action"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "admin-action"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "admin-action"
+      },
+      {
+        "name": "Preact",
+        "value": "preact",
+        "path": "admin-print-action"
+      }
+    ],
+    "minimumCliVersion": "3.78.1"
+  },
+  {
     "identifier": "admin_purchase_option",
     "name": "Admin purchase options action",
     "defaultName": "admin-purchase-option",
@@ -126,6 +240,44 @@
         "path": "admin-purchase-options-action"
       }
     ]
+  },
+  {
+    "identifier": "admin_purchase_option_preact",
+    "name": "Admin purchase options action",
+    "defaultName": "admin-purchase-options-action",
+    "group": "Admin",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "admin-action"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "admin-action"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "admin-action"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "admin-action"
+      },
+      {
+        "name": "Preact",
+        "value": "preact",
+        "path": "admin-purchase-options-action"
+      }
+    ],
+    "minimumCliVersion": "3.78.1"
   },
   {
     "identifier": "support_link",
@@ -176,6 +328,44 @@
         "path": "conditional-action-extension-ts"
       }
     ]
+  },
+  {
+    "identifier": "conditional_admin_action_preact",
+    "name": "Conditional admin action",
+    "defaultName": "conditional-admin-action",
+    "group": "Admin",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "admin-action"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "admin-action"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "admin-action"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "admin-action"
+      },
+      {
+        "name": "Preact",
+        "value": "preact",
+        "path": "conditional-action-extension-js"
+      }
+    ],
+    "minimumCliVersion": "3.78.1"
   },
   {
     "identifier": "customer_segment_template",
@@ -296,6 +486,46 @@
         "path": "product-configuration-extension"
       }
     ]
+  },
+  {
+    "identifier": "product_configuration_preact",
+    "name": "Product configuration",
+    "defaultName": "product-configuration",
+    "group": "Admin",
+    "supportLinks": [
+      "https://shopify.dev/docs/apps/selling-strategies/bundles/product-config"
+    ],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "admin-action"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "admin-action"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "admin-action"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "admin-action"
+      },
+      {
+        "name": "Preact",
+        "value": "preact",
+        "path": "product-configuration-extension"
+      }
+    ],
+    "minimumCliVersion": "3.78.1"
   },
   {
     "identifier": "subscription_link_extension",
@@ -488,6 +718,44 @@
     ]
   },
   {
+    "identifier": "customer_account_ui_preact",
+    "name": "Customer account UI",
+    "defaultName": "customer-account-ui",
+    "group": "Customer account",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "admin-action"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "admin-action"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "admin-action"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "admin-action"
+      },
+      {
+        "name": "Preact",
+        "value": "preact",
+        "path": "customer-account-extension"
+      }
+    ],
+    "minimumCliVersion": "3.78.1"
+  },
+  {
     "identifier": "checkout_ui",
     "name": "Checkout UI",
     "defaultName": "checkout-ui",
@@ -520,6 +788,46 @@
         "path": "checkout-extension"
       }
     ]
+  },
+  {
+    "identifier": "checkout_ui_preact",
+    "name": "Checkout UI",
+    "defaultName": "checkout-ui",
+    "group": "Discounts and checkout",
+    "supportLinks": [
+      "https://shopify.dev/api/checkout-extensions/checkout/configuration"
+    ],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "admin-action"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "admin-action"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "admin-action"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "admin-action"
+      },
+      {
+        "name": "Preact",
+        "value": "preact",
+        "path": "checkout-extension"
+      }
+    ],
+    "minimumCliVersion": "3.78.1"
   },
   {
     "identifier": "post_purchase_ui",


### PR DESCRIPTION
### Background

Add preact templates for dev-dash

### Tophat

1. Clone the `cli` repo and set the version to `export const CLI_KIT_VERSION = '3.78.1'`
2. Update the `TEMPLATE_JSON_URL` to be `https://raw.githubusercontent.com/Shopify/extensions-templates/41634dfde2543e707484900b689cc20f736e6219/templates.json` (raw json from this PR)
3. Run the generate command on an app under the new dev dash org `POLARIS_UNIFIED=true pnpm shopify app generate extension --path ../../../apps/test-remix --clone-url https://github.com/Shopify/extensions-templates#dev-dash-templates`
4. Verify that you can select an Admin, Checkout or Customer Account ui extension and successfully generate it

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have squashed my commits into chunks of work with meaningful commit messages
