### PR TITLE
remove s-stack for customer account preact example

### DIFF
--- a/customer-account-extension/src/OrderStatusBlock.liquid
+++ b/customer-account-extension/src/OrderStatusBlock.liquid
@@ -9,11 +9,9 @@ export default function() {
 function Extension() {
   return (
     <s-banner>
-      <s-stack gap="base" alignment="center">
-        <s-text>
-          {shopify.i18n.translate("earnPoints")}
-        </s-text>
-      </s-stack>
+      <s-text>
+        {shopify.i18n.translate("earnPoints")}
+      </s-text>
     </s-banner>
   );
 }


### PR DESCRIPTION
### Background

`alignment="center` is not valid. 

And while reviewing the example, there is no meaning to use Stack with alignment. Banner will have an info icon, and the icon will not center. 

<img width="1444" alt="Screenshot 2025-04-25 at 10 56 30 AM" src="https://github.com/user-attachments/assets/da5470fb-0130-4375-a771-b29c459a284d" />

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
