### PR TITLE
Use @shopify/ui-extensions@2025-10

### DIFF
--- a/admin-action/package.json.liquid
+++ b/admin-action/package.json.liquid
@@ -6,7 +6,7 @@
 {%- if flavor contains "preact" %}
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "2025-07-rc"
+    "@shopify/ui-extensions": "2025-10"
   }
 {%- elsif flavor contains "react" %}
   "dependencies": {

--- a/admin-block/package.json.liquid
+++ b/admin-block/package.json.liquid
@@ -6,7 +6,7 @@
 {%- if flavor contains "preact" %}
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "2025-07-rc"
+    "@shopify/ui-extensions": "2025-10"
   }
 {%- elsif flavor contains "react" %}
   "dependencies": {

--- a/admin-print-action/package.json.liquid
+++ b/admin-print-action/package.json.liquid
@@ -6,7 +6,7 @@
 {%- if flavor contains "preact" %}
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "2025-07-rc"
+    "@shopify/ui-extensions": "2025-10"
   }
 {%- elsif flavor contains "react" %}
   "dependencies": {

--- a/admin-purchase-options-action/package.json.liquid
+++ b/admin-purchase-options-action/package.json.liquid
@@ -6,7 +6,7 @@
 {%- if flavor contains "preact" %}
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "2025-07-rc"
+    "@shopify/ui-extensions": "2025-10"
   }
 {%- elsif flavor contains "react" %}
   "dependencies": {

--- a/checkout-extension/package.json.liquid
+++ b/checkout-extension/package.json.liquid
@@ -6,7 +6,7 @@
 {%- if flavor contains "preact" %}
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "2025-07-rc"
+    "@shopify/ui-extensions": "2025-10"
   }
 {%- elsif flavor contains "react" %}
   "dependencies": {

--- a/conditional-action-extension-js/package.json.liquid
+++ b/conditional-action-extension-js/package.json.liquid
@@ -6,7 +6,7 @@
 {%- if flavor contains "preact" %}
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "2025-07-rc"
+    "@shopify/ui-extensions": "2025-10"
   }
 {%- elsif flavor contains "react" %}
   "dependencies": {

--- a/customer-account-extension/package.json.liquid
+++ b/customer-account-extension/package.json.liquid
@@ -6,7 +6,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "2025-07-rc"
+    "@shopify/ui-extensions": "2025-10"
   }
 }
 {%- elsif flavor contains "react" -%}

--- a/product-configuration-extension/package.json.liquid
+++ b/product-configuration-extension/package.json.liquid
@@ -6,7 +6,7 @@
 {%- if flavor contains "preact" -%}
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "2025-07-rc"
+    "@shopify/ui-extensions": "2025-10"
   }
 {%- elsif flavor contains "react" -%}
   "dependencies": {


### PR DESCRIPTION
### Background
Related to https://github.com/Shopify/app-ui/issues/2220

### Solution

Use new 2025-10 tag as 2025-07-rc has already been converted back to remote-ui.

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have squashed my commits into chunks of work with meaningful commit messages
