### PR TITLE
create default config for card present payment extensions

### DIFF
--- a/payments-app-extension-card-present/shopify.extension.toml.liquid
+++ b/payments-app-extension-card-present/shopify.extension.toml.liquid
@@ -1,0 +1,26 @@
+# The version of APIs your extension will receive. Learn more:
+# https://shopify.dev/docs/api/usage/versioning
+api_version = "2025-04"
+
+[[extensions]]
+name = "{{ name }}"
+handle = "{{ handle }}"
+type = "payments_extension"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+
+merchant_label = "Card Present Payments App Extension"
+payment_session_url = "https://api.paymentprovider.com/endpoint"
+refund_session_url = "https://api.paymentprovider.com/refund"
+capture_session_url = "https://api.paymentprovider.com/capture"
+void_session_url = "https://api.paymentprovider.com/void"
+sync_terminal_transaction_result_url = "https://api.paymentprovider.com/terminal-result"
+# List of ISO 3166 (alpha-2) country codes your app is available for installation by merchants. Learn more:
+# https://www.iso.org/iso-3166-country-codes.html
+supported_countries = ["US"]
+# List payment method names that your payment extension will support. Learn more:
+# https://github.com/activemerchant/payment_icons/blob/master/db/payment_icons.yml
+supported_payment_methods = ["visa"]
+test_mode_available = true
+
+[[extensions.targeting]]
+target = "payments.card-present.render"

--- a/templates.json
+++ b/templates.json
@@ -1359,6 +1359,27 @@
     ]
   },
   {
+    "identifier": "card_present_payments",
+    "name": "Card Present",
+    "defaultName": "Card Present",
+    "group": "Payments App Extension",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "payments_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "payments-app-extension-card-present"
+      }
+    ],
+    "organizationBetaFlags": [
+      "cli_payment_extensions",
+      "card_present_payment_extensions"
+    ]
+  },
+  {
     "identifier": "credit_card_payments",
     "name": "Credit Card",
     "defaultName": "Credit Card",


### PR DESCRIPTION
### Background

- closes https://github.com/shop/issues-retail-on-payments-platform/issues/172

Create the default toml file for the new Card Present payment app extension. 

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
