### PR TITLE
Update templates to use kebab case slot names

### DIFF
--- a/admin-action/src/ActionExtension.liquid
+++ b/admin-action/src/ActionExtension.liquid
@@ -44,11 +44,11 @@ function Extension() {
         <s-text type="strong">{i18n.translate('welcome', {target})}</s-text>
         <s-text>Current product: {productTitle}</s-text>
       </s-stack>
-      <s-button slot="primaryAction" onClick={() => {
+      <s-button slot="primary-action" onClick={() => {
           console.log('saving');
           close();
         }}>Done</s-button>
-      <s-button slot="secondaryAction" onClick={() => {
+      <s-button slot="secondary-actions" onClick={() => {
           console.log('closing');
           close();
       }}>Close</s-button>

--- a/admin-purchase-options-action/src/PurchaseOptionsActionExtension.liquid
+++ b/admin-purchase-options-action/src/PurchaseOptionsActionExtension.liquid
@@ -40,8 +40,8 @@ export default function PurchaseOptionsActionExtension() {
 
   return (
     <s-admin-action>
-      <s-button slot="primaryAction" onClick={handleSave}>Save</s-button>
-      <s-button slot="secondaryAction" onClick={() => {
+      <s-button slot="primary-action" onClick={handleSave}>Save</s-button>
+      <s-button slot="secondary-actions" onClick={() => {
         console.log('closing');
         close();
         }}>Cancel</s-button>

--- a/conditional-action-extension-js/src/ActionExtension.liquid
+++ b/conditional-action-extension-js/src/ActionExtension.liquid
@@ -43,11 +43,11 @@ function Extension() {
         <s-text type="strong">{i18n.translate('welcome', {target})}</s-text>
         <s-text>Current product: {productTitle}</s-text>
       </s-stack>
-      <s-button slot="primaryAction" onClick={() => {
+      <s-button slot="primary-action" onClick={() => {
           console.log('saving');
           close();
         }}>Done</s-button>
-      <s-button slot="secondaryAction" onClick={() => {
+      <s-button slot="secondary-actions" onClick={() => {
           console.log('closing');
           close();
       }}>Close</s-button>


### PR DESCRIPTION
### Background

The `ui-extensions` have been updated to use kebab case.

### Solution

This PR updates the templates to follow the new casing convention.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
