### PR TITLE
Add terminal management extension.

### DIFF
--- a/terminal-management/shopify.extension.toml.liquid
+++ b/terminal-management/shopify.extension.toml.liquid
@@ -1,0 +1,8 @@
+api_version = "2025-07"
+name = "{{ name }}"
+type = "terminal_management"
+
+terminals_url = "https://api.paymentprovider.com/terminals"
+terminal_status_url = "https://api.paymentprovider.com/terminal/status"
+# This is the page on your website where merchants can go to diagnose problems.
+terminal_diagnostic_page_url = "https://paymentprovider.com/help"


### PR DESCRIPTION
### Background

Part of issue https://github.com/shop/issues-retail-on-payments-platform/issues/49

RPP is no longer just enabling cloud terminals, but local terminals as well. Because of this we're renaming the extension to the more general terminal_management_extension.
### Solution

Rename extension specification and relevant fields

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
