### PR TITLE
Fix type issues in Admin preact templates

### DIFF
--- a/admin-block/src/BlockExtension.liquid
+++ b/admin-block/src/BlockExtension.liquid
@@ -38,7 +38,7 @@ function App() {
 
   return (
     // The AdminBlock component provides an API for setting the title of the Block extension wrapper.
-    <AdminBlock title="My Block Extension">
+    <AdminBlock heading="My Block Extension">
       <BlockStack>
         <Text fontWeight="bold">{i18n.translate('welcome', {target: TARGET})}</Text>
       </BlockStack>

--- a/admin-purchase-options-action/src/PurchaseOptionsActionExtension.liquid
+++ b/admin-purchase-options-action/src/PurchaseOptionsActionExtension.liquid
@@ -51,18 +51,18 @@ export default function PurchaseOptionsActionExtension() {
           label="Title"
           placeholder="Subscribe and save"
           value={planName}
-          onChange={(event) => setPlanName(event.target.value)}
+          onChange={(event) => setPlanName(event.currentTarget.value)}
         />
         <s-text-field
           label="Internal description"
           value={merchantCode}
-          onChange={(event) => setMerchantCode(event.target.value)}
+          onChange={(event) => setMerchantCode(event.currentTarget.value)}
         />
         <s-box>
           <s-choice-list
             name="discountType"
             values={[discountType]}
-            onChange={(e) => setDiscountType(e.target.values[0])}
+            onChange={(e) => setDiscountType(e.currentTarget.values[0])}
           >
             <s-choice value="percentageOff">Percentage off</s-choice>
             <s-choice value="amountOff">Amount off</s-choice>


### PR DESCRIPTION
### Background

- Changed the `title` prop to `heading` in the `AdminBlock` component to align with the correct API
- Updated event handlers in form elements to use `event.currentTarget` instead to get proper typing

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have squashed my commits into chunks of work with meaningful commit messages