### PR TITLE
Rename cli_payment_extensions feature flag to payments_extensions

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -1375,7 +1375,7 @@
       }
     ],
     "organizationBetaFlags": [
-      "cli_payment_extensions"
+      "payments_extensions"
     ]
   },
   {
@@ -1395,7 +1395,7 @@
       }
     ],
     "organizationBetaFlags": [
-      "cli_payment_extensions"
+      "payments_extensions"
     ]
   },
   {
@@ -1415,7 +1415,7 @@
       }
     ],
     "organizationBetaFlags": [
-      "cli_payment_extensions"
+      "payments_extensions"
     ]
   },
   {
@@ -1435,7 +1435,7 @@
       }
     ],
     "organizationBetaFlags": [
-      "cli_payment_extensions"
+      "payments_extensions"
     ]
   },
   {
@@ -1455,7 +1455,7 @@
       }
     ],
     "organizationBetaFlags": [
-      "cli_payment_extensions"
+      "payments_extensions"
     ]
   },
   {


### PR DESCRIPTION
### Background

See [Rename cli_payment_extensions feature flag to payments_extensions #285](https://github.com/shop/issues-payment-partners/issues/285).

