### PR TITLE
Rename cli_payment_extensions feature flag to payments_extensions for card-present

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -1375,7 +1375,7 @@
       }
     ],
     "organizationBetaFlags": [
-      "cli_payment_extensions",
+      "payments_extensions",
       "card_present_payment_extensions"
     ]
   },

--- a/templates.json
+++ b/templates.json
@@ -1376,7 +1376,7 @@
     ],
     "organizationBetaFlags": [
       "payments_extensions",
-      "card_present_payment_extensions"
+      "payments_extensions_card_present"
     ]
   },
   {


### PR DESCRIPTION
### Background

Rename `cli_payment_extensions` feature flag to `payments_extensions` for card-present, as already done for the other payment extensions with https://github.com/Shopify/extensions-templates/pull/241. Card-present was added to this repo concomitantly with 
- https://github.com/Shopify/extensions-templates/pull/241 
  by 
- https://github.com/Shopify/extensions-templates/pull/236

Part of https://github.com/shop/issues-payment-partners/issues/285.


