### PR TITLE
Add individual payments extensions feature flags

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -1396,7 +1396,8 @@
       }
     ],
     "organizationBetaFlags": [
-      "payments_extensions"
+      "payments_extensions",
+      "payments_extensions_card_present"
     ]
   },
   {
@@ -1416,7 +1417,8 @@
       }
     ],
     "organizationBetaFlags": [
-      "payments_extensions"
+      "payments_extensions",
+      "payments_extensions_custom_credit_card"
     ]
   },
   {
@@ -1436,7 +1438,8 @@
       }
     ],
     "organizationBetaFlags": [
-      "payments_extensions"
+      "payments_extensions",
+      "payments_extensions_custom_onsite"
     ]
   },
   {
@@ -1476,7 +1479,8 @@
       }
     ],
     "organizationBetaFlags": [
-      "payments_extensions"
+      "payments_extensions",
+      "payments_extensions_redeemable"
     ]
   },
   {

--- a/templates.json
+++ b/templates.json
@@ -1397,7 +1397,7 @@
     ],
     "organizationBetaFlags": [
       "payments_extensions",
-      "payments_extensions_card_present"
+      "payments_extensions_credit_card"
     ]
   },
   {


### PR DESCRIPTION
### Background

The shopify CLI filters which payment extension can be created by a developer based on feature flags. The CLI load `templates.json` at run time, to load which organizational feature flags apply to a given extension.

In `templates.json`, we presently gate all the payments extensions being the `payments_extensions` feature flag.

Each payments extension type has its own specific organizational feature flag that will be checked by plugins in `core`, to prevent that an extension is deployed if the feature flag is not enabled. These specific flags have been introduced by https://github.com/Shopify/business-platform/pull/26938. The offsite payment extension is an exception and it is not gated by a specific feature flag, because it is not gated today, before the migration to the business platform.

Before this PR, the card-present  payment extension is the only payments extension that is also gated by its specific `payments_extensions_card_present` feature flag in `templates.json`. In this state, the card present extension won't be included in the extensions exposed by the CLI. 
This is not consistent with the other payments extensions, making it possibly confusing for shopifolks and 3P developers.

Part of https://github.com/shop/issues-payment-partners/issues/152.

### Solution 
This PR adds the specific feature flags so the behavior is consistent across all payments extensions, except for the offsite payments extension because it is not meant to be gated other than with the non-specific `payments_extensions` feature flag.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
