### PR TITLE
downgrade js function vitest dependency to support node 21

### DIFF
--- a/functions-cart-checkout-validation-js/package.json.liquid
+++ b/functions-cart-checkout-validation-js/package.json.liquid
@@ -28,6 +28,6 @@
     "@shopify/shopify_function": "2.0.0-rc.0"
   },
   "devDependencies": {
-    "vitest": "^3.1.3"
+   "vitest": "2.1.9"
   }
 }

--- a/functions-cart-transform-js/package.json.liquid
+++ b/functions-cart-transform-js/package.json.liquid
@@ -28,6 +28,6 @@
     "@shopify/shopify_function": "2.0.0-rc.0"
   },
   "devDependencies": {
-    "vitest": "^3.1.3"
+   "vitest": "2.1.9"
   }
 }

--- a/functions-delivery-customization-js/package.json.liquid
+++ b/functions-delivery-customization-js/package.json.liquid
@@ -28,6 +28,6 @@
     "@shopify/shopify_function": "2.0.0-rc.0"
   },
   "devDependencies": {
-    "vitest": "^3.1.3"
+   "vitest": "2.1.9"
   }
 }

--- a/functions-discount-js/package.json.liquid
+++ b/functions-discount-js/package.json.liquid
@@ -28,6 +28,6 @@
     "@shopify/shopify_function": "2.0.0-rc.0"
   },
   "devDependencies": {
-    "vitest": "^3.1.3"
+   "vitest": "2.1.9"
   }
 }

--- a/functions-discounts-allocator-js/package.json.liquid
+++ b/functions-discounts-allocator-js/package.json.liquid
@@ -25,7 +25,7 @@
     }
   },
   "devDependencies": {
-    "vitest": "^3.1.3"
+   "vitest": "2.1.9"
   },
   "dependencies": {
     "decimal.js": "^10.5.0",

--- a/functions-fulfillment-constraints-js/package.json.liquid
+++ b/functions-fulfillment-constraints-js/package.json.liquid
@@ -28,6 +28,6 @@
     "@shopify/shopify_function": "2.0.0-rc.0"
   },
   "devDependencies": {
-    "vitest": "^3.1.3"
+   "vitest": "2.1.9"
   }
 }

--- a/functions-local-pickup-delivery-option-generators-js/package.json.liquid
+++ b/functions-local-pickup-delivery-option-generators-js/package.json.liquid
@@ -28,6 +28,6 @@
     "@shopify/shopify_function": "2.0.0-rc.0"
   },
   "devDependencies": {
-    "vitest": "^3.1.3"
+   "vitest": "2.1.9"
   }
 }

--- a/functions-location-rules-js/package.json.liquid
+++ b/functions-location-rules-js/package.json.liquid
@@ -28,6 +28,6 @@
     "@shopify/shopify_function": "2.0.0-rc.0"
   },
   "devDependencies": {
-    "vitest": "^3.1.3"
+   "vitest": "2.1.9"
   }
 }

--- a/functions-order-discounts-js/package.json.liquid
+++ b/functions-order-discounts-js/package.json.liquid
@@ -28,6 +28,6 @@
     "@shopify/shopify_function": "2.0.0-rc.0"
   },
   "devDependencies": {
-    "vitest": "^3.1.3"
+   "vitest": "2.1.9"
   }
 }

--- a/functions-payment-customization-js/package.json.liquid
+++ b/functions-payment-customization-js/package.json.liquid
@@ -28,6 +28,6 @@
     "@shopify/shopify_function": "2.0.0-rc.0"
   },
   "devDependencies": {
-    "vitest": "^3.1.3"
+   "vitest": "2.1.9"
   }
 }

--- a/functions-pickup-point-delivery-option-generators-js/package.json.liquid
+++ b/functions-pickup-point-delivery-option-generators-js/package.json.liquid
@@ -28,6 +28,6 @@
     "@shopify/shopify_function": "2.0.0-rc.0"
   },
   "devDependencies": {
-    "vitest": "^3.1.3"
+   "vitest": "2.1.9"
   }
 }

--- a/functions-pickup-point-delivery-option-generators-ts/package.json.liquid
+++ b/functions-pickup-point-delivery-option-generators-ts/package.json.liquid
@@ -25,6 +25,6 @@
     }
   },
   "devDependencies": {
-    "vitest": "^3.1.3"
+   "vitest": "2.1.9"
   }
 }

--- a/functions-product-discounts-js/package.json.liquid
+++ b/functions-product-discounts-js/package.json.liquid
@@ -28,6 +28,6 @@
     "@shopify/shopify_function": "2.0.0-rc.0"
   },
   "devDependencies": {
-    "vitest": "^3.1.3"
+   "vitest": "2.1.9"
   }
 }

--- a/functions-shipping-discounts-js/package.json.liquid
+++ b/functions-shipping-discounts-js/package.json.liquid
@@ -28,6 +28,6 @@
     "@shopify/shopify_function": "2.0.0-rc.0"
   },
   "devDependencies": {
-    "vitest": "^3.1.3"
+   "vitest": "2.1.9"
   }
 }


### PR DESCRIPTION
### Background

Vitest 3.1.3 uses [Vite 6+](https://github.com/vitest-dev/vitest/blob/6e8d9377949b78957a2a617b922925250c80fbcb/package.json#L66), which in turn [does not support node 21](https://github.com/vitejs/vite/blob/5fdcfe77a93ca7bc90a5427a2a20eceaee1c4da1/package.json#L5-L7).

The CLI [currently supports node 21](https://shopify.dev/docs/api/shopify-cli#requirements), so our templates need to work on that version.

### Solution
Downgrades vitest dep in our function js templates to v2.
Did a find and replace of ` "vitest": "^3.1.3"` -> `"vitest": "2.1.9"` in all `package.json.liquid` files.

### Tophat
Ran `npm install` within my function directory with various versions of `node` and the `vitest` dep.

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have squashed my commits into chunks of work with meaningful commit messages
