### PR TITLE
60654: Add draft orders template

### DIFF
--- a/pos-ui-extension-draft-order-details/package.json.liquid
+++ b/pos-ui-extension-draft-order-details/package.json.liquid
@@ -1,0 +1,27 @@
+{%- if flavor contains "react" -%}
+{
+  "name": "{{ handle }}",
+  "private": true,
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "react": "^18.0.0",
+    "@shopify/ui-extensions": "2025.4.x",
+    "@shopify/ui-extensions-react": "2025.4.x",
+    "react-reconciler": "0.29.0"
+  }{% if flavor contains "typescript" %},
+  "devDependencies": {
+    "@types/react": "^18.0.0"
+  }{% endif %}
+}
+{%- else -%}
+{
+  "name": "{{ handle }}",
+  "private": true,
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "@shopify/ui-extensions": "2025.4.x"
+  }
+}
+{%- endif -%}

--- a/pos-ui-extension-draft-order-details/shopify.extension.toml.liquid
+++ b/pos-ui-extension-draft-order-details/shopify.extension.toml.liquid
@@ -1,0 +1,24 @@
+# The version of APIs your extension will receive. Learn more:
+# https://shopify.dev/docs/api/usage/versioning
+api_version = "2025-04"
+
+[[extensions]]
+type = "ui_extension"
+name = "{{ name }}"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+handle = "{{ handle }}"
+description = "A {{ flavor }} POS UI extension"
+
+# Controls where in POS your extension will be injected,
+# and the file that contains your extension’s source code.
+[[extensions.targeting]]
+module = "./src/Action.{{ srcFileExtension }}"
+target = "pos.draft-order-details.action.render"
+
+[[extensions.targeting]]
+module = "./src/Block.{{ srcFileExtension }}"
+target = "pos.draft-order-details.block.render"
+
+[[extensions.targeting]]
+module = "./src/MenuItem.{{ srcFileExtension }}"
+target = "pos.draft-order-details.action.menu-item.render"

--- a/pos-ui-extension-draft-order-details/src/Action.liquid
+++ b/pos-ui-extension-draft-order-details/src/Action.liquid
@@ -1,0 +1,58 @@
+{%- if flavor contains "react" -%}
+import React from 'react';
+
+import {
+  Text,
+  Screen,
+  ScrollView,
+  Navigator,
+  reactExtension,
+  useApi,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const Modal = () => {
+  {% if flavor contains "typescript" %}const api = useApi<"pos.draft-order-details.action.render">();
+  {% else %}const api = useApi();
+  {% endif %}
+  return (
+    <Navigator>
+      <Screen name="DraftOrderDetailsAction" title="Draft Order Details Action">
+        <ScrollView>
+          <Text>{`Draft Order ID: ${api.draftOrder.id}`}</Text>
+        </ScrollView>
+      </Screen>
+    </Navigator>
+  );
+};
+
+export default reactExtension('pos.draft-order-details.action.render', () => (
+  <Modal />
+));
+{%- else -%}
+import {
+  Navigator,
+  Screen,
+  ScrollView,
+  Text,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension(
+  'pos.draft-order-details.action.render',
+  (root, api) => {
+    const navigator = root.createComponent(Navigator);
+    const screen = root.createComponent(Screen, {
+      name: 'DraftOrderDetailsAction',
+      title: 'Draft Order Details Action',
+    });
+    const scrollView = root.createComponent(ScrollView);
+    const text = root.createComponent(Text);
+
+    text.append(`ID for current draft order screen: ${api.draftOrder.id}`);
+    scrollView.append(text);
+    screen.append(scrollView);
+    navigator.append(screen);
+    root.append(navigator);
+  },
+);
+{%- endif -%}

--- a/pos-ui-extension-draft-order-details/src/Block.liquid
+++ b/pos-ui-extension-draft-order-details/src/Block.liquid
@@ -1,0 +1,58 @@
+{%- if flavor contains "react" -%}
+import React from 'react';
+
+import {
+  Text,
+  useApi,
+  reactExtension,
+  POSBlock,
+  POSBlockRow,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const Block = () => {
+  {% if flavor contains "typescript" %}const api = useApi<"pos.draft-order-details.block.render">();
+  {% else %}const api = useApi();
+  {% endif %}
+  {% raw %}return (
+    <POSBlock action={{title: 'Open action', onPress: api.action.presentModal}}>
+      <POSBlockRow>
+        <Text>{'This is a block extension'}</Text>
+        <Text>{`Draft Order ID for this draft order: ${api.draftOrder.id}`}</Text>
+      </POSBlockRow>
+    </POSBlock>
+  );{% endraw %}
+};
+
+export default reactExtension('pos.draft-order-details.block.render', () => (
+  <Block />
+));
+{%- else -%}
+import {
+  POSBlock,
+  Text,
+  POSBlockRow,
+  extension,
+} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension('pos.draft-order-details.block.render', (root, api) => {
+  const block = root.createComponent(POSBlock, {
+    action: {title: 'Open action', onPress: api.action.presentModal},
+  });
+
+  const mainText = root.createComponent(Text);
+  mainText.append('This is a block extension');
+
+  const subtitleText = root.createComponent(Text);
+  subtitleText.append(`Draft Order ID for this draft order: ${api.draftOrder.id}`);
+
+  const blockMainRow = root.createComponent(POSBlockRow);
+  blockMainRow.append(mainText);
+
+  const blockSubtitleRow = root.createComponent(POSBlockRow);
+  blockSubtitleRow.append(subtitleText);
+  block.append(blockMainRow);
+  block.append(blockSubtitleRow);
+
+  root.append(block);
+});
+{%- endif -%}

--- a/pos-ui-extension-draft-order-details/src/MenuItem.liquid
+++ b/pos-ui-extension-draft-order-details/src/MenuItem.liquid
@@ -1,0 +1,35 @@
+{%- if flavor contains "react" -%}
+import React from 'react';
+import {
+  reactExtension,
+  Button,
+  useApi,
+} from '@shopify/ui-extensions-react/point-of-sale';
+
+const ButtonComponent = () => {
+  {% if flavor contains "typescript" %}const api = useApi<"pos.draft-order-details.action.menu-item.render">();
+  {% else %}const api = useApi();
+  {% endif %}
+  return <Button onPress={() => api.action.presentModal()} />;
+};
+
+export default reactExtension(
+  'pos.draft-order-details.action.menu-item.render',
+  () => <ButtonComponent />,
+);
+{%- else -%}
+import {Button, extension} from '@shopify/ui-extensions/point-of-sale';
+
+export default extension(
+  'pos.draft-order-details.action.menu-item.render',
+  (root, api) => {
+    const button = root.createComponent(Button, {
+      onPress: () => {
+        api.action.presentModal();
+      },
+    });
+
+    root.append(button);
+  },
+);
+{%- endif -%}

--- a/templates.json
+++ b/templates.json
@@ -1607,6 +1607,38 @@
     ]
   },
   {
+    "identifier": "pos_ui_draft_order_details",
+    "name": "POS UI Draft Order Details",
+    "defaultName": "pos-ui-draft-order-details",
+    "group": "Point-of-Sale",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "pos_ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "pos-ui-extension-draft-order-details"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "pos-ui-extension-draft-order-details"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "pos-ui-extension-draft-order-details"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "pos-ui-extension-draft-order-details"
+      }
+    ]
+  },
+  {
     "identifier": "pos_ui_post_purchase",
     "name": "POS UI Post Purchase",
     "defaultName": "pos-ui-post-purchase",


### PR DESCRIPTION
### Background

Add draft orders template
Relates to https://github.com/Shopify/pos-next-react-native/issues/60654

Note: pos.draft-order-details.block.render seems to have the wrong AllowedComponents type (ActionComponents instead of BlockComponents)

Fixed in https://github.com/Shopify/ui-extensions/pull/2897. Switch ui-extensions to `0.0.0-snapshot-20250520192734` when tophatting to avoid typing issues in this pr.


### Solution

Tophat

1. Go to cli
2. `pnpm shopify app generate extension --clone-url="https://github.com/Shopify/extensions-templates#andy-chhuon/60654-add-pos-ui-draft-orders-template" --path ./your-app-root`

If the above doesn't work (can't see template in input list), replace `extensionTemplates` in `packages/app/src/cli/services/generate.ts` [L43](https://github.com/Shopify/cli/blob/main/packages/app/src/cli/services/generate.ts#L43) with

```js
  const extensionTemplates = await fetch(
    'https://raw.githubusercontent.com/Shopify/extensions-templates/refs/heads/andy-chhuon/60654-add-pos-ui-draft-orders-template/templates.json?cache_bust=fdsfsdsf',
  )
    .then((res) => res.json())
    .then((data) => data as ExtensionTemplate[])
```

Tophat screencapture:
https://share.descript.com/view/U8rvTDlwG9P

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
