### PR TITLE
60654: rename pos ui smart grid

### DIFF
--- a/pos-ui-extension-smart-grid/package.json.liquid
+++ b/pos-ui-extension-smart-grid/package.json.liquid
@@ -1,0 +1,27 @@
+{%- if flavor contains "react" -%}
+{
+  "name": "{{ handle }}",
+  "private": true,
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "react": "^18.0.0",
+    "@shopify/ui-extensions": "2025.4.x",
+    "@shopify/ui-extensions-react": "2025.4.x",
+    "react-reconciler": "0.29.0"
+  }{% if flavor contains "typescript" %},
+  "devDependencies": {
+    "@types/react": "^18.0.0"
+  }{% endif %}
+}
+{%- else -%}
+{
+  "name": "{{ handle }}",
+  "private": true,
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "@shopify/ui-extensions": "2025.4.x"
+  }
+}
+{%- endif -%}

--- a/pos-ui-extension-smart-grid/shopify.extension.toml.liquid
+++ b/pos-ui-extension-smart-grid/shopify.extension.toml.liquid
@@ -1,0 +1,20 @@
+# The version of APIs your extension will receive. Learn more:
+# https://shopify.dev/docs/api/usage/versioning
+api_version = "2025-04"
+
+[[extensions]]
+type = "ui_extension"
+name = "{{ name }}"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+handle = "{{ handle }}"
+description = "A {{ flavor }} POS UI extension"
+
+# Controls where in POS your extension will be injected,
+# and the file that contains your extension’s source code.
+[[extensions.targeting]]
+module = "./src/Tile.{{ srcFileExtension }}"
+target = "pos.home.tile.render"
+
+[[extensions.targeting]]
+module = "./src/Modal.{{ srcFileExtension }}"
+target = "pos.home.modal.render"

--- a/pos-ui-extension-smart-grid/src/Modal.liquid
+++ b/pos-ui-extension-smart-grid/src/Modal.liquid
@@ -1,0 +1,34 @@
+{%- if flavor contains "react" -%}
+import React from 'react'
+
+import { Text, Screen, ScrollView, Navigator, reactExtension } from '@shopify/ui-extensions-react/point-of-sale'
+
+const Modal = () => {
+  return (
+    <Navigator>
+      <Screen name="HelloWorld" title="Hello World!">
+        <ScrollView>
+          <Text>Welcome to the extension!</Text>
+        </ScrollView>
+      </Screen>
+    </Navigator>
+  )
+}
+
+export default reactExtension('pos.home.modal.render', () => <Modal />);
+{%- else -%}
+import { Navigator, Screen, ScrollView, Text, extension } from '@shopify/ui-extensions/point-of-sale'
+
+export default extension('pos.home.modal.render', (root) => {
+    const navigator = root.createComponent(Navigator);
+    const screen = root.createComponent(Screen, { name: "HelloWorld", title: "Hello World!" });
+    const scrollView = root.createComponent(ScrollView);
+    const text = root.createComponent(Text);
+
+    text.append("Welcome to the extension!")
+    scrollView.append(text);
+    screen.append(scrollView);
+    navigator.append(screen);
+    root.append(navigator);
+});
+{%- endif -%}

--- a/pos-ui-extension-smart-grid/src/Tile.liquid
+++ b/pos-ui-extension-smart-grid/src/Tile.liquid
@@ -1,0 +1,37 @@
+{%- if flavor contains "react" -%}
+import React from 'react'
+
+import { Tile, reactExtension, useApi } from '@shopify/ui-extensions-react/point-of-sale'
+
+const TileComponent = () => {
+  const api = useApi()
+  return (
+    <Tile
+      title="My app"
+      subtitle="SmartGrid {{ flavor }} Extension"
+      onPress={() => {
+        api.action.presentModal()
+      }}
+      enabled
+    />
+  )
+}
+
+export default reactExtension('pos.home.tile.render', () => {
+  return <TileComponent />
+})
+{%- else -%}
+import {extension, Tile} from '@shopify/ui-extensions/point-of-sale'
+
+export default extension('pos.home.tile.render', (root, api) => {
+    const tile = root.createComponent(Tile, {
+        title: "My app",
+        subtitle: "SmartGrid {{ flavor }} Extension",
+        onPress: () => api.action.presentModal(),
+        enabled: true
+    });
+
+    root.append(tile);
+});
+
+{%- endif -%}

--- a/templates.json
+++ b/templates.json
@@ -1479,9 +1479,9 @@
     ]
   },
   {
-    "identifier": "pos_ui",
-    "name": "POS UI",
-    "defaultName": "pos-ui",
+    "identifier": "pos_ui_smart_grid",
+    "name": "POS UI Smart Grid",
+    "defaultName": "pos-ui-smart-grid",
     "group": "Point-of-Sale",
     "supportLinks": [],
     "url": "https://github.com/Shopify/extensions-templates",
@@ -1491,22 +1491,22 @@
       {
         "name": "JavaScript React",
         "value": "react",
-        "path": "pos-ui-extension"
+        "path": "pos-ui-extension-smart-grid"
       },
       {
         "name": "JavaScript",
         "value": "vanilla-js",
-        "path": "pos-ui-extension"
+        "path": "pos-ui-extension-smart-grid"
       },
       {
         "name": "TypeScript React",
         "value": "typescript-react",
-        "path": "pos-ui-extension"
+        "path": "pos-ui-extension-smart-grid"
       },
       {
         "name": "TypeScript",
         "value": "typescript",
-        "path": "pos-ui-extension"
+        "path": "pos-ui-extension-smart-grid"
       }
     ]
   },


### PR DESCRIPTION
### Background
Relates to https://github.com/Shopify/pos-next-react-native/issues/60654

Rename pos ui smart grid

### Solution

Tophat

1. Go to cli
2. `pnpm shopify app generate extension --clone-url="https://github.com/Shopify/extensions-templates#andy-chhuon/60654-rename-pos-ui-smartgrid" --path ./your-app-root`

If the above doesn't work (can't see template in input list), replace `extensionTemplates` in `packages/app/src/cli/services/generate.ts` [L43](https://github.com/Shopify/cli/blob/main/packages/app/src/cli/services/generate.ts#L43) with

```js
  const extensionTemplates = await fetch(
    'https://raw.githubusercontent.com/Shopify/extensions-templates/refs/heads/andy-chhuon/60654-rename-pos-ui-smartgrid/templates.json?cache_bust=fdsfsdsf',
  )
    .then((res) => res.json())
    .then((data) => data as ExtensionTemplate[])
```

Tophat screencapture:
https://share.descript.com/view/ClvWr9yk7T2

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
