### PR TITLE
Bump Functions JS template package to 2.0.0

### DIFF
--- a/functions-cart-checkout-validation-js/package.json.liquid
+++ b/functions-cart-checkout-validation-js/package.json.liquid
@@ -25,7 +25,7 @@
     }
   },
   "dependencies": {
-    "@shopify/shopify_function": "2.0.0-rc.0"
+    "@shopify/shopify_function": "2.0.0"
   },
   "devDependencies": {
    "vitest": "2.1.9"

--- a/functions-cart-transform-js/package.json.liquid
+++ b/functions-cart-transform-js/package.json.liquid
@@ -25,7 +25,7 @@
     }
   },
   "dependencies": {
-    "@shopify/shopify_function": "2.0.0-rc.0"
+    "@shopify/shopify_function": "2.0.0"
   },
   "devDependencies": {
    "vitest": "2.1.9"

--- a/functions-delivery-customization-js/package.json.liquid
+++ b/functions-delivery-customization-js/package.json.liquid
@@ -25,7 +25,7 @@
     }
   },
   "dependencies": {
-    "@shopify/shopify_function": "2.0.0-rc.0"
+    "@shopify/shopify_function": "2.0.0"
   },
   "devDependencies": {
    "vitest": "2.1.9"

--- a/functions-discount-js/package.json.liquid
+++ b/functions-discount-js/package.json.liquid
@@ -25,7 +25,7 @@
     }
   },
   "dependencies": {
-    "@shopify/shopify_function": "2.0.0-rc.0"
+    "@shopify/shopify_function": "2.0.0"
   },
   "devDependencies": {
    "vitest": "2.1.9"

--- a/functions-discounts-allocator-js/package.json.liquid
+++ b/functions-discounts-allocator-js/package.json.liquid
@@ -29,6 +29,6 @@
   },
   "dependencies": {
     "decimal.js": "^10.5.0",
-    "@shopify/shopify_function": "2.0.0-rc.0"
+    "@shopify/shopify_function": "2.0.0"
   }
 }

--- a/functions-fulfillment-constraints-js/package.json.liquid
+++ b/functions-fulfillment-constraints-js/package.json.liquid
@@ -25,7 +25,7 @@
     }
   },
   "dependencies": {
-    "@shopify/shopify_function": "2.0.0-rc.0"
+    "@shopify/shopify_function": "2.0.0"
   },
   "devDependencies": {
    "vitest": "2.1.9"

--- a/functions-local-pickup-delivery-option-generators-js/package.json.liquid
+++ b/functions-local-pickup-delivery-option-generators-js/package.json.liquid
@@ -25,7 +25,7 @@
     }
   },
   "dependencies": {
-    "@shopify/shopify_function": "2.0.0-rc.0"
+    "@shopify/shopify_function": "2.0.0"
   },
   "devDependencies": {
    "vitest": "2.1.9"

--- a/functions-location-rules-js/package.json.liquid
+++ b/functions-location-rules-js/package.json.liquid
@@ -25,7 +25,7 @@
     }
   },
   "dependencies": {
-    "@shopify/shopify_function": "2.0.0-rc.0"
+    "@shopify/shopify_function": "2.0.0"
   },
   "devDependencies": {
    "vitest": "2.1.9"

--- a/functions-order-discounts-js/package.json.liquid
+++ b/functions-order-discounts-js/package.json.liquid
@@ -25,7 +25,7 @@
     }
   },
   "dependencies": {
-    "@shopify/shopify_function": "2.0.0-rc.0"
+    "@shopify/shopify_function": "2.0.0"
   },
   "devDependencies": {
    "vitest": "2.1.9"

--- a/functions-payment-customization-js/package.json.liquid
+++ b/functions-payment-customization-js/package.json.liquid
@@ -25,7 +25,7 @@
     }
   },
   "dependencies": {
-    "@shopify/shopify_function": "2.0.0-rc.0"
+    "@shopify/shopify_function": "2.0.0"
   },
   "devDependencies": {
    "vitest": "2.1.9"

--- a/functions-pickup-point-delivery-option-generators-js/package.json.liquid
+++ b/functions-pickup-point-delivery-option-generators-js/package.json.liquid
@@ -25,7 +25,7 @@
     }
   },
   "dependencies": {
-    "@shopify/shopify_function": "2.0.0-rc.0"
+    "@shopify/shopify_function": "2.0.0"
   },
   "devDependencies": {
    "vitest": "2.1.9"

--- a/functions-product-discounts-js/package.json.liquid
+++ b/functions-product-discounts-js/package.json.liquid
@@ -25,7 +25,7 @@
     }
   },
   "dependencies": {
-    "@shopify/shopify_function": "2.0.0-rc.0"
+    "@shopify/shopify_function": "2.0.0"
   },
   "devDependencies": {
    "vitest": "2.1.9"

--- a/functions-shipping-discounts-js/package.json.liquid
+++ b/functions-shipping-discounts-js/package.json.liquid
@@ -25,7 +25,7 @@
     }
   },
   "dependencies": {
-    "@shopify/shopify_function": "2.0.0-rc.0"
+    "@shopify/shopify_function": "2.0.0"
   },
   "devDependencies": {
    "vitest": "2.1.9"


### PR DESCRIPTION
### Background

We've released 2.0.0 so don't need to use the RC version anymore

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
