### PR TITLE
Apply Preact side effect for future-proofing

### DIFF
--- a/checkout-extension/src/Checkout.liquid
+++ b/checkout-extension/src/Checkout.liquid
@@ -1,4 +1,5 @@
 {%- if flavor contains "preact" -%}
+import '@shopify/ui-extensions/preact';
 import {render} from "preact";
 import {useSubscription} from "@shopify/ui-extensions/checkout/preact"
 


### PR DESCRIPTION
### Background

We have decided ([internal decision](https://docs.google.com/document/d/1Asx-neu8JgEnCeB_Z7lbk61PLydA56YxHrwpzP6EzzQ/edit?tab=t.0#heading=h.nyyxyhny0fzo)) to support Preact signals via side-effect import. It's not implemented yet but I'd like to add this to the template so that extensions are more likely to include the import. It won't do any harm.

### Solution

Future proof extensions created from the template.

# 🎩 

Make sure `pnpm` is `10.9.0` or higher

Use the latest CLI

```
pnpm i -g @shopify/cli@latest --@shopify:registry=https://registry.npmjs.org
```

Check the version

```
shopify --version                                                           
@shopify/cli/3.80.3 darwin-arm64 node-v23.10.0
```

Create an app. Select _Remix_ and _TypeScript_.

```
shopify app init
```

Change into the app directory and generate a _Checkout UI_ extension with this template

```
POLARIS_UNIFIED=true shopify app generate extension --clone-url https://github.com/Shopify/extensions-templates#km-preact-side-effect
```

Run the app

```
shopify app dev
```

Here's what it should look like

<details>
<summary>📸 Screenshot</summary>

<img width="820" alt="Screenshot 2025-05-21 at 1 32 07 PM" src="https://github.com/user-attachments/assets/2860bdd9-69b1-4a5c-a572-c69595860c7f" />



</details>

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
