### PR TITLE
Import preact side effect for setting up signals binding

### DIFF
--- a/admin-block/src/BlockExtension.liquid
+++ b/admin-block/src/BlockExtension.liquid
@@ -1,4 +1,5 @@
 {%- if flavor contains "preact" -%}
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
 export default function extension() {

--- a/admin-print-action/src/PrintActionExtension.liquid
+++ b/admin-print-action/src/PrintActionExtension.liquid
@@ -1,4 +1,5 @@
 {%- if flavor contains "preact" -%}
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 

--- a/conditional-action-extension-js/src/ActionExtension.liquid
+++ b/conditional-action-extension-js/src/ActionExtension.liquid
@@ -1,4 +1,5 @@
 {%- if flavor contains "preact" -%}
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 

--- a/customer-account-extension/src/OrderStatusBlock.liquid
+++ b/customer-account-extension/src/OrderStatusBlock.liquid
@@ -1,5 +1,5 @@
 {%- if flavor contains "preact" -%}
-
+import '@shopify/ui-extensions/preact';
 import {render} from "preact";
 
 export default function() {

--- a/product-configuration-extension/src/ProductDetailsConfigurationExtension.liquid
+++ b/product-configuration-extension/src/ProductDetailsConfigurationExtension.liquid
@@ -1,4 +1,5 @@
 {%- if flavor contains "preact" -%}
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 import {useState, useEffect} from 'preact/hooks';
 

--- a/product-configuration-extension/src/ProductVariantDetailsConfigurationExtension.liquid
+++ b/product-configuration-extension/src/ProductVariantDetailsConfigurationExtension.liquid
@@ -1,4 +1,5 @@
 {%- if flavor contains "preact" -%}
+import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 import {useState, useEffect} from 'preact/hooks';
 


### PR DESCRIPTION
### Background

This PR adds the missing import for `@shopify/ui-extensions/preact` across multiple extension templates to ensure proper functionality of Preact-based UI extensions.

### Solution

Added the import statement `import '@shopify/ui-extensions/preact';` to all Preact-flavored extension templates. This import is necessary to properly initialize the Preact environment for Shopify UI extensions and ensure all required dependencies are available at runtime.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages