### PR TITLE
Fix remote ui template paths

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -116,22 +116,22 @@
       {
         "name": "JavaScript React",
         "value": "react",
-        "path": "admin-action"
+        "path": "admin-block"
       },
       {
         "name": "JavaScript",
         "value": "vanilla-js",
-        "path": "admin-action"
+        "path": "admin-block"
       },
       {
         "name": "TypeScript React",
         "value": "typescript-react",
-        "path": "admin-action"
+        "path": "admin-block"
       },
       {
         "name": "TypeScript",
         "value": "typescript",
-        "path": "admin-action"
+        "path": "admin-block"
       },
       {
         "name": "Preact",
@@ -187,7 +187,7 @@
       {
         "name": "JavaScript React",
         "value": "react",
-        "path": "admin-action"
+        "path": "admin-print-action"
       },
       {
         "name": "JavaScript",


### PR DESCRIPTION
### Background

The paths for various JavaScript and TypeScript templates in the templates.json file are incorrect, pointing to "admin-action" when they should be pointing to different locations.
