### PR TITLE
Update function-discount-rs shopify.extension.toml.liquid input_query path

### DIFF
--- a/functions-discount-rs/shopify.extension.toml.liquid
+++ b/functions-discount-rs/shopify.extension.toml.liquid
@@ -14,7 +14,7 @@ description = "t:description"
 
   [[extensions.targeting]]
   target = "cart.delivery-options.discounts.generate.run"
-  input_query = "src/generate_delivery_run.graphql"
+  input_query = "src/cart_delivery_options_discounts_generate_run.graphql"
   export = "cart_delivery_options_discounts_generate_run"
 
   [extensions.build]


### PR DESCRIPTION
This input_query value errors because the file does not exist. 
 This pr updates the function-discount-rs input_query to point to the correct file.

### Background

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
