### PR TITLE
Bump `shopify_function` Rust crate to `1.1.0`

### DIFF
--- a/functions-cart-checkout-validation-rs/Cargo.toml.liquid
+++ b/functions-cart-checkout-validation-rs/Cargo.toml.liquid
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-shopify_function = "1.0.0"
+shopify_function = "1.1.0"
 
 [profile.release]
 lto = true

--- a/functions-cart-transform-rs/Cargo.toml.liquid
+++ b/functions-cart-transform-rs/Cargo.toml.liquid
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-shopify_function = "1.0.0"
+shopify_function = "1.1.0"
 
 [profile.release]
 lto = true

--- a/functions-delivery-customization-rs/Cargo.toml.liquid
+++ b/functions-delivery-customization-rs/Cargo.toml.liquid
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-shopify_function = "1.0.0"
+shopify_function = "1.1.0"
 
 [profile.release]
 lto = true

--- a/functions-discount-rs/Cargo.toml.liquid
+++ b/functions-discount-rs/Cargo.toml.liquid
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-shopify_function = "1.0.0"
+shopify_function = "1.1.0"
 
 [profile.release]
 lto = true

--- a/functions-discounts-allocator-rs/Cargo.toml.liquid
+++ b/functions-discounts-allocator-rs/Cargo.toml.liquid
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-shopify_function = "1.0.0"
+shopify_function = "1.1.0"
 
 [profile.release]
 lto = true

--- a/functions-fulfillment-constraints-rs/Cargo.toml.liquid
+++ b/functions-fulfillment-constraints-rs/Cargo.toml.liquid
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-shopify_function = "1.0.0"
+shopify_function = "1.1.0"
 
 [profile.release]
 lto = true

--- a/functions-local-pickup-delivery-option-generators-rs/Cargo.toml.liquid
+++ b/functions-local-pickup-delivery-option-generators-rs/Cargo.toml.liquid
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-shopify_function = "1.0.0"
+shopify_function = "1.1.0"
 
 [profile.release]
 lto = true

--- a/functions-location-rules-rs/Cargo.toml.liquid
+++ b/functions-location-rules-rs/Cargo.toml.liquid
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-shopify_function = "1.0.0"
+shopify_function = "1.1.0"
 
 [profile.release]
 lto = true

--- a/functions-order-discounts-rs/Cargo.toml.liquid
+++ b/functions-order-discounts-rs/Cargo.toml.liquid
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-shopify_function = "1.0.0"
+shopify_function = "1.1.0"
 
 [profile.release]
 lto = true

--- a/functions-payment-customization-rs/Cargo.toml.liquid
+++ b/functions-payment-customization-rs/Cargo.toml.liquid
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-shopify_function = "1.0.0"
+shopify_function = "1.1.0"
 
 [profile.release]
 lto = true

--- a/functions-pickup-point-delivery-option-generators-rs/Cargo.toml.liquid
+++ b/functions-pickup-point-delivery-option-generators-rs/Cargo.toml.liquid
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0.13", features = ["derive"] }
 serde_json = "1.0"
-shopify_function = "1.0.0"
+shopify_function = "1.1.0"
 
 [profile.release]
 lto = true

--- a/functions-product-discounts-rs/Cargo.toml.liquid
+++ b/functions-product-discounts-rs/Cargo.toml.liquid
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-shopify_function = "1.0.0"
+shopify_function = "1.1.0"
 
 [profile.release]
 lto = true

--- a/functions-shipping-discounts-rs/Cargo.toml.liquid
+++ b/functions-shipping-discounts-rs/Cargo.toml.liquid
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-shopify_function = "1.0.0"
+shopify_function = "1.1.0"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
### Background

We released a new version of `shopify_function` Rust crate with some new functionality and bug fixes.

### Solution

Update the templates to use the new version.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
