### PR TITLE
Replace named `default` `extension` with anon func

### DIFF
--- a/admin-action/src/ActionExtension.liquid
+++ b/admin-action/src/ActionExtension.liquid
@@ -2,7 +2,7 @@
 import {render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/admin-block/src/BlockExtension.liquid
+++ b/admin-block/src/BlockExtension.liquid
@@ -1,7 +1,7 @@
 {%- if flavor contains "preact" -%}
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/admin-print-action/src/PrintActionExtension.liquid
+++ b/admin-print-action/src/PrintActionExtension.liquid
@@ -4,7 +4,7 @@ import {useEffect, useState} from 'preact/hooks';
 
 const baseSrc = `https://cdn.shopify.com/static/extensibility/print-example`;
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/admin-purchase-options-action/src/ProductExtension.liquid
+++ b/admin-purchase-options-action/src/ProductExtension.liquid
@@ -2,7 +2,7 @@
 import {render} from 'preact';
 import PurchaseOptionsActionExtension from './PurchaseOptionsActionExtension';
 
-export default function extension() {
+export default async () => {
   render(<PurchaseOptionsActionExtension />, document.body);
 }
 {%- elsif flavor contains "react" -%}

--- a/admin-purchase-options-action/src/ProductVariantExtension.liquid
+++ b/admin-purchase-options-action/src/ProductVariantExtension.liquid
@@ -2,7 +2,7 @@
 import {render} from 'preact';
 import PurchaseOptionsActionExtension from './PurchaseOptionsActionExtension';
 
-export default function extension() {
+export default async () => {
   render(<PurchaseOptionsActionExtension />, document.body);
 }
 {%- elsif flavor contains "react" -%}

--- a/conditional-action-extension-js/src/ActionExtension.liquid
+++ b/conditional-action-extension-js/src/ActionExtension.liquid
@@ -2,7 +2,7 @@
 import {render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/order-routing-location-rule/src/OrderRoutingLocationRule.liquid
+++ b/order-routing-location-rule/src/OrderRoutingLocationRule.liquid
@@ -1,6 +1,6 @@
 import {render} from 'preact';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/product-configuration-extension/src/ProductDetailsConfigurationExtension.liquid
+++ b/product-configuration-extension/src/ProductDetailsConfigurationExtension.liquid
@@ -2,7 +2,7 @@
 import {render} from 'preact';
 import {useState, useEffect} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/product-configuration-extension/src/ProductVariantDetailsConfigurationExtension.liquid
+++ b/product-configuration-extension/src/ProductVariantDetailsConfigurationExtension.liquid
@@ -2,7 +2,7 @@
 import {render} from 'preact';
 import {useState, useEffect} from 'preact/hooks';
 
-export default function extension() {
+export default async () => {
   render(<Extension />, document.body);
 }
 


### PR DESCRIPTION
## TLDR

Replace named `default` `extension` function with anonymous `default` function

```diff
- export default function extension() {
+ export default async () => {
```

Closes https://github.com/Shopify/admin-ui-foundations/issues/2933

### Background

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
