### PR TITLE
Update Link to Product Configuration Extension Documentation in Template

### DIFF
--- a/product-configuration-extension/README.md
+++ b/product-configuration-extension/README.md
@@ -1,5 +1,5 @@
 # Product Configuration Extension
 
 The Product Configuration extensions let app developers build custom functionality at defined points in
-the Product Details and Product Variant Details sections of the Shopify Admin experience. 
-You can learn more about Product Configuration extensions in Shopify’s [developer documentation](https://shopify.dev/docs/apps/selling-strategies/bundles/product-config).
+the Product Details and Product Variant Details sections of the Shopify Admin experience.
+You can learn more about Product Configuration extensions in Shopify’s [developer documentation](https://shopify.dev/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui).


### PR DESCRIPTION
### Background

Updated the documentation link for Product Configuration extensions to reflect the new path in the developer documentation.

### Solution

The PR updates the link in the README.md file to point to the correct location in Shopify's developer documentation. The new URL (`https://shopify.dev/docs/apps/build/product-merchandising/bundles/product-configuration-extension/add-merchant-config-ui`) replaces the outdated one (`https://shopify.dev/docs/apps/selling-strategies/bundles/product-config`), ensuring developers are directed to the most current documentation.

Also removed an extra space at the end of the line above the link for consistent formatting.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages