### PR TITLE
Add Test cert in the credit card extension config by default

### DIFF
--- a/payments-app-extension-credit-card/shopify.extension.toml.liquid
+++ b/payments-app-extension-credit-card/shopify.extension.toml.liquid
@@ -24,7 +24,7 @@ supports_3ds = false
 supports_installments = false
 supports_deferred_payments = false
 test_mode_available = true
-encryption_certificate_fingerprint = ""
+encryption_certificate_fingerprint = "Test Certificate"
 
 [[extensions.targeting]]
 target = "payments.credit-card.render"


### PR DESCRIPTION
Fix the template so the CLI does not automatically fail on `shopify app dev/deploy` due to missing cert. config

### Background

N/A

### Solution

Decided to include the Test Certificate by default in the template. This is an acceptable fallback initially when registering a new credit card extension.

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
