### PR TITLE
Updates to make naming and order more consistent

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -1076,7 +1076,7 @@
   },
   {
     "identifier": "order_discounts",
-    "name": "Order discounts",
+    "name": "Order discount",
     "defaultName": "order-discount",
     "group": "Functions",
     "supportLinks": [
@@ -1110,7 +1110,7 @@
   },
   {
     "identifier": "product_discounts",
-    "name": "Product discounts",
+    "name": "Product discount",
     "defaultName": "product-discount",
     "group": "Functions",
     "supportLinks": [
@@ -1144,7 +1144,7 @@
   },
   {
     "identifier": "shipping_discounts",
-    "name": "Shipping discounts",
+    "name": "Shipping discount",
     "defaultName": "shipping-discount",
     "group": "Functions",
     "supportLinks": [
@@ -1212,7 +1212,7 @@
   },
   {
     "identifier": "fulfillment_constraints",
-    "name": "Fulfillment constraints",
+    "name": "Fulfillment constraint",
     "defaultName": "fulfillment-constraints",
     "group": "Functions",
     "supportLinks": [],

--- a/templates.json
+++ b/templates.json
@@ -109,40 +109,6 @@
     ]
   },
   {
-    "identifier": "validation_settings_ui",
-    "name": "Validation settings",
-    "defaultName": "validation-settings-ui",
-    "group": "UI extensions",
-    "supportLinks": [
-      "https://shopify.dev/docs/apps/checkout/validation/server-side"
-    ],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "ui_extension",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "JavaScript React",
-        "value": "react",
-        "path": "validation-settings"
-      },
-      {
-        "name": "JavaScript",
-        "value": "vanilla-js",
-        "path": "validation-settings"
-      },
-      {
-        "name": "TypeScript React",
-        "value": "typescript-react",
-        "path": "validation-settings"
-      },
-      {
-        "name": "TypeScript",
-        "value": "typescript",
-        "path": "validation-settings"
-      }
-    ]
-  },
-  {
     "identifier": "customer_account_ui",
     "name": "Customer account UI",
     "defaultName": "customer-account-ui",
@@ -605,40 +571,6 @@
     ]
   },
   {
-    "identifier": "discount_details_function_settings",
-    "name": "Discount Function settings",
-    "defaultName": "Discount Function Settings",
-    "group": "UI extensions",
-    "supportLinks": [
-      "https://shopify.dev/docs/apps/discounts"
-    ],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "ui_extension",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "JavaScript React",
-        "value": "react",
-        "path": "discount-details-function-settings-block"
-      },
-      {
-        "name": "JavaScript",
-        "value": "vanilla-js",
-        "path": "discount-details-function-settings-block"
-      },
-      {
-        "name": "TypeScript React",
-        "value": "typescript-react",
-        "path": "discount-details-function-settings-block"
-      },
-      {
-        "name": "TypeScript",
-        "value": "typescript",
-        "path": "discount-details-function-settings-block"
-      }
-    ]
-  },
-  {
     "identifier": "product_configuration",
     "name": "Product configuration",
     "defaultName": "product-configuration",
@@ -714,8 +646,76 @@
     "minimumCliVersion": "3.78.2"
   },
   {
+    "identifier": "discount_details_function_settings",
+    "name": "Discount function settings",
+    "defaultName": "Discount function settings",
+    "group": "UI extensions",
+    "supportLinks": [
+      "https://shopify.dev/docs/apps/discounts"
+    ],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "discount-details-function-settings-block"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "discount-details-function-settings-block"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "discount-details-function-settings-block"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "discount-details-function-settings-block"
+      }
+    ]
+  },
+  {
+    "identifier": "validation_settings_ui",
+    "name": "Cart and checkout validation function settings",
+    "defaultName": "validation-settings-ui",
+    "group": "UI extensions",
+    "supportLinks": [
+      "https://shopify.dev/docs/apps/checkout/validation/server-side"
+    ],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "JavaScript React",
+        "value": "react",
+        "path": "validation-settings"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "validation-settings"
+      },
+      {
+        "name": "TypeScript React",
+        "value": "typescript-react",
+        "path": "validation-settings"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "validation-settings"
+      }
+    ]
+  },
+  {
     "identifier": "order_routing_location_rule_ui",
-    "name": "Order routing location rule",
+    "name": "Order routing location rule function settings",
     "defaultName": "order-routing-location-rule-ui",
     "group": "UI extensions",
     "supportLinks": [
@@ -1041,40 +1041,6 @@
     ]
   },
   {
-    "identifier": "order_discounts",
-    "name": "Discount orders",
-    "defaultName": "order-discount",
-    "group": "Functions",
-    "supportLinks": [
-      "https://shopify.dev/docs/apps/discounts"
-    ],
-    "url": "https://github.com/Shopify/extensions-templates",
-    "type": "function",
-    "extensionPoints": [],
-    "supportedFlavors": [
-      {
-        "name": "Rust",
-        "value": "rust",
-        "path": "functions-order-discounts-rs"
-      },
-      {
-        "name": "JavaScript",
-        "value": "vanilla-js",
-        "path": "functions-order-discounts-js"
-      },
-      {
-        "name": "TypeScript",
-        "value": "typescript",
-        "path": "functions-order-discounts-js"
-      },
-      {
-        "name": "Wasm",
-        "value": "wasm",
-        "path": "functions-order-discounts-wasm"
-      }
-    ]
-  },
-  {
     "identifier": "discount",
     "name": "Discount",
     "defaultName": "discount-function",
@@ -1105,6 +1071,40 @@
         "name": "Wasm",
         "value": "wasm",
         "path": "functions-discount-wasm"
+      }
+    ]
+  },
+  {
+    "identifier": "order_discounts",
+    "name": "Order discounts",
+    "defaultName": "order-discount",
+    "group": "Functions",
+    "supportLinks": [
+      "https://shopify.dev/docs/apps/discounts"
+    ],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "function",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Rust",
+        "value": "rust",
+        "path": "functions-order-discounts-rs"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "functions-order-discounts-js"
+      },
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "functions-order-discounts-js"
+      },
+      {
+        "name": "Wasm",
+        "value": "wasm",
+        "path": "functions-order-discounts-wasm"
       }
     ]
   },
@@ -1244,7 +1244,7 @@
   },
   {
     "identifier": "local_pickup_delivery_option_generator",
-    "name": "Local pickup delivery option generators",
+    "name": "Local pickup delivery option generator",
     "defaultName": "local-pickup-delivery-option-generators",
     "group": "Functions",
     "supportLinks": [],


### PR DESCRIPTION
A few tweaks to the new template grouping to make the names and order in the list more consistent for UI Extensions and Functions.

Issues resolved:
* UI Extensions
   * `Validation settings` wasn't named consistently with its equivalent Function
   * Function settings weren't consistently named or grouped together
* Functions
  * Pluralization wasn't consistent
  * `Discount orders` wasn't named consistently w/ other legacy discounts
  * `Discount orders` appeared before the new multi-class `Discount` option

|  | Before | After |
|-|-|-|
| UI Extensions | ![image](https://github.com/user-attachments/assets/ce513b31-d368-4368-a22a-89f55e427479) |  ![image](https://github.com/user-attachments/assets/e66152fc-8e8a-470f-82a2-570996cdc7ba) |
| Functions | ![image](https://github.com/user-attachments/assets/30913507-3210-4206-a04d-d5227be95a3b) |  ![image](https://github.com/user-attachments/assets/8564e858-6b3c-4e44-9f61-4b32441ca826) |

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
