### PR TITLE
update checkout cli templates with 2025-07 stable version

### DIFF
--- a/checkout-extension/package.json.liquid
+++ b/checkout-extension/package.json.liquid
@@ -11,8 +11,8 @@
 {%- elsif flavor contains "react" %}
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2025.4.x",
-    "@shopify/ui-extensions-react": "2025.4.x",
+    "@shopify/ui-extensions": "2025.7.x",
+    "@shopify/ui-extensions-react": "2025.7.x",
     "react-reconciler": "0.29.0"
   },
   "devDependencies": {
@@ -20,7 +20,7 @@
   }
 {%- else %}
   "dependencies": {
-    "@shopify/ui-extensions": "2025.4.x"
+    "@shopify/ui-extensions": "2025.7.x"
   }
 {%- endif %}
 }

--- a/checkout-extension/shopify.extension.toml.liquid
+++ b/checkout-extension/shopify.extension.toml.liquid
@@ -6,7 +6,7 @@
 {%- if flavor contains "preact" %}
 api_version = "2025-10"
 {%- else %}
-api_version = "2025-04"
+api_version = "2025-07"
 {%- endif %}
 
 [[extensions]]


### PR DESCRIPTION
ui-extensions 2025-07 version release as latest stable, updating cli templates to match this new stable version

# 🎩 

Make sure `pnpm` is `10.9.0` or higher

Use the latest CLI

```
pnpm i -g @shopify/cli@latest --@shopify:registry=https://registry.npmjs.org
```

Create an app. Select _Remix_ and _TypeScript_.

```
shopify app init
```

Change into the app directory and generate a _Checkout UI_ extension with this template

```
shopify app generate extension --clone-url https://github.com/Shopify/extensions-templates#07-03-update_checkout_cli_templates_with_2025-07_stable_version
```

When prompted, create a react/typescript extension and ensure package.json of extension references `2025.7.x` for ui-extensions and ui-extensions-react

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/f0eauGjqTpa48KjfElr8/bddfef57-d8bc-4e6e-a686-4dea767c43d7.png)

and that extensions toml file reference `2025-07` as api version

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/f0eauGjqTpa48KjfElr8/39bc8d93-ef37-4ac0-b00c-ee979c5f99e9.png)

I did the same steps above for creating an extension with a TS extension (non-react) as well and ensured similar changes

```
npm run dev
```

and make sure extensions render and function properly

