### PR TITLE
Fix rs format macro errors

### DIFF
--- a/functions-pickup-point-delivery-option-generators-rs/src/fetch.rs
+++ b/functions-pickup-point-delivery-option-generators-rs/src/fetch.rs
@@ -23,8 +23,7 @@ fn fetch(input: schema::fetch::Input) -> Result<schema::FunctionFetchResult> {
 fn build_external_api_request(latitude: &f64, longitude: &f64) -> schema::HttpRequest {
     // The latitude and longitude parameters are included in the URL for demonstration purposes only. They do not influence the result.
     let url = format!(
-        "https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api-v2.json?v=1714588690&lat={}&lon={}",
-        latitude, longitude
+        "https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api-v2.json?v=1714588690&lat={latitude}&lon={longitude}",
     );
 
     schema::HttpRequest {

--- a/functions-pickup-point-delivery-option-generators-rs/src/run.rs
+++ b/functions-pickup-point-delivery-option-generators-rs/src/run.rs
@@ -192,7 +192,7 @@ fn format_time(time: &str) -> TimeWithoutTimezone {
         _ => hour,
     };
 
-    format!("{:02}:{:02}:00", hour_in_24_format, min)
+    format!("{hour_in_24_format:02}:{min:02}:00")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Background

CI seems to be failing on main.

`cargo clippy -- -D warnings`

```
error: variables can be used directly in the `format!` string
  --> functions-pickup-point-delivery-option-generators-rs/src/fetch.rs:25:15
   |
25 |       let url = format!(
   |  _______________^
26 | |         "https://cdn.shopify.com/s/files/1/0628/3830/9033/files/pickup-points-external-api-v2.json?v=1714588690&lat={}&lon={}",
27 | |         latitude, longitude
28 | |     );
   | |_____^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
   = note: `-D clippy::uninlined-format-args` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::uninlined_format_args)]`

error: variables can be used directly in the `format!` string
   --> functions-pickup-point-delivery-option-generators-rs/src/run.rs:195:5
    |
195 |     format!("{:02}:{:02}:00", hour_in_24_format, min)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
help: change this to
    |
195 -     format!("{:02}:{:02}:00", hour_in_24_format, min)
195 +     format!("{hour_in_24_format:02}:{min:02}:00")
    |

error: could not compile `functions-pickup-point-delivery-option-generators` (bin "functions-pickup-point-delivery-option-generators") due to 2 previous errors
```

### Solution

Make the appropriate changes:
https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
