### PR TITLE
Expand liquid wasm support

### DIFF
--- a/.github/scripts/expand-liquid.js
+++ b/.github/scripts/expand-liquid.js
@@ -32,13 +32,26 @@ async function directoryNames(parentPath) {
 
 async function expandExtensionLiquidTemplates(projectName, flavor) {
   console.log(`Expanding liquid templates for ${projectName}`);
-  const pathSuffix =
-    flavor === "typescript" || flavor === "vanilla-js" ? "js" : "rs";
-  const projectPath = path.join(process.cwd(), projectName + "-" + pathSuffix);
-  const langName =
-    flavor === "typescript" || flavor === "vanilla-js" ? "javascript" : "rust";
 
-  if (langName === "javascript") {
+  let pathSuffix;
+  switch (flavor) {
+    case "typescript":
+    case "vanilla-js":
+      pathSuffix = "js";
+      break;
+    case "rust":
+      pathSuffix = "rs";
+      break;
+    case "wasm":
+      pathSuffix = "wasm";
+      break;
+    default:
+      throw(`Unrecognized language ${flavor}.`);
+  }
+
+  const projectPath = path.join(process.cwd(), projectName + "-" + pathSuffix);
+
+  if (flavor === "typescript" || flavor === "vanilla-js") {
     await (
       await glob(path.join(projectPath, "src", "!(*.liquid|*.graphql)"))
     ).forEach(async (path) => await fs.rm(path));
@@ -52,7 +65,7 @@ async function expandExtensionLiquidTemplates(projectName, flavor) {
 
   await expandLiquidTemplates(projectPath, liquidData);
 
-  if (langName === "javascript") {
+  if (flavor === "typescript" || flavor === "vanilla-js") {
     const srcFilePaths = await glob(
       path.join(projectPath, "src", "!(*.liquid|*.graphql)")
     );

--- a/.github/workflows/validate-wasm-functions.yml
+++ b/.github/workflows/validate-wasm-functions.yml
@@ -1,0 +1,21 @@
+name: Validate WASM Functions
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "functions-*-wasm/**"
+      - ".github/workflows/validate-wasm-functions.yml"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install node dependencies
+        run: yarn
+      - name: Expand liquid for TypeScript functions
+        run: CI=1 yarn expand-liquid wasm

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ yarn expand-liquid [rust|vanilla-js|typescript] <project-name-without-suffix>
 
 # optionally specify only the language argument to expand all functions projects for that language
 yarn expand-liquid rust
-yarn expand-liquid vanilla-js
 yarn expand-liquid typescript
+yarn expand-liquid vanilla-js
+yarn expand-liquid wasm
 ```
 
 ### JavaScript / TypeScript


### PR DESCRIPTION
### Background

There was no way to expand `wasm` example liquid files.

### Solution

Add support to `yarn expand-liquid wasm`

It's not quite doing anything else than that for now (no actual CI steps) but it's a start toward parity of `wasm` with the rest.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
