### PR TITLE
Update POS UI Extensions for 2025-07

### DIFF
--- a/pos-ui-extension-customer-details/package.json.liquid
+++ b/pos-ui-extension-customer-details/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2025.4.x",
-    "@shopify/ui-extensions-react": "2025.4.x",
+    "@shopify/ui-extensions": "2025.7.x",
+    "@shopify/ui-extensions-react": "2025.7.x",
     "react-reconciler": "0.29.0"
   }{% if flavor contains "typescript" %},
   "devDependencies": {
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2025.4.x"
+    "@shopify/ui-extensions": "2025.7.x"
   }
 }
 {%- endif -%}

--- a/pos-ui-extension-customer-details/shopify.extension.toml.liquid
+++ b/pos-ui-extension-customer-details/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 # The version of APIs your extension will receive. Learn more:
 # https://shopify.dev/docs/api/usage/versioning
-api_version = "2025-04"
+api_version = "2025-07"
 
 [[extensions]]
 type = "ui_extension"

--- a/pos-ui-extension-draft-order-details/package.json.liquid
+++ b/pos-ui-extension-draft-order-details/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2025.4.x",
-    "@shopify/ui-extensions-react": "2025.4.x",
+    "@shopify/ui-extensions": "2025.7.x",
+    "@shopify/ui-extensions-react": "2025.7.x",
     "react-reconciler": "0.29.0"
   }{% if flavor contains "typescript" %},
   "devDependencies": {
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2025.4.x"
+    "@shopify/ui-extensions": "2025.7.x"
   }
 }
 {%- endif -%}

--- a/pos-ui-extension-draft-order-details/shopify.extension.toml.liquid
+++ b/pos-ui-extension-draft-order-details/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 # The version of APIs your extension will receive. Learn more:
 # https://shopify.dev/docs/api/usage/versioning
-api_version = "2025-04"
+api_version = "2025-07"
 
 [[extensions]]
 type = "ui_extension"

--- a/pos-ui-extension-order-details/package.json.liquid
+++ b/pos-ui-extension-order-details/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2025.4.x",
-    "@shopify/ui-extensions-react": "2025.4.x",
+    "@shopify/ui-extensions": "2025.7.x",
+    "@shopify/ui-extensions-react": "2025.7.x",
     "react-reconciler": "0.29.0"
   }{% if flavor contains "typescript" %},
   "devDependencies": {
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2025.4.x"
+    "@shopify/ui-extensions": "2025.7.x"
   }
 }
 {%- endif -%}

--- a/pos-ui-extension-order-details/shopify.extension.toml.liquid
+++ b/pos-ui-extension-order-details/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 # The version of APIs your extension will receive. Learn more:
 # https://shopify.dev/docs/api/usage/versioning
-api_version = "2025-04"
+api_version = "2025-07"
 
 [[extensions]]
 type = "ui_extension"

--- a/pos-ui-extension-post-purchase/package.json.liquid
+++ b/pos-ui-extension-post-purchase/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2025.4.x",
-    "@shopify/ui-extensions-react": "2025.4.x",
+    "@shopify/ui-extensions": "2025.7.x",
+    "@shopify/ui-extensions-react": "2025.7.x",
     "react-reconciler": "0.29.0"
   }{% if flavor contains "typescript" %},
   "devDependencies": {
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2025.4.x"
+    "@shopify/ui-extensions": "2025.7.x"
   }
 }
 {%- endif -%}

--- a/pos-ui-extension-post-purchase/shopify.extension.toml.liquid
+++ b/pos-ui-extension-post-purchase/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 # The version of APIs your extension will receive. Learn more:
 # https://shopify.dev/docs/api/usage/versioning
-api_version = "2025-04"
+api_version = "2025-07"
 
 [[extensions]]
 type = "ui_extension"

--- a/pos-ui-extension-product-details/package.json.liquid
+++ b/pos-ui-extension-product-details/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2025.4.x",
-    "@shopify/ui-extensions-react": "2025.4.x",
+    "@shopify/ui-extensions": "2025.7.x",
+    "@shopify/ui-extensions-react": "2025.7.x",
     "react-reconciler": "0.29.0"
   }{% if flavor contains "typescript" %},
   "devDependencies": {
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2025.4.x"
+    "@shopify/ui-extensions": "2025.7.x"
   }
 }
 {%- endif -%}

--- a/pos-ui-extension-product-details/shopify.extension.toml.liquid
+++ b/pos-ui-extension-product-details/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 # The version of APIs your extension will receive. Learn more:
 # https://shopify.dev/docs/api/usage/versioning
-api_version = "2025-04"
+api_version = "2025-07"
 
 [[extensions]]
 type = "ui_extension"

--- a/pos-ui-extension-smart-grid/package.json.liquid
+++ b/pos-ui-extension-smart-grid/package.json.liquid
@@ -6,8 +6,8 @@
   "license": "UNLICENSED",
   "dependencies": {
     "react": "^18.0.0",
-    "@shopify/ui-extensions": "2025.4.x",
-    "@shopify/ui-extensions-react": "2025.4.x",
+    "@shopify/ui-extensions": "2025.7.x",
+    "@shopify/ui-extensions-react": "2025.7.x",
     "react-reconciler": "0.29.0"
   }{% if flavor contains "typescript" %},
   "devDependencies": {
@@ -21,7 +21,7 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "2025.4.x"
+    "@shopify/ui-extensions": "2025.7.x"
   }
 }
 {%- endif -%}

--- a/pos-ui-extension-smart-grid/shopify.extension.toml.liquid
+++ b/pos-ui-extension-smart-grid/shopify.extension.toml.liquid
@@ -1,6 +1,6 @@
 # The version of APIs your extension will receive. Learn more:
 # https://shopify.dev/docs/api/usage/versioning
-api_version = "2025-04"
+api_version = "2025-07"
 
 [[extensions]]
 type = "ui_extension"


### PR DESCRIPTION
### Background
Related to https://github.com/shop/issues-retail/issues/1907
Updating all POS UI extensions to use the latest API version (2025-07) and corresponding dependency versions.

### Solution

This PR updates all POS UI extension templates to use the 2025-07 API version instead of 2025-04. The changes include:

- Updated `api_version` from "2025-04" to "2025-07" in all `shopify.extension.toml.liquid` files
- Updated `@shopify/ui-extensions` and `@shopify/ui-extensions-react` dependencies from "2025.4.x" to "2025.7.x" in all `package.json.liquid` files

These updates ensure that all POS UI extensions use the latest available API version and corresponding dependencies.

### Checklist

- [X] I have :tophat:'d these changes
- [X] I have squashed my commits into chunks of work with meaningful commit messages