### PR TITLE
update readme to link to guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repo contains the templates used by `@shopify/app` CLI when generating extensions.
 
+## Create an extension template
+
+Follow this guide to [create an extension template](https://vault.shopify.io/page/Create-an-extension-template~cqQS.md)
+
 ## Local Functions Development
 
 The following instructions are for building and testing Function templates, which follow the pattern `functions-*-[rs|js]`.


### PR DESCRIPTION
### Background

(Provide a link to any relevant issues AND provide a TLDR of the issue in this pull request)
There is a github action which needs running, in order to publish the new `templates.json` to shopify cdn. That step is usually missed.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)
Link the Vault page to the repo.

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
