### PR TITLE
Migrate POS Templates to Preact

### DIFF
--- a/pos-ui-extension-cart-line-item-details/package.json.liquid
+++ b/pos-ui-extension-cart-line-item-details/package.json.liquid
@@ -5,13 +5,11 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "react": "^18.0.0",
-    "@shopify/ui-extensions": "2025.7.x",
-    "@shopify/ui-extensions-react": "2025.7.x",
-    "react-reconciler": "0.29.0"
+    "preact": "^10.0.0",
+    "@shopify/ui-extensions": "2025.7.x"
   }{% if flavor contains "typescript" %},
   "devDependencies": {
-    "@types/react": "^18.0.0"
+    "@types/preact": "^10.0.0"
   }{% endif %}
 }
 {%- else -%}

--- a/pos-ui-extension-cart-line-item-details/package.json.liquid
+++ b/pos-ui-extension-cart-line-item-details/package.json.liquid
@@ -5,12 +5,9 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "preact": "^10.0.0",
+    "preact": "^10.26.9",
     "@shopify/ui-extensions": "2025.7.x"
-  }{% if flavor contains "typescript" %},
-  "devDependencies": {
-    "@types/preact": "^10.0.0"
-  }{% endif %}
+  }
 }
 {%- else -%}
 {

--- a/pos-ui-extension-cart-line-item-details/src/Action.liquid
+++ b/pos-ui-extension-cart-line-item-details/src/Action.liquid
@@ -1,32 +1,22 @@
 {%- if flavor contains "react" -%}
-import React from 'react';
+import { render } from '@shopify/ui-extensions/preact';
 
-import {
-  Text,
-  Screen,
-  ScrollView,
-  Navigator,
-  reactExtension,
-  useApi,
-} from '@shopify/ui-extensions-react/point-of-sale';
-
-const Modal = () => {
-  const api = useApi<'pos.cart.line-item-details.action.render'>();
+function Modal() {
+  const api = (window as any).shopify.extension.api;
   return (
-    <Navigator>
-      <Screen name="CartLineItem" title="Cart Line Item">
-        <ScrollView>
-          <Text>{`Title for this line item: ${api.cartLineItem.title}`}</Text>
-        </ScrollView>
-      </Screen>
-    </Navigator>
+    <s-navigator>
+      <s-screen name="CartLineItem" title="Cart Line Item">
+        <s-scroll-view>
+          <s-text>{`Title for this line item: ${api.cartLineItem.title}`}</s-text>
+        </s-scroll-view>
+      </s-screen>
+    </s-navigator>
   );
-};
+}
 
-export default reactExtension(
-  'pos.cart.line-item-details.action.render',
-  () => <Modal />,
-);
+export default async () => {
+  render(<Modal />, document.body);
+};
 {%- else -%}
 import {
   Navigator,

--- a/pos-ui-extension-cart-line-item-details/src/Action.liquid
+++ b/pos-ui-extension-cart-line-item-details/src/Action.liquid
@@ -2,12 +2,11 @@
 import { render } from '@shopify/ui-extensions/preact';
 
 function Modal() {
-  const api = (window as any).shopify.extension.api;
   return (
     <s-navigator>
       <s-screen name="CartLineItem" title="Cart Line Item">
         <s-scroll-view>
-          <s-text>{`Title for this line item: ${api.cartLineItem.title}`}</s-text>
+          <s-text>{`Title for this line item: ${shopify.cartLineItem.title}`}</s-text>
         </s-scroll-view>
       </s-screen>
     </s-navigator>

--- a/pos-ui-extension-cart-line-item-details/src/MenuItem.liquid
+++ b/pos-ui-extension-cart-line-item-details/src/MenuItem.liquid
@@ -1,21 +1,15 @@
 {%- if flavor contains "react" -%}
-import React from 'react';
-import {
-  reactExtension,
-  Button,
-  useApi,
-} from '@shopify/ui-extensions-react/point-of-sale';
+import { render } from '@shopify/ui-extensions/preact';
 
-const ButtonComponent = () => {
-  const api = useApi<'pos.cart.line-item-details.action.menu-item.render'>();
+function ButtonComponent() {
+  const api = (window as any).shopify.extension.api;
 
-  return <Button onPress={() => api.action.presentModal()} />;
+  return <s-button onClick={() => api.action.presentModal()} />;
+}
+
+export default async () => {
+  render(<ButtonComponent />, document.body);
 };
-
-export default reactExtension(
-  'pos.cart.line-item-details.action.menu-item.render',
-  () => <ButtonComponent />,
-);
 
 {%- else -%}
 import {Button, extension} from '@shopify/ui-extensions/point-of-sale';

--- a/pos-ui-extension-cart-line-item-details/src/MenuItem.liquid
+++ b/pos-ui-extension-cart-line-item-details/src/MenuItem.liquid
@@ -2,9 +2,7 @@
 import { render } from '@shopify/ui-extensions/preact';
 
 function ButtonComponent() {
-  const api = (window as any).shopify.extension.api;
-
-  return <s-button onClick={() => api.action.presentModal()} />;
+  return <s-button onClick={() => shopify.action.presentModal()} />;
 }
 
 export default async () => {

--- a/pos-ui-extension-customer-details/package.json.liquid
+++ b/pos-ui-extension-customer-details/package.json.liquid
@@ -5,13 +5,11 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "react": "^18.0.0",
-    "@shopify/ui-extensions": "2025.7.x",
-    "@shopify/ui-extensions-react": "2025.7.x",
-    "react-reconciler": "0.29.0"
+    "preact": "^10.0.0",
+    "@shopify/ui-extensions": "2025.7.x"
   }{% if flavor contains "typescript" %},
   "devDependencies": {
-    "@types/react": "^18.0.0"
+    "@types/preact": "^10.0.0"
   }{% endif %}
 }
 {%- else -%}

--- a/pos-ui-extension-customer-details/package.json.liquid
+++ b/pos-ui-extension-customer-details/package.json.liquid
@@ -5,12 +5,9 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "preact": "^10.0.0",
+    "preact": "^10.26.9",
     "@shopify/ui-extensions": "2025.7.x"
-  }{% if flavor contains "typescript" %},
-  "devDependencies": {
-    "@types/preact": "^10.0.0"
-  }{% endif %}
+  }
 }
 {%- else -%}
 {

--- a/pos-ui-extension-customer-details/src/Action.liquid
+++ b/pos-ui-extension-customer-details/src/Action.liquid
@@ -2,12 +2,11 @@
 import { render } from '@shopify/ui-extensions/preact';
 
 function Modal() {
-  const api = (window as any).shopify.extension.api;
   return (
     <s-navigator>
       <s-screen name="CustomerDetails" title="Customer Details">
         <s-scroll-view>
-          <s-text>{`Customer ID: ${api.customer.id}`}</s-text>
+          <s-text>{`Customer ID: ${shopify.customer.id}`}</s-text>
         </s-scroll-view>
       </s-screen>
     </s-navigator>

--- a/pos-ui-extension-customer-details/src/Action.liquid
+++ b/pos-ui-extension-customer-details/src/Action.liquid
@@ -1,33 +1,22 @@
 {%- if flavor contains "react" -%}
-import React from "react";
+import { render } from '@shopify/ui-extensions/preact';
 
-import {
-  Text,
-  Screen,
-  ScrollView,
-  Navigator,
-  reactExtension,
-  useApi,
-} from "@shopify/ui-extensions-react/point-of-sale";
-
-const Modal = () => {
-  {% if flavor contains "typescript" %}const api = useApi<"pos.customer-details.action.render">();
-  {% else %}const api = useApi();
-  {% endif %}
+function Modal() {
+  const api = (window as any).shopify.extension.api;
   return (
-    <Navigator>
-      <Screen name="CustomerDetails" title="Customer Details">
-        <ScrollView>
-          <Text>{`Customer ID: ${api.customer.id}`}</Text>
-        </ScrollView>
-      </Screen>
-    </Navigator>
+    <s-navigator>
+      <s-screen name="CustomerDetails" title="Customer Details">
+        <s-scroll-view>
+          <s-text>{`Customer ID: ${api.customer.id}`}</s-text>
+        </s-scroll-view>
+      </s-screen>
+    </s-navigator>
   );
-};
+}
 
-export default reactExtension("pos.customer-details.action.render", () => (
-  <Modal />
-));
+export default async () => {
+  render(<Modal />, document.body);
+};
 {%- else -%}
 import {
   Navigator,

--- a/pos-ui-extension-customer-details/src/Block.liquid
+++ b/pos-ui-extension-customer-details/src/Block.liquid
@@ -2,14 +2,13 @@
 import { render } from '@shopify/ui-extensions/preact';
 
 function Block() {
-  const api = (window as any).shopify.extension.api;
   return (
     <s-pos-block
-      action={{ title: "Open action", onPress: api.action.presentModal }}
+      action={{ title: "Open action", onPress: shopify.action.presentModal }}
     >
       <s-pos-block-row>
         <s-text>{"This is a block extension"}</s-text>
-        <s-text>{`Customer ID for this customer: ${api.customer.id}`}</s-text>
+        <s-text>{`Customer ID for this customer: ${shopify.customer.id}`}</s-text>
       </s-pos-block-row>
     </s-pos-block>
   );

--- a/pos-ui-extension-customer-details/src/Block.liquid
+++ b/pos-ui-extension-customer-details/src/Block.liquid
@@ -1,33 +1,23 @@
 {%- if flavor contains "react" -%}
-import React from "react";
+import { render } from '@shopify/ui-extensions/preact';
 
-import {
-  Text,
-  useApi,
-  reactExtension,
-  POSBlock,
-  POSBlockRow,
-} from "@shopify/ui-extensions-react/point-of-sale";
-
-const Block = () => {
-  {% if flavor contains "typescript" %}const api = useApi<"pos.customer-details.block.render">();
-  {% else %}const api = useApi();
-  {% endif %}
-  {% raw %}return (
-    <POSBlock
+function Block() {
+  const api = (window as any).shopify.extension.api;
+  return (
+    <s-pos-block
       action={{ title: "Open action", onPress: api.action.presentModal }}
     >
-      <POSBlockRow>
-        <Text>{"This is a block extension"}</Text>
-        <Text>{`Customer ID for this customer: ${api.customer.id}`}</Text>
-      </POSBlockRow>
-    </POSBlock>
-  );{% endraw %}
-};
+      <s-pos-block-row>
+        <s-text>{"This is a block extension"}</s-text>
+        <s-text>{`Customer ID for this customer: ${api.customer.id}`}</s-text>
+      </s-pos-block-row>
+    </s-pos-block>
+  );
+}
 
-export default reactExtension("pos.customer-details.block.render", () => (
-  <Block />
-));
+export default async () => {
+  render(<Block />, document.body);
+};
 {%- else -%}
 import {
   POSBlock,

--- a/pos-ui-extension-customer-details/src/MenuItem.liquid
+++ b/pos-ui-extension-customer-details/src/MenuItem.liquid
@@ -1,22 +1,14 @@
 {%- if flavor contains "react" -%}
-import React from "react";
-import {
-  reactExtension,
-  Button,
-  useApi,
-} from "@shopify/ui-extensions-react/point-of-sale";
+import { render } from '@shopify/ui-extensions/preact';
 
-const ButtonComponent = () => {
-  {% if flavor contains "typescript" %}const api = useApi<"pos.customer-details.action.menu-item.render">();
-  {% else %}const api = useApi();
-  {% endif %}
-  return <Button onPress={() => api.action.presentModal()} />;
+function ButtonComponent() {
+  const api = (window as any).shopify.extension.api;
+  return <s-button onPress={() => api.action.presentModal()} />;
+}
+
+export default async () => {
+  render(<ButtonComponent />, document.body);
 };
-
-export default reactExtension(
-  "pos.customer-details.action.menu-item.render",
-  () => <ButtonComponent />,
-);
 {%- else -%}
 import {Button, extension} from '@shopify/ui-extensions/point-of-sale';
 

--- a/pos-ui-extension-customer-details/src/MenuItem.liquid
+++ b/pos-ui-extension-customer-details/src/MenuItem.liquid
@@ -2,8 +2,7 @@
 import { render } from '@shopify/ui-extensions/preact';
 
 function ButtonComponent() {
-  const api = (window as any).shopify.extension.api;
-  return <s-button onPress={() => api.action.presentModal()} />;
+  return <s-button onPress={() => shopify.action.presentModal()} />;
 }
 
 export default async () => {

--- a/pos-ui-extension-draft-order-details/package.json.liquid
+++ b/pos-ui-extension-draft-order-details/package.json.liquid
@@ -5,13 +5,11 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "react": "^18.0.0",
-    "@shopify/ui-extensions": "2025.7.x",
-    "@shopify/ui-extensions-react": "2025.7.x",
-    "react-reconciler": "0.29.0"
+    "preact": "^10.0.0",
+    "@shopify/ui-extensions": "2025.7.x"
   }{% if flavor contains "typescript" %},
   "devDependencies": {
-    "@types/react": "^18.0.0"
+    "@types/preact": "^10.0.0"
   }{% endif %}
 }
 {%- else -%}

--- a/pos-ui-extension-draft-order-details/package.json.liquid
+++ b/pos-ui-extension-draft-order-details/package.json.liquid
@@ -5,12 +5,9 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "preact": "^10.0.0",
+    "preact": "^10.26.9",
     "@shopify/ui-extensions": "2025.7.x"
-  }{% if flavor contains "typescript" %},
-  "devDependencies": {
-    "@types/preact": "^10.0.0"
-  }{% endif %}
+  }
 }
 {%- else -%}
 {

--- a/pos-ui-extension-draft-order-details/src/Action.liquid
+++ b/pos-ui-extension-draft-order-details/src/Action.liquid
@@ -1,33 +1,22 @@
 {%- if flavor contains "react" -%}
-import React from 'react';
+import { render } from '@shopify/ui-extensions/preact';
 
-import {
-  Text,
-  Screen,
-  ScrollView,
-  Navigator,
-  reactExtension,
-  useApi,
-} from '@shopify/ui-extensions-react/point-of-sale';
-
-const Modal = () => {
-  {% if flavor contains "typescript" %}const api = useApi<"pos.draft-order-details.action.render">();
-  {% else %}const api = useApi();
-  {% endif %}
+function Modal() {
+  const api = (window as any).shopify.extension.api;
   return (
-    <Navigator>
-      <Screen name="DraftOrderDetailsAction" title="Draft Order Details Action">
-        <ScrollView>
-          <Text>{`Draft Order ID: ${api.draftOrder.id}`}</Text>
-        </ScrollView>
-      </Screen>
-    </Navigator>
+    <s-navigator>
+      <s-screen name="DraftOrderDetailsAction" title="Draft Order Details Action">
+        <s-scroll-view>
+          <s-text>{`Draft Order ID: ${api.draftOrder.id}`}</s-text>
+        </s-scroll-view>
+      </s-screen>
+    </s-navigator>
   );
-};
+}
 
-export default reactExtension('pos.draft-order-details.action.render', () => (
-  <Modal />
-));
+export default async () => {
+  render(<Modal />, document.body);
+};
 {%- else -%}
 import {
   Navigator,

--- a/pos-ui-extension-draft-order-details/src/Action.liquid
+++ b/pos-ui-extension-draft-order-details/src/Action.liquid
@@ -2,12 +2,11 @@
 import { render } from '@shopify/ui-extensions/preact';
 
 function Modal() {
-  const api = (window as any).shopify.extension.api;
   return (
     <s-navigator>
       <s-screen name="DraftOrderDetailsAction" title="Draft Order Details Action">
         <s-scroll-view>
-          <s-text>{`Draft Order ID: ${api.draftOrder.id}`}</s-text>
+          <s-text>{`Draft Order ID: ${shopify.draftOrder.id}`}</s-text>
         </s-scroll-view>
       </s-screen>
     </s-navigator>

--- a/pos-ui-extension-draft-order-details/src/Block.liquid
+++ b/pos-ui-extension-draft-order-details/src/Block.liquid
@@ -2,12 +2,11 @@
 import { render } from '@shopify/ui-extensions/preact';
 
 function Block() {
-  const api = (window as any).shopify.extension.api;
   return (
-    <s-pos-block action={{title: 'Open action', onPress: api.action.presentModal}}>
+    <s-pos-block action={{title: 'Open action', onPress: shopify.action.presentModal}}>
       <s-pos-block-row>
         <s-text>{'This is a block extension'}</s-text>
-        <s-text>{`Draft Order ID for this draft order: ${api.draftOrder.id}`}</s-text>
+        <s-text>{`Draft Order ID for this draft order: ${shopify.draftOrder.id}`}</s-text>
       </s-pos-block-row>
     </s-pos-block>
   );

--- a/pos-ui-extension-draft-order-details/src/Block.liquid
+++ b/pos-ui-extension-draft-order-details/src/Block.liquid
@@ -1,31 +1,21 @@
 {%- if flavor contains "react" -%}
-import React from 'react';
+import { render } from '@shopify/ui-extensions/preact';
 
-import {
-  Text,
-  useApi,
-  reactExtension,
-  POSBlock,
-  POSBlockRow,
-} from '@shopify/ui-extensions-react/point-of-sale';
+function Block() {
+  const api = (window as any).shopify.extension.api;
+  return (
+    <s-pos-block action={{title: 'Open action', onPress: api.action.presentModal}}>
+      <s-pos-block-row>
+        <s-text>{'This is a block extension'}</s-text>
+        <s-text>{`Draft Order ID for this draft order: ${api.draftOrder.id}`}</s-text>
+      </s-pos-block-row>
+    </s-pos-block>
+  );
+}
 
-const Block = () => {
-  {% if flavor contains "typescript" %}const api = useApi<"pos.draft-order-details.block.render">();
-  {% else %}const api = useApi();
-  {% endif %}
-  {% raw %}return (
-    <POSBlock action={{title: 'Open action', onPress: api.action.presentModal}}>
-      <POSBlockRow>
-        <Text>{'This is a block extension'}</Text>
-        <Text>{`Draft Order ID for this draft order: ${api.draftOrder.id}`}</Text>
-      </POSBlockRow>
-    </POSBlock>
-  );{% endraw %}
+export default async () => {
+  render(<Block />, document.body);
 };
-
-export default reactExtension('pos.draft-order-details.block.render', () => (
-  <Block />
-));
 {%- else -%}
 import {
   POSBlock,

--- a/pos-ui-extension-draft-order-details/src/MenuItem.liquid
+++ b/pos-ui-extension-draft-order-details/src/MenuItem.liquid
@@ -1,22 +1,14 @@
 {%- if flavor contains "react" -%}
-import React from 'react';
-import {
-  reactExtension,
-  Button,
-  useApi,
-} from '@shopify/ui-extensions-react/point-of-sale';
+import { render } from '@shopify/ui-extensions/preact';
 
-const ButtonComponent = () => {
-  {% if flavor contains "typescript" %}const api = useApi<"pos.draft-order-details.action.menu-item.render">();
-  {% else %}const api = useApi();
-  {% endif %}
-  return <Button onPress={() => api.action.presentModal()} />;
+function ButtonComponent() {
+  const api = (window as any).shopify.extension.api;
+  return <s-button onPress={() => api.action.presentModal()} />;
+}
+
+export default async () => {
+  render(<ButtonComponent />, document.body);
 };
-
-export default reactExtension(
-  'pos.draft-order-details.action.menu-item.render',
-  () => <ButtonComponent />,
-);
 {%- else -%}
 import {Button, extension} from '@shopify/ui-extensions/point-of-sale';
 

--- a/pos-ui-extension-draft-order-details/src/MenuItem.liquid
+++ b/pos-ui-extension-draft-order-details/src/MenuItem.liquid
@@ -2,8 +2,7 @@
 import { render } from '@shopify/ui-extensions/preact';
 
 function ButtonComponent() {
-  const api = (window as any).shopify.extension.api;
-  return <s-button onPress={() => api.action.presentModal()} />;
+  return <s-button onPress={() => shopify.action.presentModal()} />;
 }
 
 export default async () => {

--- a/pos-ui-extension-order-details/package.json.liquid
+++ b/pos-ui-extension-order-details/package.json.liquid
@@ -5,13 +5,11 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "react": "^18.0.0",
-    "@shopify/ui-extensions": "2025.7.x",
-    "@shopify/ui-extensions-react": "2025.7.x",
-    "react-reconciler": "0.29.0"
+    "preact": "^10.0.0",
+    "@shopify/ui-extensions": "2025.7.x"
   }{% if flavor contains "typescript" %},
   "devDependencies": {
-    "@types/react": "^18.0.0"
+    "@types/preact": "^10.0.0"
   }{% endif %}
 }
 {%- else -%}

--- a/pos-ui-extension-order-details/package.json.liquid
+++ b/pos-ui-extension-order-details/package.json.liquid
@@ -5,12 +5,9 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "preact": "^10.0.0",
+    "preact": "^10.26.9",
     "@shopify/ui-extensions": "2025.7.x"
-  }{% if flavor contains "typescript" %},
-  "devDependencies": {
-    "@types/preact": "^10.0.0"
-  }{% endif %}
+  }
 }
 {%- else -%}
 {

--- a/pos-ui-extension-order-details/src/Action.liquid
+++ b/pos-ui-extension-order-details/src/Action.liquid
@@ -1,33 +1,22 @@
 {%- if flavor contains "react" -%}
-import React from 'react';
+import { render } from '@shopify/ui-extensions/preact';
 
-import {
-  Text,
-  Screen,
-  ScrollView,
-  useApi,
-  Navigator,
-  reactExtension,
-} from '@shopify/ui-extensions-react/point-of-sale';
-
-const Modal = () => {
-  {% if flavor contains "typescript" %}const api = useApi<"pos.order-details.action.render">();
-  {% else %}const api = useApi();
-  {% endif %}
+function Modal() {
+  const api = (window as any).shopify.extension.api;
   return (
-    <Navigator>
-      <Screen name="OrderDetailsAction" title="Order Details Action">
-        <ScrollView>
-          <Text>{`Order ID: ${api.order.id}`}</Text>
-        </ScrollView>
-      </Screen>
-    </Navigator>
+    <s-navigator>
+      <s-screen name="OrderDetailsAction" title="Order Details Action">
+        <s-scroll-view>
+          <s-text>{`Order ID: ${api.order.id}`}</s-text>
+        </s-scroll-view>
+      </s-screen>
+    </s-navigator>
   );
-};
+}
 
-export default reactExtension('pos.order-details.action.render', () => (
-  <Modal />
-));
+export default async () => {
+  render(<Modal />, document.body);
+};
 {%- else -%}
 import {
   Navigator,

--- a/pos-ui-extension-order-details/src/Action.liquid
+++ b/pos-ui-extension-order-details/src/Action.liquid
@@ -2,12 +2,11 @@
 import { render } from '@shopify/ui-extensions/preact';
 
 function Modal() {
-  const api = (window as any).shopify.extension.api;
   return (
     <s-navigator>
       <s-screen name="OrderDetailsAction" title="Order Details Action">
         <s-scroll-view>
-          <s-text>{`Order ID: ${api.order.id}`}</s-text>
+          <s-text>{`Order ID: ${shopify.order.id}`}</s-text>
         </s-scroll-view>
       </s-screen>
     </s-navigator>

--- a/pos-ui-extension-order-details/src/Block.liquid
+++ b/pos-ui-extension-order-details/src/Block.liquid
@@ -2,12 +2,11 @@
 import { render } from '@shopify/ui-extensions/preact';
 
 function Block() {
-  const api = (window as any).shopify.extension.api;
   return (
-    <s-pos-block action={{title: 'Open action', onPress: api.action.presentModal}}>
+    <s-pos-block action={{title: 'Open action', onPress: shopify.action.presentModal}}>
       <s-pos-block-row>
         <s-text>{'This is a block extension'}</s-text>
-        <s-text>{`Order ID: ${api.order.id}`}</s-text>
+        <s-text>{`Order ID: ${shopify.order.id}`}</s-text>
       </s-pos-block-row>
     </s-pos-block>
   );

--- a/pos-ui-extension-order-details/src/Block.liquid
+++ b/pos-ui-extension-order-details/src/Block.liquid
@@ -1,31 +1,21 @@
 {%- if flavor contains "react" -%}
-import React from 'react';
+import { render } from '@shopify/ui-extensions/preact';
 
-import {
-  Text,
-  useApi,
-  reactExtension,
-  POSBlock,
-  POSBlockRow,
-} from '@shopify/ui-extensions-react/point-of-sale';
+function Block() {
+  const api = (window as any).shopify.extension.api;
+  return (
+    <s-pos-block action={{title: 'Open action', onPress: api.action.presentModal}}>
+      <s-pos-block-row>
+        <s-text>{'This is a block extension'}</s-text>
+        <s-text>{`Order ID: ${api.order.id}`}</s-text>
+      </s-pos-block-row>
+    </s-pos-block>
+  );
+}
 
-const Block = () => {
-  {% if flavor contains "typescript" %}const api = useApi<"pos.order-details.block.render">();
-  {% else %}const api = useApi();
-  {% endif %}
-  {% raw %}return (
-    <POSBlock action={{title: 'Open action', onPress: api.action.presentModal}}>
-      <POSBlockRow>
-        <Text>{'This is a block extension'}</Text>
-        <Text>{`Order ID: ${api.order.id}`}</Text>
-      </POSBlockRow>
-    </POSBlock>
-  );{% endraw %}
+export default async () => {
+  render(<Block />, document.body);
 };
-
-export default reactExtension('pos.order-details.block.render', () => (
-  <Block />
-));
 {%- else -%}
 import {
   POSBlock,

--- a/pos-ui-extension-order-details/src/MenuItem.liquid
+++ b/pos-ui-extension-order-details/src/MenuItem.liquid
@@ -1,22 +1,14 @@
 {%- if flavor contains "react" -%}
-import React from 'react';
-import {
-  reactExtension,
-  Button,
-  useApi,
-} from '@shopify/ui-extensions-react/point-of-sale';
+import { render } from '@shopify/ui-extensions/preact';
 
-const ButtonComponent = () => {
-  {% if flavor contains "typescript" %}const api = useApi<"pos.order-details.action.menu-item.render">();
-  {% else %}const api = useApi();
-  {% endif %}
-  return <Button onPress={() => api.action.presentModal()} />;
+function ButtonComponent() {
+  const api = (window as any).shopify.extension.api;
+  return <s-button onPress={() => api.action.presentModal()} />;
+}
+
+export default async () => {
+  render(<ButtonComponent />, document.body);
 };
-
-export default reactExtension(
-  'pos.order-details.action.menu-item.render',
-  () => <ButtonComponent />,
-);
 {%- else -%}
 import {Button, extension} from '@shopify/ui-extensions/point-of-sale';
 

--- a/pos-ui-extension-order-details/src/MenuItem.liquid
+++ b/pos-ui-extension-order-details/src/MenuItem.liquid
@@ -2,8 +2,7 @@
 import { render } from '@shopify/ui-extensions/preact';
 
 function ButtonComponent() {
-  const api = (window as any).shopify.extension.api;
-  return <s-button onPress={() => api.action.presentModal()} />;
+  return <s-button onPress={() => shopify.action.presentModal()} />;
 }
 
 export default async () => {

--- a/pos-ui-extension-post-purchase/package.json.liquid
+++ b/pos-ui-extension-post-purchase/package.json.liquid
@@ -5,13 +5,11 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "react": "^18.0.0",
-    "@shopify/ui-extensions": "2025.7.x",
-    "@shopify/ui-extensions-react": "2025.7.x",
-    "react-reconciler": "0.29.0"
+    "preact": "^10.0.0",
+    "@shopify/ui-extensions": "2025.7.x"
   }{% if flavor contains "typescript" %},
   "devDependencies": {
-    "@types/react": "^18.0.0"
+    "@types/preact": "^10.0.0"
   }{% endif %}
 }
 {%- else -%}

--- a/pos-ui-extension-post-purchase/package.json.liquid
+++ b/pos-ui-extension-post-purchase/package.json.liquid
@@ -5,12 +5,9 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "preact": "^10.0.0",
+    "preact": "^10.26.9",
     "@shopify/ui-extensions": "2025.7.x"
-  }{% if flavor contains "typescript" %},
-  "devDependencies": {
-    "@types/preact": "^10.0.0"
-  }{% endif %}
+  }
 }
 {%- else -%}
 {

--- a/pos-ui-extension-post-purchase/src/Action.liquid
+++ b/pos-ui-extension-post-purchase/src/Action.liquid
@@ -2,12 +2,11 @@
 import { render } from '@shopify/ui-extensions/preact';
 
 function Modal() {
-  const api = (window as any).shopify.extension.api;
   return (
     <s-navigator>
       <s-screen name="PostPurchaseAction" title="Post Purchase Action">
         <s-scroll-view>
-          <s-text>{`Order ID for complete checkout: ${api.order.id}`}</s-text>
+          <s-text>{`Order ID for complete checkout: ${shopify.order.id}`}</s-text>
         </s-scroll-view>
       </s-screen>
     </s-navigator>

--- a/pos-ui-extension-post-purchase/src/Action.liquid
+++ b/pos-ui-extension-post-purchase/src/Action.liquid
@@ -1,33 +1,22 @@
 {%- if flavor contains "react" -%}
-import React from 'react';
+import { render } from '@shopify/ui-extensions/preact';
 
-import {
-  Text,
-  Screen,
-  ScrollView,
-  Navigator,
-  useApi,
-  reactExtension,
-} from '@shopify/ui-extensions-react/point-of-sale';
-
-const Modal = () => {
-  {% if flavor contains "typescript" %}const api = useApi<"pos.purchase.post.action.render">();
-  {% else %}const api = useApi();
-  {% endif %}
+function Modal() {
+  const api = (window as any).shopify.extension.api;
   return (
-    <Navigator>
-      <Screen name="PostPurchaseAction" title="Post Purchase Action">
-        <ScrollView>
-          <Text>{`Order ID for complete checkout: ${api.order.id}`}</Text>
-        </ScrollView>
-      </Screen>
-    </Navigator>
+    <s-navigator>
+      <s-screen name="PostPurchaseAction" title="Post Purchase Action">
+        <s-scroll-view>
+          <s-text>{`Order ID for complete checkout: ${api.order.id}`}</s-text>
+        </s-scroll-view>
+      </s-screen>
+    </s-navigator>
   );
-};
+}
 
-export default reactExtension('pos.purchase.post.action.render', () => (
-  <Modal />
-));
+export default async () => {
+  render(<Modal />, document.body);
+};
 {%- else -%}
 import {
   Navigator,

--- a/pos-ui-extension-post-purchase/src/Block.liquid
+++ b/pos-ui-extension-post-purchase/src/Block.liquid
@@ -1,31 +1,21 @@
 {%- if flavor contains "react" -%}
-import React from 'react';
+import { render } from '@shopify/ui-extensions/preact';
 
-import {
-  Text,
-  useApi,
-  reactExtension,
-  POSBlock,
-  POSBlockRow,
-} from '@shopify/ui-extensions-react/point-of-sale';
-
-const Block = () => {
-  {% if flavor contains "typescript" %}const api = useApi<"pos.purchase.post.block.render">();
-  {% else %}const api = useApi();
-  {% endif %}
+function Block() {
+  const api = (window as any).shopify.extension.api;
   return (
-    {% raw %}<POSBlock action={{title: 'Open action', onPress: api.action.presentModal}}>
-      <POSBlockRow>
-        <Text>{'This is a block extension'}</Text>
-        <Text>{`Order ID for complete checkout: ${api.order.id}`}</Text>
-      </POSBlockRow>
-    </POSBlock>
-  );{% endraw %}
-};
+    <s-pos-block action={{title: 'Open action', onPress: api.action.presentModal}}>
+      <s-pos-block-row>
+        <s-text>{'This is a block extension'}</s-text>
+        <s-text>{`Order ID for complete checkout: ${api.order.id}`}</s-text>
+      </s-pos-block-row>
+    </s-pos-block>
+  );
+}
 
-export default reactExtension('pos.purchase.post.block.render', () => (
-  <Block />
-));
+export default async () => {
+  render(<Block />, document.body);
+};
 {%- else -%}
 import {
   POSBlock,

--- a/pos-ui-extension-post-purchase/src/Block.liquid
+++ b/pos-ui-extension-post-purchase/src/Block.liquid
@@ -2,12 +2,11 @@
 import { render } from '@shopify/ui-extensions/preact';
 
 function Block() {
-  const api = (window as any).shopify.extension.api;
   return (
-    <s-pos-block action={{title: 'Open action', onPress: api.action.presentModal}}>
+    <s-pos-block action={{title: 'Open action', onPress: shopify.action.presentModal}}>
       <s-pos-block-row>
         <s-text>{'This is a block extension'}</s-text>
-        <s-text>{`Order ID for complete checkout: ${api.order.id}`}</s-text>
+        <s-text>{`Order ID for complete checkout: ${shopify.order.id}`}</s-text>
       </s-pos-block-row>
     </s-pos-block>
   );

--- a/pos-ui-extension-post-purchase/src/MenuItem.liquid
+++ b/pos-ui-extension-post-purchase/src/MenuItem.liquid
@@ -1,22 +1,14 @@
 {%- if flavor contains "react" -%}
-import React from 'react';
-import {
-  reactExtension,
-  Button,
-  useApi,
-} from '@shopify/ui-extensions-react/point-of-sale';
+import { render } from '@shopify/ui-extensions/preact';
 
-const ButtonComponent = () => {
-  {% if flavor contains "typescript" %}const api = useApi<"pos.purchase.post.action.menu-item.render">();
-  {% else %}const api = useApi();
-  {% endif %}
-  return <Button onPress={() => api.action.presentModal()} />;
+function ButtonComponent() {
+  const api = (window as any).shopify.extension.api;
+  return <s-button onPress={() => api.action.presentModal()} />;
+}
+
+export default async () => {
+  render(<ButtonComponent />, document.body);
 };
-
-export default reactExtension(
-  'pos.purchase.post.action.menu-item.render',
-  () => <ButtonComponent />,
-);
 {%- else -%}
 import {Button, extension} from '@shopify/ui-extensions/point-of-sale';
 

--- a/pos-ui-extension-post-purchase/src/MenuItem.liquid
+++ b/pos-ui-extension-post-purchase/src/MenuItem.liquid
@@ -2,8 +2,7 @@
 import { render } from '@shopify/ui-extensions/preact';
 
 function ButtonComponent() {
-  const api = (window as any).shopify.extension.api;
-  return <s-button onPress={() => api.action.presentModal()} />;
+  return <s-button onPress={() => shopify.action.presentModal()} />;
 }
 
 export default async () => {

--- a/pos-ui-extension-product-details/package.json.liquid
+++ b/pos-ui-extension-product-details/package.json.liquid
@@ -5,13 +5,11 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "react": "^18.0.0",
-    "@shopify/ui-extensions": "2025.7.x",
-    "@shopify/ui-extensions-react": "2025.7.x",
-    "react-reconciler": "0.29.0"
+    "preact": "^10.0.0",
+    "@shopify/ui-extensions": "2025.7.x"
   }{% if flavor contains "typescript" %},
   "devDependencies": {
-    "@types/react": "^18.0.0"
+    "@types/preact": "^10.0.0"
   }{% endif %}
 }
 {%- else -%}

--- a/pos-ui-extension-product-details/package.json.liquid
+++ b/pos-ui-extension-product-details/package.json.liquid
@@ -5,12 +5,9 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "preact": "^10.0.0",
+    "preact": "^10.26.9",
     "@shopify/ui-extensions": "2025.7.x"
-  }{% if flavor contains "typescript" %},
-  "devDependencies": {
-    "@types/preact": "^10.0.0"
-  }{% endif %}
+  }
 }
 {%- else -%}
 {

--- a/pos-ui-extension-product-details/src/Action.liquid
+++ b/pos-ui-extension-product-details/src/Action.liquid
@@ -2,12 +2,11 @@
 import { render } from '@shopify/ui-extensions/preact';
 
 function Modal() {
-  const api = (window as any).shopify.extension.api;
   return (
     <s-navigator>
       <s-screen name="ProductDetails" title="Product Details">
         <s-scroll-view>
-          <s-text>{`Product ID: ${api.product.id}`}</s-text>
+          <s-text>{`Product ID: ${shopify.product.id}`}</s-text>
         </s-scroll-view>
       </s-screen>
     </s-navigator>

--- a/pos-ui-extension-product-details/src/Action.liquid
+++ b/pos-ui-extension-product-details/src/Action.liquid
@@ -1,33 +1,22 @@
 {%- if flavor contains "react" -%}
-import React from 'react';
+import { render } from '@shopify/ui-extensions/preact';
 
-import {
-  Text,
-  Screen,
-  ScrollView,
-  Navigator,
-  reactExtension,
-  useApi,
-} from '@shopify/ui-extensions-react/point-of-sale';
-
-const Modal = () => {
-  {% if flavor contains "typescript" %}const api = useApi<"pos.product-details.action.render">();
-  {% else %}const api = useApi();
-  {% endif %}
+function Modal() {
+  const api = (window as any).shopify.extension.api;
   return (
-    <Navigator>
-      <Screen name="ProductDetails" title="Product Details">
-        <ScrollView>
-          <Text>{`Product ID: ${api.product.id}`}</Text>
-        </ScrollView>
-      </Screen>
-    </Navigator>
+    <s-navigator>
+      <s-screen name="ProductDetails" title="Product Details">
+        <s-scroll-view>
+          <s-text>{`Product ID: ${api.product.id}`}</s-text>
+        </s-scroll-view>
+      </s-screen>
+    </s-navigator>
   );
-};
+}
 
-export default reactExtension('pos.product-details.action.render', () => (
-  <Modal />
-));
+export default async () => {
+  render(<Modal />, document.body);
+};
 {%- else -%}
 import {
   Navigator,

--- a/pos-ui-extension-product-details/src/Block.liquid
+++ b/pos-ui-extension-product-details/src/Block.liquid
@@ -1,31 +1,21 @@
 {%- if flavor contains "react" -%}
-import React from 'react';
+import { render } from '@shopify/ui-extensions/preact';
 
-import {
-  Text,
-  useApi,
-  reactExtension,
-  POSBlock,
-  POSBlockRow,
-} from '@shopify/ui-extensions-react/point-of-sale';
+function Block() {
+  const api = (window as any).shopify.extension.api;
+  return (
+    <s-pos-block action={{title: 'Open action', onPress: api.action.presentModal}}>
+      <s-pos-block-row>
+        <s-text>{'This is a block extension'}</s-text>
+        <s-text>{`Product ID for this product: ${api.product.id}`}</s-text>
+      </s-pos-block-row>
+    </s-pos-block>
+  );
+}
 
-const Block = () => {
-  {% if flavor contains "typescript" %}const api = useApi<"pos.product-details.block.render">();
-  {% else %}const api = useApi();
-  {% endif %}
-  {% raw %}return (
-    <POSBlock action={{title: 'Open action', onPress: api.action.presentModal}}>
-      <POSBlockRow>
-        <Text>{'This is a block extension'}</Text>
-        <Text>{`Product ID for this product: ${api.product.id}`}</Text>
-      </POSBlockRow>
-    </POSBlock>
-  );{% endraw %}
+export default async () => {
+  render(<Block />, document.body);
 };
-
-export default reactExtension('pos.product-details.block.render', () => (
-  <Block />
-));
 {%- else -%}
 import {
   POSBlock,

--- a/pos-ui-extension-product-details/src/Block.liquid
+++ b/pos-ui-extension-product-details/src/Block.liquid
@@ -2,12 +2,11 @@
 import { render } from '@shopify/ui-extensions/preact';
 
 function Block() {
-  const api = (window as any).shopify.extension.api;
   return (
-    <s-pos-block action={{title: 'Open action', onPress: api.action.presentModal}}>
+    <s-pos-block action={{title: 'Open action', onPress: shopify.action.presentModal}}>
       <s-pos-block-row>
         <s-text>{'This is a block extension'}</s-text>
-        <s-text>{`Product ID for this product: ${api.product.id}`}</s-text>
+        <s-text>{`Product ID for this product: ${shopify.product.id}`}</s-text>
       </s-pos-block-row>
     </s-pos-block>
   );

--- a/pos-ui-extension-product-details/src/MenuItem.liquid
+++ b/pos-ui-extension-product-details/src/MenuItem.liquid
@@ -1,22 +1,14 @@
 {%- if flavor contains "react" -%}
-import React from 'react';
-import {
-  reactExtension,
-  Button,
-  useApi,
-} from '@shopify/ui-extensions-react/point-of-sale';
+import { render } from '@shopify/ui-extensions/preact';
 
-const ButtonComponent = () => {
-  {% if flavor contains "typescript" %}const api = useApi<"pos.product-details.action.menu-item.render">();
-  {% else %}const api = useApi();
-  {% endif %}
-  return <Button onPress={() => api.action.presentModal()} />;
+function ButtonComponent() {
+  const api = (window as any).shopify.extension.api;
+  return <s-button onPress={() => api.action.presentModal()} />;
+}
+
+export default async () => {
+  render(<ButtonComponent />, document.body);
 };
-
-export default reactExtension(
-  'pos.product-details.action.menu-item.render',
-  () => <ButtonComponent />,
-);
 {%- else -%}
 import {Button, extension} from '@shopify/ui-extensions/point-of-sale';
 

--- a/pos-ui-extension-product-details/src/MenuItem.liquid
+++ b/pos-ui-extension-product-details/src/MenuItem.liquid
@@ -2,8 +2,7 @@
 import { render } from '@shopify/ui-extensions/preact';
 
 function ButtonComponent() {
-  const api = (window as any).shopify.extension.api;
-  return <s-button onPress={() => api.action.presentModal()} />;
+  return <s-button onPress={() => shopify.action.presentModal()} />;
 }
 
 export default async () => {

--- a/pos-ui-extension-smart-grid/package.json.liquid
+++ b/pos-ui-extension-smart-grid/package.json.liquid
@@ -5,13 +5,11 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "react": "^18.0.0",
-    "@shopify/ui-extensions": "2025.7.x",
-    "@shopify/ui-extensions-react": "2025.7.x",
-    "react-reconciler": "0.29.0"
+    "preact": "^10.0.0",
+    "@shopify/ui-extensions": "2025.7.x"
   }{% if flavor contains "typescript" %},
   "devDependencies": {
-    "@types/react": "^18.0.0"
+    "@types/preact": "^10.0.0"
   }{% endif %}
 }
 {%- else -%}

--- a/pos-ui-extension-smart-grid/package.json.liquid
+++ b/pos-ui-extension-smart-grid/package.json.liquid
@@ -5,12 +5,9 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "preact": "^10.0.0",
+    "preact": "^10.26.9",
     "@shopify/ui-extensions": "2025.7.x"
-  }{% if flavor contains "typescript" %},
-  "devDependencies": {
-    "@types/preact": "^10.0.0"
-  }{% endif %}
+  }
 }
 {%- else -%}
 {

--- a/pos-ui-extension-smart-grid/src/Modal.liquid
+++ b/pos-ui-extension-smart-grid/src/Modal.liquid
@@ -1,21 +1,21 @@
 {%- if flavor contains "react" -%}
-import React from 'react'
+import { render } from '@shopify/ui-extensions/preact';
 
-import { Text, Screen, ScrollView, Navigator, reactExtension } from '@shopify/ui-extensions-react/point-of-sale'
-
-const Modal = () => {
+function Modal() {
   return (
-    <Navigator>
-      <Screen name="HelloWorld" title="Hello World!">
-        <ScrollView>
-          <Text>Welcome to the extension!</Text>
-        </ScrollView>
-      </Screen>
-    </Navigator>
-  )
+    <s-navigator>
+      <s-screen name="HelloWorld" title="Hello World!">
+        <s-scroll-view>
+          <s-text>Welcome to the extension!</s-text>
+        </s-scroll-view>
+      </s-screen>
+    </s-navigator>
+  );
 }
 
-export default reactExtension('pos.home.modal.render', () => <Modal />);
+export default async () => {
+  render(<Modal />, document.body);
+};
 {%- else -%}
 import { Navigator, Screen, ScrollView, Text, extension } from '@shopify/ui-extensions/point-of-sale'
 

--- a/pos-ui-extension-smart-grid/src/Tile.liquid
+++ b/pos-ui-extension-smart-grid/src/Tile.liquid
@@ -1,12 +1,10 @@
 {%- if flavor contains "react" -%}
-import React from 'react'
+import { render } from '@shopify/ui-extensions/preact';
 
-import { Tile, reactExtension, useApi } from '@shopify/ui-extensions-react/point-of-sale'
-
-const TileComponent = () => {
-  const api = useApi()
+function TileComponent() {
+  const api = (window as any).shopify.extension.api;
   return (
-    <Tile
+    <s-tile
       title="My app"
       subtitle="SmartGrid {{ flavor }} Extension"
       onPress={() => {
@@ -14,12 +12,12 @@ const TileComponent = () => {
       }}
       enabled
     />
-  )
+  );
 }
 
-export default reactExtension('pos.home.tile.render', () => {
-  return <TileComponent />
-})
+export default async () => {
+  render(<TileComponent />, document.body);
+};
 {%- else -%}
 import {extension, Tile} from '@shopify/ui-extensions/point-of-sale'
 

--- a/pos-ui-extension-smart-grid/src/Tile.liquid
+++ b/pos-ui-extension-smart-grid/src/Tile.liquid
@@ -2,13 +2,12 @@
 import { render } from '@shopify/ui-extensions/preact';
 
 function TileComponent() {
-  const api = (window as any).shopify.extension.api;
   return (
     <s-tile
       title="My app"
       subtitle="SmartGrid {{ flavor }} Extension"
       onPress={() => {
-        api.action.presentModal()
+        shopify.action.presentModal()
       }}
       enabled
     />


### PR DESCRIPTION
### Summary
This pull request migrates all POS UI templates from React to Preact, streamlining our codebase to utilize a lighter dependency while maintaining existing functionality.

### Changes Made:
1. **Dependencies Update**:
   - Updated Preact version in all `package.json.liquid` files from `^10.0.0` to `^10.26.9`.
   - Removed the `@types/preact` dependency as the types are now included with the main Preact package.

2. **API Access Pattern**:
   - Replaced references of `window.shopify.extension.api` with direct access to the `shopify` global object, simplifying API calls throughout the code.
   - Updated all references from the old API format (e.g., `api.customer.id`) to the new format (e.g., `shopify.customer.id`).

3. **Migrate Templates**:
   - Converted all relevant POS UI extension templates to use Preact patterns. This includes:
     - Updated JSX components to use `s-` prefixed elements (e.g., `Text` became `s-text`).
     - Changed rendering method from `reactExtension` to an asynchronous render function pattern.
     - Replaced the `useApi` hook with direct `shopify` global access.
   - The following templates have been successfully migrated:
     - `pos-ui-extension-cart-line-item-details`
     - `pos-ui-extension-customer-details`
     - `pos-ui-extension-draft-order-details`
     - `pos-ui-extension-order-details`
     - `pos-ui-extension-post-purchase`
     - `pos-ui-extension-product-details`
     - `pos-ui-extension-smart-grid`

### Motivation
This migration was performed to enhance the performance and maintainability of our POS UI extensions by adopting a lighter-weight library, Preact, without losing existing functionality. For further details regarding the reasoning and documentation, refer to the [POS UI Extensions documentation](https://shopify.dev/docs/api/admin-extensions/2025-10-rc#overview).