### PR TITLE
[Discounts] bugfix: remove the extraneous applyExtensionMetafieldChange

### DIFF
--- a/discount-details-function-settings-block/src/DiscountFunctionSettings.liquid
+++ b/discount-details-function-settings-block/src/DiscountFunctionSettings.liquid
@@ -153,7 +153,7 @@
     return (
       <FunctionSettings onSave={applyExtensionMetafieldChange}>
         <Heading size={6}>{i18n.translate("title")}</Heading>
-        <Form onReset={resetForm} onSubmit={applyExtensionMetafieldChange}>
+        <Form onReset={resetForm}>
           <Section>
             <BlockStack gap="base">
               <BlockStack gap="base">
@@ -448,7 +448,6 @@ export default extension(TARGET, async (root, api) => {
   });
 
   const formComponent = root.createComponent(Form, {
-    onSave: saveSettings,
     onReset: resetSettings
   });
 


### PR DESCRIPTION
### Background

applyExtensionMetafield is called twice, on `FunctionSettings onSave` and `Form onSubmit`.  The result is that the input value is not updated when we save the discount with the ui extension.

### Solution

I tested using only Form onSubmit, but that didn't work.  FunctionSettings onSave is required.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
