### PR TITLE
Adjust discount function settings metafield dependency array

### DIFF
--- a/discount-details-function-settings-block/src/DiscountFunctionSettings.liquid
+++ b/discount-details-function-settings-block/src/DiscountFunctionSettings.liquid
@@ -201,6 +201,7 @@
   function useExtensionData() {
     const { applyMetafieldChange, i18n, data, resourcePicker, query } =
       useApi(TARGET);
+    const metafields = data?.metafields ? JSON.stringify(data.metafields) : '';
     const metafieldConfig = useMemo(
       () =>
         parseMetafield(
@@ -208,7 +209,7 @@
             (metafield) => metafield.key === "function-configuration"
           )?.value
         ),
-      [data?.metafields]
+      [metafields]
     );
     const [percentages, setPercentages] = useState(metafieldConfig.percentages);
     const [initialCollections, setInitialCollections] = useState([]);


### PR DESCRIPTION
### Background

Currently when you save a discount using this extension, the old metadata appears in the form fields after the save.  The data.metafields in the dependency array is an array which is compared by reference, not by value.

### Solution

This uses JSON.stringify to convert the array to a string so react can compare by value more easily.  There is some performance risk with this depending on how much data is in the array, but for the purposes of this demo, for which we use 4 fields on one object in the array, I think it's ok.  Developers should be able to figure out a more reliable way to determine that they need to memoize again, which should be straight forward depending on the data.
### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
