### PR TITLE
Fix import paths for JSX files in ProductExtension.liquid

### DIFF
--- a/admin-purchase-options-action/src/ProductExtension.liquid
+++ b/admin-purchase-options-action/src/ProductExtension.liquid
@@ -1,13 +1,17 @@
-{%- if flavor contains "preact" -%}
+{%- if flavor == "preact" -%}
 import {render} from 'preact';
-import PurchaseOptionsActionExtension from './PurchaseOptionsActionExtension';
+import PurchaseOptionsActionExtension from './PurchaseOptionsActionExtension.jsx';
 
 export default async () => {
   render(<PurchaseOptionsActionExtension />, document.body);
 }
 {%- elsif flavor contains "react" -%}
 import {reactExtension} from '@shopify/ui-extensions-react/admin';
+{%- if flavor == "react" -%}
+import PurchaseOptionsActionExtension from './PurchaseOptionsActionExtension.jsx';
+{%- else -%}
 import PurchaseOptionsActionExtension from './PurchaseOptionsActionExtension';
+{%- endif %}
 
 export default reactExtension('admin.product-purchase-option.action.render', () => (
   <PurchaseOptionsActionExtension extension="admin.product-purchase-option.action.render" />

--- a/admin-purchase-options-action/src/ProductVariantExtension.liquid
+++ b/admin-purchase-options-action/src/ProductVariantExtension.liquid
@@ -1,13 +1,17 @@
-{%- if flavor contains "preact" -%}
+{%- if flavor == "preact" -%}
 import {render} from 'preact';
-import PurchaseOptionsActionExtension from './PurchaseOptionsActionExtension';
+import PurchaseOptionsActionExtension from './PurchaseOptionsActionExtension.jsx';
 
 export default async () => {
   render(<PurchaseOptionsActionExtension />, document.body);
 }
 {%- elsif flavor contains "react" -%}
 import {reactExtension} from '@shopify/ui-extensions-react/admin';
+{%- if flavor == "react" -%}
+import PurchaseOptionsActionExtension from './PurchaseOptionsActionExtension.jsx';
+{%- else -%}
 import PurchaseOptionsActionExtension from './PurchaseOptionsActionExtension';
+{%- endif %}
 
 export default reactExtension('admin.product-variant-purchase-option.action.render', () => (
   <PurchaseOptionsActionExtension extension="admin.product-variant-purchase-option.action.render" />


### PR DESCRIPTION
### Background

This PR addresses an issue with file imports in the `ProductExtension.liquid` file, where JSX files weren't being properly referenced with their extensions.

### Solution

Updated the import statements in `ProductExtension.liquid` to correctly reference JSX files with their `.jsx` extension. This change ensures proper file resolution during build and runtime.

Specifically:
- Changed the flavor check from `contains "preact"` to an exact match `== "preact"`
- Added the `.jsx` extension to the Preact import
- Added conditional logic for React imports to use `.jsx` extension when the flavor is exactly "react"

These changes ensure consistent file resolution across different flavor configurations.

### Tophat
1. Create an preact extension with the following command `POLARIS_UNIFIED=true shopify app generate extension --clone-url https://github.com/Shopify/extensions-templates#cx-include-extension-purchaseoptionsaction-react-preact --template admin_purchase_option`
1. Create a legacy react extension with the following command `shopify app generate extension --clone-url https://github.com/Shopify/extensions-templates#cx-include-extension-purchaseoptionsaction-react-preact --template admin_purchase_option --flavor react`
1. Create a legacy react typescript extension with the following command `shopify app generate extension --clone-url https://github.com/Shopify/extensions-templates#cx-include-extension-purchaseoptionsaction-react-preact --template admin_purchase_option --flavor typescript-react`
2. Run `shopify app build` and verify that it builds all extensions without errors

### Checklist

- [X] I have 🎩'd these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages