### PR TITLE
Update to use latest `shopify_function` crate

### DIFF
--- a/.github/workflows/validate-rust-functions.yml
+++ b/.github/workflows/validate-rust-functions.yml
@@ -28,5 +28,5 @@ jobs:
         run: cargo clippy -- -D warnings
       - name: Run tests
         run: cargo test
-      - name: Build with wasm32-wasip1 target
-        run: cargo build --release --target wasm32-wasip1
+      - name: Build with wasm32-unknown-unknown target
+        run: cargo build --release --target wasm32-unknown-unknown

--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ cargo clippy -- -D warnings
 # Run tests
 cargo test
 # Build .wasm packages
-cargo build --release --target wasm32-wasip1
+cargo build --release --target wasm32-unknown-unknown
 ```

--- a/functions-cart-checkout-validation-rs/shopify.extension.toml.liquid
+++ b/functions-cart-checkout-validation-rs/shopify.extension.toml.liquid
@@ -13,6 +13,6 @@ description = "t:description"
   export = "cart_validations_generate_run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = ["src/**/*.rs"]

--- a/functions-cart-checkout-validation-rs/src/main.rs
+++ b/functions-cart-checkout-validation-rs/src/main.rs
@@ -10,6 +10,6 @@ pub mod schema {
 }
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/functions-cart-transform-rs/shopify.extension.toml.liquid
+++ b/functions-cart-transform-rs/shopify.extension.toml.liquid
@@ -13,8 +13,8 @@ description = "t:description"
   export = "cart_transform_run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/functions-cart-transform-rs/src/main.rs
+++ b/functions-cart-transform-rs/src/main.rs
@@ -10,6 +10,6 @@ pub mod schema {
 }
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/functions-delivery-customization-rs/shopify.extension.toml.liquid
+++ b/functions-delivery-customization-rs/shopify.extension.toml.liquid
@@ -13,8 +13,8 @@ description = "t:description"
   export = "cart_delivery_options_transform_run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/functions-delivery-customization-rs/src/main.rs
+++ b/functions-delivery-customization-rs/src/main.rs
@@ -12,6 +12,6 @@ pub mod schema {
 }
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/functions-discount-rs/README.md
+++ b/functions-discount-rs/README.md
@@ -10,7 +10,7 @@
 You can build this individual function using `cargo build`.
 
 ```shell
-cargo build --target=wasm32-wasip1 --release
+cargo build --target=wasm32-unknown-unknown --release
 ```
 
 The Shopify CLI `build` command will also execute this, based on the configuration in `shopify.extension.toml`.

--- a/functions-discount-rs/shopify.extension.toml.liquid
+++ b/functions-discount-rs/shopify.extension.toml.liquid
@@ -18,6 +18,6 @@ description = "t:description"
   export = "cart_delivery_options_discounts_generate_run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]

--- a/functions-discount-rs/src/main.rs
+++ b/functions-discount-rs/src/main.rs
@@ -14,6 +14,6 @@ pub mod schema {
 }
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/functions-discounts-allocator-rs/README.md
+++ b/functions-discounts-allocator-rs/README.md
@@ -10,7 +10,7 @@
 You can build this individual function using `cargo build`.
 
 ```shell
-cargo build --target=wasm32-wasip1 --release
+cargo build --target=wasm32-unknown-unknown --release
 ```
 
 The Shopify CLI `build` command will also execute this, based on the configuration in `shopify.extension.toml`.

--- a/functions-discounts-allocator-rs/shopify.extension.toml.liquid
+++ b/functions-discounts-allocator-rs/shopify.extension.toml.liquid
@@ -13,8 +13,8 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/functions-discounts-allocator-rs/src/main.rs
+++ b/functions-discounts-allocator-rs/src/main.rs
@@ -10,6 +10,6 @@ pub mod schema {
 }
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/functions-fulfillment-constraints-rs/shopify.extension.toml.liquid
+++ b/functions-fulfillment-constraints-rs/shopify.extension.toml.liquid
@@ -13,8 +13,8 @@ description = "t:description"
   export = "cart_fulfillment_constraints_generate_run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/functions-fulfillment-constraints-rs/src/main.rs
+++ b/functions-fulfillment-constraints-rs/src/main.rs
@@ -10,6 +10,6 @@ pub mod schema {
 }
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/functions-local-pickup-delivery-option-generators-rs/shopify.extension.toml.liquid
+++ b/functions-local-pickup-delivery-option-generators-rs/shopify.extension.toml.liquid
@@ -12,8 +12,8 @@ type = "function"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/functions-local-pickup-delivery-option-generators-rs/src/main.rs
+++ b/functions-local-pickup-delivery-option-generators-rs/src/main.rs
@@ -10,6 +10,6 @@ pub mod schema {
 }
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/functions-location-rules-rs/shopify.extension.toml.liquid
+++ b/functions-location-rules-rs/shopify.extension.toml.liquid
@@ -13,8 +13,8 @@ description = "t:description"
   export = "cart_fulfillment_groups_location_rankings_generate_run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/functions-location-rules-rs/src/main.rs
+++ b/functions-location-rules-rs/src/main.rs
@@ -10,6 +10,6 @@ pub mod schema {
 }
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/functions-order-discounts-rs/README.md
+++ b/functions-order-discounts-rs/README.md
@@ -10,7 +10,7 @@
 You can build this individual function using `cargo build`.
 
 ```shell
-cargo build --target=wasm32-wasip1 --release
+cargo build --target=wasm32-unknown-unknown --release
 ```
 
 The Shopify CLI `build` command will also execute this, based on the configuration in `shopify.extension.toml`.

--- a/functions-order-discounts-rs/shopify.extension.toml.liquid
+++ b/functions-order-discounts-rs/shopify.extension.toml.liquid
@@ -13,8 +13,8 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/functions-order-discounts-rs/src/main.rs
+++ b/functions-order-discounts-rs/src/main.rs
@@ -12,6 +12,6 @@ pub mod schema {
 }
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/functions-payment-customization-rs/shopify.extension.toml.liquid
+++ b/functions-payment-customization-rs/shopify.extension.toml.liquid
@@ -13,8 +13,8 @@ description = "t:description"
   export = "cart_payment_methods_transform_run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/functions-payment-customization-rs/src/main.rs
+++ b/functions-payment-customization-rs/src/main.rs
@@ -12,6 +12,6 @@ pub mod schema {
 }
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/functions-pickup-point-delivery-option-generators-rs/shopify.extension.toml.liquid
+++ b/functions-pickup-point-delivery-option-generators-rs/shopify.extension.toml.liquid
@@ -17,8 +17,8 @@ input_query = "src/run.graphql"
 export = "run"
 
 [extensions.build]
-command = "cargo build --target=wasm32-wasip1 --release"
-path = "target/wasm32-wasip1/release/{{handle | replace: " ", "_" | downcase}}.wasm"
+command = "cargo build --target=wasm32-unknown-unknown --release"
+path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "_" | downcase}}.wasm"
 watch = ["src/**/*.rs"]
 
 [extensions.ui.paths]

--- a/functions-pickup-point-delivery-option-generators-rs/src/main.rs
+++ b/functions-pickup-point-delivery-option-generators-rs/src/main.rs
@@ -13,6 +13,6 @@ pub mod schema {
 }
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/functions-product-discounts-rs/README.md
+++ b/functions-product-discounts-rs/README.md
@@ -10,7 +10,7 @@
 You can build this individual function using `cargo build`.
 
 ```shell
-cargo build --target=wasm32-wasip1 --release
+cargo build --target=wasm32-unknown-unknown --release
 ```
 
 The Shopify CLI `build` command will also execute this, based on the configuration in `shopify.extension.toml`.

--- a/functions-product-discounts-rs/shopify.extension.toml.liquid
+++ b/functions-product-discounts-rs/shopify.extension.toml.liquid
@@ -13,8 +13,8 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/functions-product-discounts-rs/src/main.rs
+++ b/functions-product-discounts-rs/src/main.rs
@@ -12,6 +12,6 @@ pub mod schema {
 }
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/functions-shipping-discounts-rs/README.md
+++ b/functions-shipping-discounts-rs/README.md
@@ -10,7 +10,7 @@
 You can build this individual function using `cargo build`.
 
 ```shell
-cargo build --target=wasm32-wasip1 --release
+cargo build --target=wasm32-unknown-unknown --release
 ```
 
 The Shopify CLI `build` command will also execute this, based on the configuration in `shopify.extension.toml`.

--- a/functions-shipping-discounts-rs/shopify.extension.toml.liquid
+++ b/functions-shipping-discounts-rs/shopify.extension.toml.liquid
@@ -13,8 +13,8 @@ description = "t:description"
   export = "run"
 
   [extensions.build]
-  command = "cargo build --target=wasm32-wasip1 --release"
-  path = "target/wasm32-wasip1/release/{{handle | replace: " ", "-" | downcase}}.wasm"
+  command = "cargo build --target=wasm32-unknown-unknown --release"
+  path = "target/wasm32-unknown-unknown/release/{{handle | replace: " ", "-" | downcase}}.wasm"
   watch = [ "src/**/*.rs" ]
 
   [extensions.ui.paths]

--- a/functions-shipping-discounts-rs/src/main.rs
+++ b/functions-shipping-discounts-rs/src/main.rs
@@ -12,6 +12,6 @@ pub mod schema {
 }
 
 fn main() {
-    eprintln!("Please invoke a named export.");
-    process::exit(1);
+    log!("Please invoke a named export.");
+    process::abort();
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "stable"
 components = ["rustfmt", "clippy"]
-targets = ["wasm32-wasip1"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
### Background

The new version of the Function Wasm API does not support using WASI and the upcoming `shopify_function` Rust crate has a new logging API.

### Solution

- Update the build targets to use `wasm32-unknown-unknown` instead of `wasm32-wasip1`
- Update `process::exit(1)` to `process::abort()`
- Update `eprintln!` to `log!`

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
