### PR TITLE
Remove channel specifications from channel-config extension

### DIFF
--- a/channel-config/shopify.extension.toml.liquid
+++ b/channel-config/shopify.extension.toml.liquid
@@ -2,7 +2,3 @@
 type = "channel_config"
 name = "{{ name }}"
 handle = "{{ handle }}"
-specifications = [
-  "example-us.toml",
-  "example-de.toml"
-]


### PR DESCRIPTION
### Background

Removed the `specifications` field from the Shopify extension configuration template as it can easily inferred by the specifications folder content

### Checklist

- [x] I have 🎩'd these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages