### PR TITLE
Update the ui-extension templates to use preact by default

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -890,7 +890,7 @@
     "deprecatedFromCliVersion": "3.78.2"
   },
   {
-    "identifier": "validation_settings_ui",
+    "identifier": "validation_settings_ui_pre_release",
     "name": "Cart and checkout validation function settings",
     "defaultName": "validation-settings-ui",
     "group": "UI extensions",
@@ -927,7 +927,28 @@
         "path": "validation-settings"
       }
     ],
-    "minimumCliVersion": "3.78.2"
+    "minimumCliVersion": "3.78.2",
+    "deprecatedFromCliVersion": "3.85.1"
+  },
+  {
+    "identifier": "validation_settings_ui",
+    "name": "Cart and checkout validation function settings",
+    "defaultName": "validation-settings-ui",
+    "group": "UI extensions",
+    "supportLinks": [
+      "https://shopify.dev/docs/apps/checkout/validation/server-side"
+    ],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Preact",
+        "value": "preact",
+        "path": "validation-settings"
+      }
+    ],
+    "minimumCliVersion": "3.85.1"
   },
   {
     "identifier": "order_routing_location_rule_ui",
@@ -1000,7 +1021,7 @@
     "deprecatedFromCliVersion": "3.78.2"
   },
   {
-    "identifier": "pos_action",
+    "identifier": "pos_action_pre_release",
     "name": "POS action",
     "defaultName": "pos-action",
     "group": "UI extensions",
@@ -1035,7 +1056,26 @@
         "path": "pos-action"
       }
     ],
-    "minimumCliVersion": "3.78.2"
+    "minimumCliVersion": "3.78.2",
+    "deprecatedFromCliVersion": "3.85.1"
+  },
+  {
+    "identifier": "pos_action",
+    "name": "POS action",
+    "defaultName": "pos-action",
+    "group": "UI extensions",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Preact",
+        "value": "preact",
+        "path": "pos-action"
+      }
+    ],
+    "minimumCliVersion": "3.85.1"
   },
   {
     "identifier": "pos_block_legacy",
@@ -1071,7 +1111,7 @@
     "deprecatedFromCliVersion": "3.78.2"
   },
   {
-    "identifier": "pos_block",
+    "identifier": "pos_block_pre_release",
     "name": "POS block",
     "defaultName": "pos-block",
     "group": "UI extensions",
@@ -1106,7 +1146,26 @@
         "path": "pos-block"
       }
     ],
-    "minimumCliVersion": "3.78.2"
+    "minimumCliVersion": "3.78.2",
+    "deprecatedFromCliVersion": "3.85.1"
+  },
+  {
+    "identifier": "pos_block",
+    "name": "POS block",
+    "defaultName": "pos-block",
+    "group": "UI extensions",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Preact",
+        "value": "preact",
+        "path": "pos-block"
+      }
+    ],
+    "minimumCliVersion": "3.85.1"
   },
   {
     "identifier": "pos_smart_grid_legacy",
@@ -1142,7 +1201,7 @@
     "deprecatedFromCliVersion": "3.78.2"
   },
   {
-    "identifier": "pos_smart_grid",
+    "identifier": "pos_smart_grid_pre_release",
     "name": "POS smart grid",
     "defaultName": "pos-smart-grid",
     "group": "UI extensions",
@@ -1177,7 +1236,26 @@
         "path": "pos-smart-grid"
       }
     ],
-    "minimumCliVersion": "3.78.2"
+    "minimumCliVersion": "3.78.2",
+    "deprecatedFromCliVersion": "3.85.1"
+  },
+  {
+    "identifier": "pos_smart_grid",
+    "name": "POS smart grid",
+    "defaultName": "pos-smart-grid",
+    "group": "UI extensions",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Preact",
+        "value": "preact",
+        "path": "pos-smart-grid"
+      }
+    ],
+    "minimumCliVersion": "3.85.1"
   },
   {
     "identifier": "cart_checkout_validation",


### PR DESCRIPTION
This pull request updates the `templates.json` file to deprecate several pre-release UI extension templates and introduce new stable versions of those templates, effective from CLI version 3.85.0. For each affected extension, the pre-release template is marked as deprecated and a new entry is added for its stable counterpart with updated metadata.

Deprecation and introduction of stable UI extension templates:

* Deprecated pre-release templates and added stable versions for the following UI extensions: `checkout_ui`, `customer_account_ui`, `admin_action`, `admin_block`, `admin_print`, `admin_purchase_option`, `conditional_admin_action`, and `product_configuration`. Each stable version is available from CLI version 3.85.0 and includes updated metadata. [[1]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL38-R38) [[2]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL145-R166) [[3]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL216-R256) [[4]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL287-R346) [[5]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL358-R436) [[6]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL429-R526) [[7]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL501-R617) [[8]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL609-R744)
* For each new stable template, added or updated fields such as `supportLinks`, `url`, `type`, `extensionPoints`, `supportedFlavors`, and `minimumCliVersion` to ensure consistency and provide additional documentation links where relevant. [[1]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL75-R96) [[2]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL180-R220) [[3]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL251-R310) [[4]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL322-R400) [[5]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL393-R490) [[6]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL464-R580) [[7]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL536-R671) [[8]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL646-R802)

Versioning and compatibility updates:

* Set the `deprecatedFromCliVersion` field to `3.85.0` for all pre-release templates to indicate when they are no longer supported. [[1]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL75-R96) [[2]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL180-R220) [[3]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL251-R310) [[4]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL322-R400) [[5]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL393-R490) [[6]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL464-R580) [[7]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL536-R671) [[8]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL646-R802)
* Ensured that all new stable templates require a minimum CLI version of `3.85.0` to be used. [[1]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL75-R96) [[2]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL180-R220) [[3]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL251-R310) [[4]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL322-R400) [[5]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL393-R490) [[6]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL464-R580) [[7]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL536-R671) [[8]](diffhunk://#diff-4559d9c33eeb9a10ed9c3970cab31e7514e354827585f016cfe737fe190379ffL646-R802)