### PR TITLE
Adding wasm level test fixture and default test

### DIFF
--- a/functions-cart-checkout-validation-js/tests/default.test.js
+++ b/functions-cart-checkout-validation-js/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-cart-checkout-validation-js/tests/fixtures/log.json
+++ b/functions-cart-checkout-validation-js/tests/fixtures/log.json
@@ -1,0 +1,30 @@
+{
+  "payload": {
+    "export": "cart-validations-generate-run",
+  "target": "cart.validations.generate.run",
+  "input": {
+    "cart": {
+      "lines": [
+        {
+          "quantity": 1
+        },
+        {
+          "quantity": 1
+        },
+        {
+          "quantity": 1
+        }
+      ]
+    }
+  },
+  "output": {
+    "operations": [
+      {
+        "validationAdd": {
+          "errors": []
+        }
+      }
+    ]
+  }
+  }
+}

--- a/functions-cart-checkout-validation-rs/tests/default.test.js
+++ b/functions-cart-checkout-validation-rs/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-cart-checkout-validation-rs/tests/fixtures/log.json
+++ b/functions-cart-checkout-validation-rs/tests/fixtures/log.json
@@ -1,0 +1,24 @@
+{
+  "payload": {
+    "export": "run",
+  "target": "purchase.validation.run",
+  "input": {
+    "cart": {
+      "lines": [
+        {
+          "quantity": 1
+        },
+        {
+          "quantity": 1
+        },
+        {
+          "quantity": 1
+        }
+      ]
+    }
+  },
+  "output": {
+    "errors": []
+  }
+  }
+}

--- a/functions-cart-checkout-validation-wasm/tests/default.test.js
+++ b/functions-cart-checkout-validation-wasm/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-cart-checkout-validation-wasm/tests/fixtures/log.json
+++ b/functions-cart-checkout-validation-wasm/tests/fixtures/log.json
@@ -1,0 +1,30 @@
+{
+  "payload": {
+    "export": "cart-validations-generate-run",
+  "target": "cart.validations.generate.run",
+  "input": {
+    "cart": {
+      "lines": [
+        {
+          "quantity": 1
+        },
+        {
+          "quantity": 1
+        },
+        {
+          "quantity": 1
+        }
+      ]
+    }
+  },
+  "output": {
+    "operations": [
+      {
+        "validationAdd": {
+          "errors": []
+        }
+      }
+    ]
+  }
+  }
+}

--- a/functions-cart-transform-js/tests/default.test.js
+++ b/functions-cart-transform-js/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/cart_transform_run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-cart-transform-js/tests/fixtures/log.json
+++ b/functions-cart-transform-js/tests/fixtures/log.json
@@ -1,0 +1,24 @@
+{
+  "payload": {
+    "export": "cart-transform-run",
+    "target": "cart.transform.run",
+    "input": {
+      "cart": {
+        "buyerIdentity": null,
+        "cost": {
+          "subtotalAmount": {
+            "amount": "100.0"
+          }
+        },
+        "lines": [
+          {
+            "quantity": 1
+          }
+        ]
+      }
+    },
+    "output": {
+      "operations": []
+    }
+  }
+}

--- a/functions-cart-transform-rs/tests/default.test.js
+++ b/functions-cart-transform-rs/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/cart_transform_run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-cart-transform-rs/tests/fixtures/log.json
+++ b/functions-cart-transform-rs/tests/fixtures/log.json
@@ -1,0 +1,24 @@
+{
+  "payload": {
+    "export": "cart_transform_run",
+    "target": "cart.transform.run",
+    "input": {
+      "cart": {
+        "buyerIdentity": null,
+        "cost": {
+          "subtotalAmount": {
+            "amount": "100.0"
+          }
+        },
+        "lines": [
+          {
+            "quantity": 1
+          }
+        ]
+      }
+    },
+    "output": {
+      "operations": []
+    }
+  }
+}

--- a/functions-cart-transform-wasm/tests/default.test.js
+++ b/functions-cart-transform-wasm/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/cart_transform_run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-cart-transform-wasm/tests/fixtures/log.json
+++ b/functions-cart-transform-wasm/tests/fixtures/log.json
@@ -1,0 +1,24 @@
+{
+  "payload": {
+    "export": "cart_transform_run",
+    "target": "cart.transform.run",
+    "input": {
+      "cart": {
+        "buyerIdentity": null,
+        "cost": {
+          "subtotalAmount": {
+            "amount": "100.0"
+          }
+        },
+        "lines": [
+          {
+            "quantity": 1
+          }
+        ]
+      }
+    },
+    "output": {
+      "operations": []
+    }
+  }
+}

--- a/functions-delivery-customization-js/tests/default.test.js
+++ b/functions-delivery-customization-js/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/cart_delivery_options_transform_run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-delivery-customization-js/tests/fixtures/log.json
+++ b/functions-delivery-customization-js/tests/fixtures/log.json
@@ -1,0 +1,24 @@
+{
+  "payload": {
+    "export": "cart-delivery-options-transform-run",
+    "target": "cart.delivery-options.transform.run",
+    "input": {
+      "cart": {
+        "buyerIdentity": null,
+        "cost": {
+          "subtotalAmount": {
+            "amount": "100.0"
+          }
+        },
+        "lines": [
+          {
+            "quantity": 1
+          }
+        ]
+      }
+    },
+    "output": {
+      "operations": []
+    }
+  }
+}

--- a/functions-delivery-customization-rs/tests/default.test.js
+++ b/functions-delivery-customization-rs/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/cart_delivery_options_transform_run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-delivery-customization-rs/tests/fixtures/log.json
+++ b/functions-delivery-customization-rs/tests/fixtures/log.json
@@ -1,0 +1,24 @@
+{
+  "payload": {
+    "export": "cart_delivery_options_transform_run",
+    "target": "cart.delivery-options.transform.run",
+    "input": {
+      "cart": {
+        "buyerIdentity": null,
+        "cost": {
+          "subtotalAmount": {
+            "amount": "100.0"
+          }
+        },
+        "lines": [
+          {
+            "quantity": 1
+          }
+        ]
+      }
+    },
+    "output": {
+      "operations": []
+    }
+  }
+}

--- a/functions-delivery-customization-wasm/tests/default.test.js
+++ b/functions-delivery-customization-wasm/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/cart_delivery_options_transform_run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-delivery-customization-wasm/tests/fixtures/log.json
+++ b/functions-delivery-customization-wasm/tests/fixtures/log.json
@@ -1,0 +1,24 @@
+{
+  "payload": {
+    "export": "cart_delivery_options_transform_run",
+    "target": "cart.delivery-options.transform.run",
+    "input": {
+      "cart": {
+        "buyerIdentity": null,
+        "cost": {
+          "subtotalAmount": {
+            "amount": "100.0"
+          }
+        },
+        "lines": [
+          {
+            "quantity": 1
+          }
+        ]
+      }
+    },
+    "output": {
+      "operations": []
+    }
+  }
+}

--- a/functions-discount-js/tests/default.test.js
+++ b/functions-discount-js/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/cart_delivery_options_discounts_generate_run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-discount-js/tests/fixtures/log.json
+++ b/functions-discount-js/tests/fixtures/log.json
@@ -1,0 +1,49 @@
+{
+  "payload": {
+    "export": "cart-delivery-options-discounts-generate-run",
+    "target": "cart.delivery-options.discounts.generate.run",
+    "input": {
+      "discount": {
+        "discountClasses": ["SHIPPING"]
+      },
+      "cart": {
+        "deliveryGroups": [
+           {
+             "id": "gid://shopify/CartDeliveryGroup/1"
+           }
+        ],
+        "cost": {
+          "subtotalAmount": {
+            "amount": "100.0"
+          }
+        }
+      }
+    },
+    "output": {
+      "operations": [
+        {
+          "deliveryDiscountsAdd": {
+            "candidates": [
+              {
+                "message": "FREE DELIVERY",
+                "targets": [
+                  {
+                    "deliveryGroup": {
+                      "id": "gid://shopify/CartDeliveryGroup/1"
+                    }
+                  }
+                ],
+                "value": {
+                  "percentage": {
+                    "value": 100
+                  }
+                }
+              }
+            ],
+            "selectionStrategy": "ALL"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/functions-discount-rs/tests/default.test.js
+++ b/functions-discount-rs/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/cart_delivery_options_discounts_generate_run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-discount-rs/tests/fixtures/log.json
+++ b/functions-discount-rs/tests/fixtures/log.json
@@ -1,0 +1,45 @@
+{
+  "payload": {
+    "export": "cart_delivery_options_discounts_generate_run",
+    "target": "cart.delivery-options.discounts.generate.run",
+    "input": {
+      "discount": {
+        "discountClasses": ["SHIPPING"]
+      },
+      "cart": {
+        "deliveryGroups": [
+          {
+            "id": "gid://shopify/CartDeliveryGroup/1"
+          }
+        ]
+      }
+    },
+    "output": {
+      "operations": [
+      {
+        "deliveryDiscountsAdd": {
+          "candidates": [
+            {
+              "associatedDiscountCode": null,
+              "message": "FREE DELIVERY",
+              "targets": [
+                {
+                  "deliveryGroup": {
+                    "id": "gid://shopify/CartDeliveryGroup/1"
+                  }
+                }
+              ],
+              "value": {
+                "percentage": {
+                  "value": "100.0"
+                }
+              }
+            }
+            ],
+            "selectionStrategy": "ALL"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/functions-discount-wasm/tests/default.test.js
+++ b/functions-discount-wasm/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/cart_delivery_options_discounts_generate_run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-discount-wasm/tests/fixtures/log.json
+++ b/functions-discount-wasm/tests/fixtures/log.json
@@ -1,0 +1,45 @@
+{
+  "payload": {
+    "export": "cart_delivery_options_discounts_generate_run",
+    "target": "cart.delivery-options.discounts.generate.run",
+    "input": {
+      "discount": {
+        "discountClasses": ["SHIPPING"]
+      },
+      "cart": {
+        "deliveryGroups": [
+          {
+            "id": "gid://shopify/CartDeliveryGroup/1"
+          }
+        ]
+      }
+    },
+    "output": {
+      "operations": [
+      {
+        "deliveryDiscountsAdd": {
+          "candidates": [
+            {
+              "associatedDiscountCode": null,
+              "message": "FREE DELIVERY",
+              "targets": [
+                {
+                  "deliveryGroup": {
+                    "id": "gid://shopify/CartDeliveryGroup/1"
+                  }
+                }
+              ],
+              "value": {
+                "percentage": {
+                  "value": "100.0"
+                }
+              }
+            }
+            ],
+            "selectionStrategy": "ALL"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/functions-discounts-allocator-js/tests/default.test.js
+++ b/functions-discounts-allocator-js/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-discounts-allocator-js/tests/fixtures/log.json
+++ b/functions-discounts-allocator-js/tests/fixtures/log.json
@@ -1,0 +1,17 @@
+{
+  "payload": {
+    "export": "run",
+    "target": "purchase.discounts-allocator.run",
+    "input": {
+      "shop": {
+        "metafield": {
+          "value": "{\"discountConfiguration\": {\"enabled\": true, \"allocationType\": \"proportional\"}}"
+        }
+      }
+    },
+    "output": {
+      "displayableErrors": [],
+      "lineDiscounts": []
+    }
+  }
+}

--- a/functions-discounts-allocator-rs/tests/default.test.js
+++ b/functions-discounts-allocator-rs/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-discounts-allocator-rs/tests/fixtures/log.json
+++ b/functions-discounts-allocator-rs/tests/fixtures/log.json
@@ -1,0 +1,17 @@
+{
+  "payload": {
+    "export": "run",
+    "target": "purchase.discounts-allocator.run",
+    "input": {
+      "shop": {
+        "metafield": {
+          "value": "{\"discountConfiguration\": {\"enabled\": true, \"allocationType\": \"proportional\"}}"
+        }
+      }
+    },
+    "output": {
+      "displayableErrors": [],
+      "lineDiscounts": []
+    }
+  }
+}

--- a/functions-discounts-allocator-wasm/tests/default.test.js
+++ b/functions-discounts-allocator-wasm/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-discounts-allocator-wasm/tests/fixtures/log.json
+++ b/functions-discounts-allocator-wasm/tests/fixtures/log.json
@@ -1,0 +1,17 @@
+{
+  "payload": {
+    "export": "run",
+    "target": "purchase.discounts-allocator.run",
+    "input": {
+      "shop": {
+        "metafield": {
+          "value": "{\"discountConfiguration\": {\"enabled\": true, \"allocationType\": \"proportional\"}}"
+        }
+      }
+    },
+    "output": {
+      "displayableErrors": [],
+      "lineDiscounts": []
+    }
+  }
+}

--- a/functions-fulfillment-constraints-js/tests/default.test.js
+++ b/functions-fulfillment-constraints-js/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/cart_fulfillment_constraints_generate_run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-fulfillment-constraints-js/tests/fixtures/log.json
+++ b/functions-fulfillment-constraints-js/tests/fixtures/log.json
@@ -1,0 +1,27 @@
+{
+  "payload": {
+    "export": "cart-fulfillment-constraints-generate-run",
+    "target": "cart.fulfillment-constraints.generate.run",
+    "input": {
+      "cart": {
+        "deliverableLines": [
+          {
+            "id": "gid://shopify/CartLine/1"
+          }
+        ]
+      },
+      "fulfillmentConstraintRule": {
+        "metafield": {
+          "jsonValue": {
+            "constraintType": "shipping_method",
+            "restrictedMethods": ["standard"],
+            "allowedMethods": ["express", "overnight"]
+          }
+        }
+      }
+    },
+    "output": {
+      "operations": []
+    }
+  }
+}

--- a/functions-fulfillment-constraints-rs/tests/default.test.js
+++ b/functions-fulfillment-constraints-rs/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/cart_fulfillment_constraints_generate_run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-fulfillment-constraints-rs/tests/fixtures/log.json
+++ b/functions-fulfillment-constraints-rs/tests/fixtures/log.json
@@ -1,0 +1,27 @@
+{
+  "payload": {
+    "export": "cart_fulfillment_constraints_generate_run",
+    "target": "cart.fulfillment-constraints.generate.run",
+    "input": {
+      "cart": {
+        "deliverableLines": [
+          {
+            "id": "gid://shopify/CartLine/1"
+          }
+        ]
+      },
+      "fulfillmentConstraintRule": {
+        "metafield": {
+          "jsonValue": {
+            "constraintType": "shipping_method",
+            "restrictedMethods": ["standard"],
+            "allowedMethods": ["express", "overnight"]
+          }
+        }
+      }
+    },
+    "output": {
+      "operations": []
+    }
+  }
+}

--- a/functions-fulfillment-constraints-wasm/tests/default.test.js
+++ b/functions-fulfillment-constraints-wasm/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/cart_fulfillment_constraints_generate_run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-fulfillment-constraints-wasm/tests/fixtures/log.json
+++ b/functions-fulfillment-constraints-wasm/tests/fixtures/log.json
@@ -1,0 +1,27 @@
+{
+  "payload": {
+    "export": "cart_fulfillment_constraints_generate_run",
+    "target": "cart.fulfillment-constraints.generate.run",
+    "input": {
+      "cart": {
+        "deliverableLines": [
+          {
+            "id": "gid://shopify/CartLine/1"
+          }
+        ]
+      },
+      "fulfillmentConstraintRule": {
+        "metafield": {
+          "jsonValue": {
+            "constraintType": "shipping_method",
+            "restrictedMethods": ["standard"],
+            "allowedMethods": ["express", "overnight"]
+          }
+        }
+      }
+    },
+    "output": {
+      "operations": []
+    }
+  }
+}

--- a/functions-local-pickup-delivery-option-generators-js/tests/default.test.js
+++ b/functions-local-pickup-delivery-option-generators-js/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-local-pickup-delivery-option-generators-js/tests/fixtures/log.json
+++ b/functions-local-pickup-delivery-option-generators-js/tests/fixtures/log.json
@@ -1,0 +1,57 @@
+{
+  "payload": {
+    "export": "run",
+    "target": "purchase.local-pickup-delivery-option-generator.run",
+    "input": {
+      "cart": {
+        "lines": [
+          {
+            "id": "gid://shopify/CartLine/1"
+          }
+        ]
+      },
+      "fulfillmentGroups": [
+        {
+          "handle": "group1",
+          "inventoryLocationHandles": ["location1"],
+          "lines": [
+            {
+              "id": "gid://shopify/CartLine/1"
+            }
+          ],
+          "deliveryGroup": {
+            "id": "gid://shopify/CartDeliveryGroup/1"
+          }
+        }
+      ],
+      "locations": [
+        {
+          "handle": "location1",
+          "name": "Main Store",
+          "address": {
+            "address1": "123 Main Street"
+          }
+        }
+      ],
+      "deliveryOptionGenerator": {
+        "metafield": {
+          "value": "[\"location1\", \"location2\"]"
+        }
+      }
+    },
+    "output": {
+      "operations": [
+        {
+          "add": {
+            "title": "Main St.",
+            "cost": 1.99,
+            "pickupLocation": {
+              "locationHandle": "2578303",
+              "pickupInstruction": "Usually ready in 24 hours."
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/functions-local-pickup-delivery-option-generators-rs/tests/default.test.js
+++ b/functions-local-pickup-delivery-option-generators-rs/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-local-pickup-delivery-option-generators-rs/tests/fixtures/log.json
+++ b/functions-local-pickup-delivery-option-generators-rs/tests/fixtures/log.json
@@ -1,0 +1,58 @@
+{
+  "payload": {
+    "export": "run",
+    "target": "purchase.local-pickup-delivery-option-generator.run",
+    "input": {
+      "cart": {
+        "lines": [
+          {
+            "id": "gid://shopify/CartLine/1"
+          }
+        ]
+      },
+      "fulfillmentGroups": [
+        {
+          "handle": "group1",
+          "inventoryLocationHandles": ["location1"],
+          "lines": [
+            {
+              "id": "gid://shopify/CartLine/1"
+            }
+          ],
+          "deliveryGroup": {
+            "id": "gid://shopify/CartDeliveryGroup/1"
+          }
+        }
+      ],
+      "locations": [
+        {
+          "handle": "location1",
+          "name": "Main Store",
+          "address": {
+            "address1": "123 Main Street"
+          }
+        }
+      ],
+      "deliveryOptionGenerator": {
+        "metafield": {
+          "value": "[\"location1\", \"location2\"]"
+        }
+      }
+    },
+    "output": {
+      "operations": [
+        {
+          "add": {
+            "cost": "1.99",
+              "metafields": null,
+              "pickupLocation": {
+                "locationHandle": "2578303",
+                "pickupInstruction": "Usually ready in 24 hours."
+              },
+              "title": "Main St."
+          }
+        }
+      ]
+    }
+  }
+}

--- a/functions-local-pickup-delivery-option-generators-wasm/tests/default.test.js
+++ b/functions-local-pickup-delivery-option-generators-wasm/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-local-pickup-delivery-option-generators-wasm/tests/fixtures/log.json
+++ b/functions-local-pickup-delivery-option-generators-wasm/tests/fixtures/log.json
@@ -1,0 +1,58 @@
+{
+  "payload": {
+    "export": "run",
+    "target": "purchase.local-pickup-delivery-option-generator.run",
+    "input": {
+      "cart": {
+        "lines": [
+          {
+            "id": "gid://shopify/CartLine/1"
+          }
+        ]
+      },
+      "fulfillmentGroups": [
+        {
+          "handle": "group1",
+          "inventoryLocationHandles": ["location1"],
+          "lines": [
+            {
+              "id": "gid://shopify/CartLine/1"
+            }
+          ],
+          "deliveryGroup": {
+            "id": "gid://shopify/CartDeliveryGroup/1"
+          }
+        }
+      ],
+      "locations": [
+        {
+          "handle": "location1",
+          "name": "Main Store",
+          "address": {
+            "address1": "123 Main Street"
+          }
+        }
+      ],
+      "deliveryOptionGenerator": {
+        "metafield": {
+          "value": "[\"location1\", \"location2\"]"
+        }
+      }
+    },
+    "output": {
+      "operations": [
+        {
+          "add": {
+            "cost": "1.99",
+              "metafields": null,
+              "pickupLocation": {
+                "locationHandle": "2578303",
+                "pickupInstruction": "Usually ready in 24 hours."
+              },
+              "title": "Main St."
+          }
+        }
+      ]
+    }
+  }
+}

--- a/functions-location-rules-js/tests/default.test.js
+++ b/functions-location-rules-js/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/cart_fulfillment_groups_location_rankings_generate_run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-location-rules-js/tests/fixtures/log.json
+++ b/functions-location-rules-js/tests/fixtures/log.json
@@ -1,0 +1,56 @@
+{
+  "payload": {
+    "export": "cart-fulfillment-groups-location-rankings-generate-run",
+    "target": "cart.fulfillment-groups.location-rankings.generate.run",
+    "input": {
+      "fulfillmentGroups": [
+        {
+          "handle": "123",
+          "inventoryLocationHandles": ["456", "789"]
+        },
+        {
+          "handle": "456",
+          "inventoryLocationHandles": ["101", "112", "131"]
+        }
+      ]
+    },
+    "output": {
+      "operations": [
+        {
+          "fulfillmentGroupLocationRankingAdd": {
+            "fulfillmentGroupHandle": "123",
+            "rankings": [
+              {
+                "locationHandle": "456",
+                "rank": 0
+              },
+              {
+                "locationHandle": "789",
+                "rank": 0
+              }
+            ]
+          }
+        },
+        {
+          "fulfillmentGroupLocationRankingAdd": {
+            "fulfillmentGroupHandle": "456",
+            "rankings": [
+              {
+                "locationHandle": "101",
+                "rank": 0
+              },
+              {
+                "locationHandle": "112",
+                "rank": 0
+              },
+              {
+                "locationHandle": "131",
+                "rank": 0
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/functions-location-rules-rs/tests/default.test.js
+++ b/functions-location-rules-rs/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/cart_fulfillment_groups_location_rankings_generate_run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-location-rules-rs/tests/fixtures/log.json
+++ b/functions-location-rules-rs/tests/fixtures/log.json
@@ -1,0 +1,56 @@
+{
+  "payload": {
+    "export": "cart_fulfillment_groups_location_rankings_generate_run",
+    "target": "cart.fulfillment-groups.location-rankings.generate.run",
+    "input": {
+      "fulfillmentGroups": [
+        {
+          "handle": "123",
+          "inventoryLocationHandles": ["456", "789"]
+        },
+        {
+          "handle": "456",
+          "inventoryLocationHandles": ["101", "112", "131"]
+        }
+      ]
+    },
+    "output": {
+      "operations": [
+        {
+          "fulfillmentGroupLocationRankingAdd": {
+            "fulfillmentGroupHandle": "123",
+            "rankings": [
+              {
+                "locationHandle": "456",
+                "rank": 0
+              },
+              {
+                "locationHandle": "789",
+                "rank": 0
+              }
+            ]
+          }
+        },
+        {
+          "fulfillmentGroupLocationRankingAdd": {
+            "fulfillmentGroupHandle": "456",
+            "rankings": [
+              {
+                "locationHandle": "101",
+                "rank": 0
+              },
+              {
+                "locationHandle": "112",
+                "rank": 0
+              },
+              {
+                "locationHandle": "131",
+                "rank": 0
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/functions-location-rules-wasm/tests/default.test.js
+++ b/functions-location-rules-wasm/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/cart_fulfillment_groups_location_rankings_generate_run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-location-rules-wasm/tests/fixtures/log.json
+++ b/functions-location-rules-wasm/tests/fixtures/log.json
@@ -1,0 +1,56 @@
+{
+  "payload": {
+    "export": "cart_fulfillment_groups_location_rankings_generate_run",
+    "target": "cart.fulfillment-groups.location-rankings.generate.run",
+    "input": {
+      "fulfillmentGroups": [
+        {
+          "handle": "123",
+          "inventoryLocationHandles": ["456", "789"]
+        },
+        {
+          "handle": "456",
+          "inventoryLocationHandles": ["101", "112", "131"]
+        }
+      ]
+    },
+    "output": {
+      "operations": [
+        {
+          "fulfillmentGroupLocationRankingAdd": {
+            "fulfillmentGroupHandle": "123",
+            "rankings": [
+              {
+                "locationHandle": "456",
+                "rank": 0
+              },
+              {
+                "locationHandle": "789",
+                "rank": 0
+              }
+            ]
+          }
+        },
+        {
+          "fulfillmentGroupLocationRankingAdd": {
+            "fulfillmentGroupHandle": "456",
+            "rankings": [
+              {
+                "locationHandle": "101",
+                "rank": 0
+              },
+              {
+                "locationHandle": "112",
+                "rank": 0
+              },
+              {
+                "locationHandle": "131",
+                "rank": 0
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/functions-payment-customization-js/tests/default.test.js
+++ b/functions-payment-customization-js/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/cart_payment_methods_transform_run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-payment-customization-js/tests/fixtures/log.json
+++ b/functions-payment-customization-js/tests/fixtures/log.json
@@ -1,0 +1,16 @@
+{
+  "payload": {
+    "export": "cart-payment-methods-transform-run",
+    "target": "cart.payment-methods.transform.run",
+    "input": {
+      "paymentCustomization": {
+        "metafield": {
+          "value": "{\"hidePaymentMethods\": [\"credit_card\"], \"showPaymentMethods\": [\"paypal\", \"apple_pay\"]}"
+        }
+      }
+    },
+    "output": {
+      "operations": []
+    }
+  }
+}

--- a/functions-payment-customization-rs/tests/default.test.js
+++ b/functions-payment-customization-rs/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/cart_payment_methods_transform_run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-payment-customization-rs/tests/fixtures/log.json
+++ b/functions-payment-customization-rs/tests/fixtures/log.json
@@ -1,0 +1,19 @@
+{
+  "payload": {
+    "export": "cart_payment_methods_transform_run",
+    "target": "cart.payment-methods.transform.run",
+    "input": {
+      "paymentCustomization": {
+        "metafield": {
+          "jsonValue": {
+            "hidePaymentMethods": ["credit_card"],
+            "showPaymentMethods": ["paypal", "apple_pay"]
+          }
+        }
+      }
+    },
+    "output": {
+      "operations": []
+    }
+  }
+}

--- a/functions-payment-customization-wasm/tests/default.test.js
+++ b/functions-payment-customization-wasm/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/cart_payment_methods_transform_run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-payment-customization-wasm/tests/fixtures/log.json
+++ b/functions-payment-customization-wasm/tests/fixtures/log.json
@@ -1,0 +1,19 @@
+{
+  "payload": {
+    "export": "cart_payment_methods_transform_run",
+    "target": "cart.payment-methods.transform.run",
+    "input": {
+      "paymentCustomization": {
+        "metafield": {
+          "jsonValue": {
+            "hidePaymentMethods": ["credit_card"],
+            "showPaymentMethods": ["paypal", "apple_pay"]
+          }
+        }
+      }
+    },
+    "output": {
+      "operations": []
+    }
+  }
+}

--- a/functions-pickup-point-delivery-option-generators-js/tests/default.test.js
+++ b/functions-pickup-point-delivery-option-generators-js/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-pickup-point-delivery-option-generators-js/tests/fixtures/log.json
+++ b/functions-pickup-point-delivery-option-generators-js/tests/fixtures/log.json
@@ -1,0 +1,70 @@
+{
+  "payload": {
+    "export": "run",
+    "target": "purchase.pickup-point-delivery-option-generator.run",
+    "input": {
+      "fetchResult": {
+        "status": 200,
+        "body": "{\"deliveryPoints\": [{\"pointId\": \"pickup1\", \"pointName\": \"Pickup Location 1\", \"location\": {\"addressComponents\": {\"streetNumber\": \"123\", \"route\": \"Main St\", \"locality\": \"New York\", \"country\": \"United States\", \"countryCode\": \"US\", \"postalCode\": \"10001\", \"administrativeArea\": {\"name\": \"New York\", \"code\": \"NY\"}}, \"geometry\": {\"location\": {\"lat\": 40.7589, \"lng\": -73.9851}}}}, {\"pointId\": \"pickup2\", \"pointName\": \"Pickup Location 2\", \"location\": {\"addressComponents\": {\"streetNumber\": \"456\", \"route\": \"Oak Ave\", \"locality\": \"New York\", \"country\": \"United States\", \"countryCode\": \"US\", \"postalCode\": \"10002\", \"administrativeArea\": {\"name\": \"New York\", \"code\": \"NY\"}}, \"geometry\": {\"location\": {\"lat\": 40.7614, \"lng\": -73.9776}}}}]}"
+      }
+    },
+    "output": {
+      "operations": [
+        {
+          "add": {
+            "cost": null,
+            "pickupPoint": {
+              "externalId": "pickup1",
+              "name": "Pickup Location 1",
+              "provider": {
+                "name": "Shopify Javascript Demo",
+                "logoUrl": "https://cdn.shopify.com/s/files/1/0628/3830/9033/files/shopify_icon_146101.png?v=1706120545"
+              },
+              "address": {
+                "address1": "123 Main St",
+                "address2": null,
+                "city": "New York",
+                "country": "United States",
+                "countryCode": "US",
+                "latitude": 40.7589,
+                "longitude": -73.9851,
+                "phone": null,
+                "province": "New York",
+                "provinceCode": "NY",
+                "zip": "10001"
+              },
+              "businessHours": null
+            }
+          }
+        },
+        {
+          "add": {
+            "cost": null,
+            "pickupPoint": {
+              "externalId": "pickup2",
+              "name": "Pickup Location 2",
+              "provider": {
+                "name": "Shopify Javascript Demo",
+                "logoUrl": "https://cdn.shopify.com/s/files/1/0628/3830/9033/files/shopify_icon_146101.png?v=1706120545"
+              },
+              "address": {
+                "address1": "456 Oak Ave",
+                "address2": null,
+                "city": "New York",
+                "country": "United States",
+                "countryCode": "US",
+                "latitude": 40.7614,
+                "longitude": -73.9776,
+                "phone": null,
+                "province": "New York",
+                "provinceCode": "NY",
+                "zip": "10002"
+              },
+              "businessHours": null
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/functions-pickup-point-delivery-option-generators-rs/tests/default.test.js
+++ b/functions-pickup-point-delivery-option-generators-rs/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-pickup-point-delivery-option-generators-rs/tests/fixtures/log.json
+++ b/functions-pickup-point-delivery-option-generators-rs/tests/fixtures/log.json
@@ -1,0 +1,72 @@
+{
+  "payload": {
+    "export": "run",
+    "target": "purchase.pickup-point-delivery-option-generator.run",
+    "input": {
+      "fetchResult": {
+        "status": 200,
+        "body": "{\"deliveryPoints\": [{\"pointId\": \"pickup1\", \"pointName\": \"Pickup Location 1\", \"location\": {\"addressComponents\": {\"streetNumber\": \"123\", \"route\": \"Main St\", \"locality\": \"New York\", \"country\": \"United States\", \"countryCode\": \"US\", \"postalCode\": \"10001\", \"administrativeArea\": {\"name\": \"New York\", \"code\": \"NY\"}}, \"geometry\": {\"location\": {\"lat\": 40.7589, \"lng\": -73.9851}}}}, {\"pointId\": \"pickup2\", \"pointName\": \"Pickup Location 2\", \"location\": {\"addressComponents\": {\"streetNumber\": \"456\", \"route\": \"Oak Ave\", \"locality\": \"New York\", \"country\": \"United States\", \"countryCode\": \"US\", \"postalCode\": \"10002\", \"administrativeArea\": {\"name\": \"New York\", \"code\": \"NY\"}}, \"geometry\": {\"location\": {\"lat\": 40.7614, \"lng\": -73.9776}}}}]}"
+      }
+    },
+    "output": {
+      "operations": [
+        {
+          "add": {
+            "cost": null,
+            "metafields": [],
+            "pickupPoint": {
+              "address": {
+                "address1": "123 Main St",
+                "address2": null,
+                "city": "New York",
+                "country": "United States",
+                "countryCode": "US",
+                "latitude": 40.7589,
+                "longitude": -73.9851,
+                "phone": null,
+                "province": "New York",
+                "provinceCode": "NY",
+                "zip": "10001"
+              },
+              "businessHours": null,
+              "externalId": "pickup1",
+              "name": "Pickup Location 1",
+              "provider": {
+                "logoUrl": "https://cdn.shopify.com/s/files/1/0628/3830/9033/files/shopify_icon_146101.png?v=1706120545",
+                "name": "Shopify Rust Demo"
+              }
+            }
+          }
+        },
+        {
+          "add": {
+            "cost": null,
+            "metafields": [],
+            "pickupPoint": {
+              "address": {
+                "address1": "456 Oak Ave",
+                "address2": null,
+                "city": "New York",
+                "country": "United States",
+                "countryCode": "US",
+                "latitude": 40.7614,
+                "longitude": -73.9776,
+                "phone": null,
+                "province": "New York",
+                "provinceCode": "NY",
+                "zip": "10002"
+              },
+              "businessHours": null,
+              "externalId": "pickup2",
+              "name": "Pickup Location 2",
+              "provider": {
+                "logoUrl": "https://cdn.shopify.com/s/files/1/0628/3830/9033/files/shopify_icon_146101.png?v=1706120545",
+                "name": "Shopify Rust Demo"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/functions-pickup-point-delivery-option-generators-wasm/tests/default.test.js
+++ b/functions-pickup-point-delivery-option-generators-wasm/tests/default.test.js
@@ -1,0 +1,40 @@
+import path from "path";
+import fs from "fs";
+import { describe, beforeAll, test, expect } from "vitest";
+import { buildFunction, loadFixture, runFunction, validateFixture } from "function-testing-helpers";
+
+describe("Default Integration Test", () => {
+  beforeAll(async () => {
+    const functionDir = path.dirname(__dirname);
+    await buildFunction(functionDir);
+  }, 30000); // 30 second timeout for building the function
+
+  const fixturesDir = path.join(__dirname, "fixtures");
+  const fixtureFiles = fs
+    .readdirSync(fixturesDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => path.join(fixturesDir, file));
+
+  fixtureFiles.forEach((fixtureFile) => {
+    test(`runs ${path.relative(fixturesDir, fixtureFile)}`, async () => {
+      const fixture = await loadFixture(fixtureFile);
+
+      const functionDir = path.dirname(__dirname);
+
+      const schemaPath = path.join(functionDir, "schema.graphql");
+      const inputQueryPath = path.join(functionDir, "src/run.graphql");
+
+      await validateFixture(fixture);
+
+      const runResult = await runFunction(
+        fixture.export,
+        fixture.input,
+        functionDir
+      );
+
+      const { result, error } = runResult;
+      expect(error).toBeNull();
+      expect(result.output).toEqual(fixture.expectedOutput);
+    }, 10000);
+  });
+});

--- a/functions-pickup-point-delivery-option-generators-wasm/tests/fixtures/log.json
+++ b/functions-pickup-point-delivery-option-generators-wasm/tests/fixtures/log.json
@@ -1,0 +1,72 @@
+{
+  "payload": {
+    "export": "run",
+    "target": "purchase.pickup-point-delivery-option-generator.run",
+    "input": {
+      "fetchResult": {
+        "status": 200,
+        "body": "{\"deliveryPoints\": [{\"pointId\": \"pickup1\", \"pointName\": \"Pickup Location 1\", \"location\": {\"addressComponents\": {\"streetNumber\": \"123\", \"route\": \"Main St\", \"locality\": \"New York\", \"country\": \"United States\", \"countryCode\": \"US\", \"postalCode\": \"10001\", \"administrativeArea\": {\"name\": \"New York\", \"code\": \"NY\"}}, \"geometry\": {\"location\": {\"lat\": 40.7589, \"lng\": -73.9851}}}}, {\"pointId\": \"pickup2\", \"pointName\": \"Pickup Location 2\", \"location\": {\"addressComponents\": {\"streetNumber\": \"456\", \"route\": \"Oak Ave\", \"locality\": \"New York\", \"country\": \"United States\", \"countryCode\": \"US\", \"postalCode\": \"10002\", \"administrativeArea\": {\"name\": \"New York\", \"code\": \"NY\"}}, \"geometry\": {\"location\": {\"lat\": 40.7614, \"lng\": -73.9776}}}}]}"
+      }
+    },
+    "output": {
+      "operations": [
+        {
+          "add": {
+            "cost": null,
+            "metafields": [],
+            "pickupPoint": {
+              "address": {
+                "address1": "123 Main St",
+                "address2": null,
+                "city": "New York",
+                "country": "United States",
+                "countryCode": "US",
+                "latitude": 40.7589,
+                "longitude": -73.9851,
+                "phone": null,
+                "province": "New York",
+                "provinceCode": "NY",
+                "zip": "10001"
+              },
+              "businessHours": null,
+              "externalId": "pickup1",
+              "name": "Pickup Location 1",
+              "provider": {
+                "logoUrl": "https://cdn.shopify.com/s/files/1/0628/3830/9033/files/shopify_icon_146101.png?v=1706120545",
+                "name": "Shopify Rust Demo"
+              }
+            }
+          }
+        },
+        {
+          "add": {
+            "cost": null,
+            "metafields": [],
+            "pickupPoint": {
+              "address": {
+                "address1": "456 Oak Ave",
+                "address2": null,
+                "city": "New York",
+                "country": "United States",
+                "countryCode": "US",
+                "latitude": 40.7614,
+                "longitude": -73.9776,
+                "phone": null,
+                "province": "New York",
+                "provinceCode": "NY",
+                "zip": "10002"
+              },
+              "businessHours": null,
+              "externalId": "pickup2",
+              "name": "Pickup Location 2",
+              "provider": {
+                "logoUrl": "https://cdn.shopify.com/s/files/1/0628/3830/9033/files/shopify_icon_146101.png?v=1706120545",
+                "name": "Shopify Rust Demo"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### Background

Fixes: https://github.com/orgs/shop/projects/147/views/9?pane=issue&itemId=125817929&issue=shop%7Cissues-shopifyvm%7C552 

We want to have a way for developers to test their compiled functions for various scenarios and find out when it breaks everytime they make changes to their extension. We want to develop a test suite that they can run which actually builds a function and runs a function with a previous run's logged input and asserts its the same as the logged output.
We are adding a default passing wasm-level test fixture and test to all function extension templates to which developers can add on. 
These wasm-level tests replace the unit tests that are baked into the templates.

### Solution

I created an app with every type of extension in both JS and Rust and then created a fixture along with a default test that passes, then copied the test directory for each extension over here to its corresponding template so I feel pretty confident in my changes, even though I haven't tophatted it, unsure how I can tophat this. 
The `package.json` in all the test directories are the same. The `default.test.js` for different extensions have different input query path but is otherwise the same. 
There is a second [follow-up PR](https://github.com/Shopify/extensions-templates/pull/322) that removes all existing unit tests.
This PR also needs [this helper](https://github.com/shopify-playground/shopify-functions-wasm-testing-helpers) to get published to NPM.

### Checklist

- [ ] I have :tophat:'d these changes 
- [x] I have squashed my commits into chunks of work with meaningful commit messages
