### PR TITLE
Replace the sketchy payment session urls for payment extensions

### DIFF
--- a/payments-app-extension-card-present/shopify.extension.toml.liquid
+++ b/payments-app-extension-card-present/shopify.extension.toml.liquid
@@ -9,11 +9,11 @@ type = "payments_extension"
 {% if uid %}uid = "{{ uid }}"{% endif %}
 
 merchant_label = "Card Present Payments App Extension"
-payment_session_url = "https://api.paymentprovider.com/endpoint"
-refund_session_url = "https://api.paymentprovider.com/refund"
-capture_session_url = "https://api.paymentprovider.com/capture"
-void_session_url = "https://api.paymentprovider.com/void"
-sync_terminal_transaction_result_url = "https://api.paymentprovider.com/terminal-result"
+payment_session_url = "https://example.com/payment"
+refund_session_url = "https://example.com/refund"
+capture_session_url = "https://example.com/capture"
+void_session_url = "https://example.com/void"
+sync_terminal_transaction_result_url = "https://example.com/terminal-result"
 # List of ISO 3166 (alpha-2) country codes your app is available for installation by merchants. Learn more:
 # https://www.iso.org/iso-3166-country-codes.html
 supported_countries = ["US"]

--- a/payments-app-extension-credit-card/shopify.extension.toml.liquid
+++ b/payments-app-extension-credit-card/shopify.extension.toml.liquid
@@ -9,10 +9,10 @@ type = "payments_extension"
 {% if uid %}uid = "{{ uid }}"{% endif %}
 
 merchant_label = "Credit Credit Payments App Extension"
-payment_session_url = "https://api.paymentprovider.com/endpoint"
-refund_session_url = "https://api.paymentprovider.com/refund"
-capture_session_url = "https://api.paymentprovider.com/capture"
-void_session_url = "https://api.paymentprovider.com/void"
+payment_session_url = "https://example.com/payment"
+refund_session_url = "https://example.com/refund"
+capture_session_url = "https://example.com/capture"
+void_session_url = "https://example.com/void"
 # List of ISO 3166 (alpha-2) country codes your app is available for installation by merchants. Learn more:
 # https://www.iso.org/iso-3166-country-codes.html
 supported_countries = ["US"]

--- a/payments-app-extension-custom-credit-card/shopify.extension.toml.liquid
+++ b/payments-app-extension-custom-credit-card/shopify.extension.toml.liquid
@@ -9,10 +9,10 @@ type = "payments_extension"
 {% if uid %}uid = "{{ uid }}"{% endif %}
 
 merchant_label = "Custom Credit Credit Payments App Extension"
-payment_session_url = "https://api.paymentprovider.com/endpoint"
-refund_session_url = "https://api.paymentprovider.com/refund"
-capture_session_url = "https://api.paymentprovider.com/capture"
-void_session_url = "https://api.paymentprovider.com/void"
+payment_session_url = "https://example.com/payment"
+refund_session_url = "https://example.com/refund"
+capture_session_url = "https://example.com/capture"
+void_session_url = "https://example.com/void"
 # List of ISO 3166 (alpha-2) country codes your app is available for installation by merchants. Learn more:
 # https://www.iso.org/iso-3166-country-codes.html
 supported_countries = ["US"]

--- a/payments-app-extension-custom-onsite/shopify.extension.toml.liquid
+++ b/payments-app-extension-custom-onsite/shopify.extension.toml.liquid
@@ -9,7 +9,7 @@ type = "payments_extension"
 {% if uid %}uid = "{{ uid }}"{% endif %}
 
 merchant_label = "Custom Onsite Payments App Extension"
-payment_session_url = "https://api.paymentprovider.com/endpoint"
+payment_session_url = "https://example.com/payment"
 supports_oversell_protection = false
 # List of ISO 3166 (alpha-2) country codes your app is available for installation by merchants. Learn more:
 # https://www.iso.org/iso-3166-country-codes.html

--- a/payments-app-extension-offsite/shopify.extension.toml.liquid
+++ b/payments-app-extension-offsite/shopify.extension.toml.liquid
@@ -9,7 +9,7 @@ type = "payments_extension"
 {% if uid %}uid = "{{ uid }}"{% endif %}
 
 merchant_label = "Offsite Payments App Extension"
-payment_session_url = "https://api.paymentprovider.com/endpoint"
+payment_session_url = "https://example.com/payment"
 supports_oversell_protection = false
 # List of ISO 3166 (alpha-2) country codes your app is available for installation by merchants. Learn more:
 # https://www.iso.org/iso-3166-country-codes.html

--- a/payments-app-extension-redeemable/shopify.extension.toml.liquid
+++ b/payments-app-extension-redeemable/shopify.extension.toml.liquid
@@ -8,7 +8,7 @@ handle = "{{ handle }}"
 type = "payments_extension"
 {% if uid %}uid = "{{ uid }}"{% endif %}
 
-payment_session_url = "https://api.paymentprovider.com/endpoint"
+payment_session_url = "https://example.com/payment"
 # List of ISO 3166 (alpha-2) country codes your app is available for installation by merchants. Learn more:
 # https://www.iso.org/iso-3166-country-codes.html
 supported_countries = ["US"]
@@ -17,7 +17,7 @@ supported_countries = ["US"]
 supported_payment_methods = ["gift-card"]
 test_mode_available = true
 merchant_label = "Redeemable Payments App Extension"
-balance_url = "https://api.paymentprovider.com/balance"
+balance_url = "https://example.com/balance"
 
 # buyer_label = ""
 # [[extensions.buyer_label_translations]]


### PR DESCRIPTION
### Background
Resolves https://github.com/shop/issues-payment-partners/issues/335


### Solution

TLDR is that the current url is a very sketchy URL, this pr changes them into more standard example urls.

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
