### PR TITLE
Fix type issues by using event.currentTarget instead of event.target

### DIFF
--- a/admin-purchase-options-action/src/PurchaseOptionsActionExtension.liquid
+++ b/admin-purchase-options-action/src/PurchaseOptionsActionExtension.liquid
@@ -9,9 +9,9 @@ export default function PurchaseOptionsActionExtension() {
   const [planName, setPlanName] = useState('');
   const [discountType, setDiscountType] = useState('percentageOff');
   const [deliveryOptions, setDeliveryOptions] = useState({
-    frequency: 0,
+    frequency: '0',
     timeType: 'day',
-    discount: 0,
+    discount: '0',
   });
 
   const updateDeliveryOption = (field, value) => {
@@ -74,12 +74,12 @@ export default function PurchaseOptionsActionExtension() {
             <s-number-field
               label="Delivery frequency"
               value={deliveryOptions.frequency}
-              onChange={(event) => updateDeliveryOption('frequency', event.target.value)}
+              onChange={(event) => updateDeliveryOption('frequency', event.currentTarget.value)}
             />
             <s-select
               label="Delivery interval"
               value={deliveryOptions.timeType}
-              onChange={(event) => updateDeliveryOption('timeType', event.target.value)}
+              onChange={(event) => updateDeliveryOption('timeType', event.currentTarget.value)}
             >
               <s-option value='weeks'>Weeks</s-option>
               <s-option value='months'>Months</s-option>
@@ -88,7 +88,7 @@ export default function PurchaseOptionsActionExtension() {
             <s-number-field
               label={getDiscountLabel(discountType)}
               value={deliveryOptions.discount}
-              onChange={(event) => updateDeliveryOption('discount', event.target.value)}
+              onChange={(event) => updateDeliveryOption('discount', event.currentTarget.value)}
             />
           </s-stack>
         </s-box>

--- a/validation-settings/src/ValidationSettings.liquid
+++ b/validation-settings/src/ValidationSettings.liquid
@@ -89,7 +89,7 @@ function Extension({ configuration, products }) {
   });
 
   return (
-    <s-function-settings onSave={() => applyMetafieldUpdate(variantLimits)}>
+    <s-function-settings onSubmit={(event) => event.waitUntil(applyMetafieldUpdate(variantLimits))}>
       <ErrorBanner errors={errors} />
       <s-table variant="auto">
         <s-table-header-row>
@@ -161,7 +161,7 @@ function VariantNumberField({ labelValue, value, onChange, name }) {
       name={`${name}-number`}
       label={`Set a limit for ${labelValue}`}
       min={0}
-      onChange={(event) => onChange(event.target.value)}
+      onChange={(event) => onChange(event.currentTarget.value)}
     />
   );
 }


### PR DESCRIPTION
### Background

Fix type issues
- Updated event handling to use `event.currentTarget.value` instead of `event.target.value` for accessing form field values.
- Changed the initial state values for frequency and discount from numbers to strings in PurchaseOptionsActionExtension to reflect the expected value for s-number-field
- Updated the function settings component to properly use `onSubmit` event with `waitUntil` instead of `onSave`

### Checklist

- [x] I have 🎩'd these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages