### PR TITLE
Update to use 2025-10 stable release for UI extensions

### DIFF
--- a/admin-action/package.json.liquid
+++ b/admin-action/package.json.liquid
@@ -6,7 +6,7 @@
 {%- if flavor contains "preact" %}
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "~2025.10.0-rc"
+    "@shopify/ui-extensions": "2025.10.x"
   }
 {%- elsif flavor contains "react" %}
   "dependencies": {

--- a/admin-block/package.json.liquid
+++ b/admin-block/package.json.liquid
@@ -6,7 +6,7 @@
 {%- if flavor contains "preact" %}
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "~2025.10.0-rc"
+    "@shopify/ui-extensions": "2025.10.x"
   }
 {%- elsif flavor contains "react" %}
   "dependencies": {

--- a/admin-print-action/package.json.liquid
+++ b/admin-print-action/package.json.liquid
@@ -6,7 +6,7 @@
 {%- if flavor contains "preact" %}
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "~2025.10.0-rc"
+    "@shopify/ui-extensions": "2025.10.x"
   }
 {%- elsif flavor contains "react" %}
   "dependencies": {

--- a/admin-purchase-options-action/package.json.liquid
+++ b/admin-purchase-options-action/package.json.liquid
@@ -6,7 +6,7 @@
 {%- if flavor contains "preact" %}
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "~2025.10.0-rc"
+    "@shopify/ui-extensions": "2025.10.x"
   }
 {%- elsif flavor contains "react" %}
   "dependencies": {

--- a/checkout-extension/package.json.liquid
+++ b/checkout-extension/package.json.liquid
@@ -7,7 +7,7 @@
   "dependencies": {
     "preact": "^10.10.x",
     "@preact/signals": "^2.3.x",
-    "@shopify/ui-extensions": "~2025.10.0-rc"
+    "@shopify/ui-extensions": "2025.10.x"
   }
 {%- elsif flavor contains "react" %}
   "dependencies": {

--- a/conditional-action-extension-js/package.json.liquid
+++ b/conditional-action-extension-js/package.json.liquid
@@ -6,7 +6,7 @@
 {%- if flavor contains "preact" %}
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "~2025.10.0-rc"
+    "@shopify/ui-extensions": "2025.10.x"
   }
 {%- elsif flavor contains "react" %}
   "dependencies": {

--- a/customer-account-extension/package.json.liquid
+++ b/customer-account-extension/package.json.liquid
@@ -7,7 +7,7 @@
   "dependencies": {
     "preact": "^10.10.x",
     "@preact/signals": "^2.3.x",
-    "@shopify/ui-extensions": "~2025.10.0-rc"
+    "@shopify/ui-extensions": "2025.10.x"
   }
 }
 {%- elsif flavor contains "react" -%}

--- a/customer-segment-template-data-extension/package.json.liquid
+++ b/customer-segment-template-data-extension/package.json.liquid
@@ -4,6 +4,6 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "@shopify/ui-extensions": "~2025.10.0-rc"
+    "@shopify/ui-extensions": "2025.10.x"
   }
 }

--- a/discount-details-function-settings-block/package.json.liquid
+++ b/discount-details-function-settings-block/package.json.liquid
@@ -6,7 +6,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "~2025.10.0-rc"
+    "@shopify/ui-extensions": "2025.10.x"
   }
 }
 {%- elsif flavor contains "react" -%}

--- a/order-routing-location-rule/package.json.liquid
+++ b/order-routing-location-rule/package.json.liquid
@@ -6,7 +6,7 @@
 {%- if flavor contains "preact" %}
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "~2025.10.0-rc"
+    "@shopify/ui-extensions": "2025.10.x"
   }
 {%- elsif flavor contains "react" %}
   "dependencies": {

--- a/pos-action/package.json.liquid
+++ b/pos-action/package.json.liquid
@@ -5,7 +5,7 @@
   "license": "UNLICENSED",
 {%- if flavor contains "preact" %}
   "dependencies": {
-    "@shopify/ui-extensions": "~2025.10.0-rc",
+    "@shopify/ui-extensions": "2025.10.x",
     "preact": "^10.10.x"
   }
 {%- elsif flavor contains "react" %}

--- a/pos-block/package.json.liquid
+++ b/pos-block/package.json.liquid
@@ -5,7 +5,7 @@
   "license": "UNLICENSED",
 {%- if flavor contains "preact" %}
   "dependencies": {
-    "@shopify/ui-extensions": "~2025.10.0-rc",
+    "@shopify/ui-extensions": "2025.10.x",
     "preact": "^10.10.x"
   }
 {%- elsif flavor contains "react" %}

--- a/pos-smart-grid/package.json.liquid
+++ b/pos-smart-grid/package.json.liquid
@@ -5,7 +5,7 @@
   "license": "UNLICENSED",
 {%- if flavor contains "preact" %}
   "dependencies": {
-    "@shopify/ui-extensions": "~2025.10.0-rc",
+    "@shopify/ui-extensions": "2025.10.x",
     "preact": "^10.10.x"
   }
 {%- elsif flavor contains "react" %}

--- a/product-configuration-extension/package.json.liquid
+++ b/product-configuration-extension/package.json.liquid
@@ -6,7 +6,7 @@
 {%- if flavor contains "preact" -%}
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "~2025.10.0-rc"
+    "@shopify/ui-extensions": "2025.10.x"
   }
 {%- elsif flavor contains "react" -%}
   "dependencies": {

--- a/validation-settings/package.json.liquid
+++ b/validation-settings/package.json.liquid
@@ -6,7 +6,7 @@
 {%- if flavor contains "preact" %}
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "~2025.10.0-rc"
+    "@shopify/ui-extensions": "2025.10.x"
   }
 {%- elsif flavor contains "react" %}
   "dependencies": {


### PR DESCRIPTION
Updates the `@shopify/ui-extensions` dependency version in all extension templates from `~2025.10.0-rc` to `2025.10.x`.
