### PR TITLE
Preact discount settings bug fixes

### DIFF
--- a/discount-details-function-settings-block/src/DiscountFunctionSettings.liquid
+++ b/discount-details-function-settings-block/src/DiscountFunctionSettings.liquid
@@ -1,6 +1,6 @@
 {% if flavor contains 'preact' %}
 import { render } from "preact";
-import { useState, useEffect } from "preact/hooks";
+import { useState, useEffect, useMemo } from "preact/hooks";
 
 export default async () => {
   const existingDefinition = await getMetafieldDefinition();
@@ -60,8 +60,8 @@ function AppliesToCollections({
             value={appliesTo}
             onChange={(event) => onAppliesToChange(event.currentTarget.value)}
           >
-            <option value="all">{i18n.translate("collections.allProducts")}</option>
-            <option value="collections">{i18n.translate("collections.collections")}</option>
+            <s-option value="all">{i18n.translate("collections.allProducts")}</s-option>
+            <s-option value="collections">{i18n.translate("collections.collections")}</s-option>
           </s-select>
 
           {appliesTo === "all" ? null : (
@@ -170,11 +170,14 @@ function App() {
 
 function useExtensionData() {
   const { applyMetafieldChange, i18n, data, resourcePicker, query } = shopify;
-  
-  const metafieldConfig = parseMetafield(
-    data?.metafields.find(
-      (metafield) => metafield.key === "function-configuration"
-    )?.value
+
+  const metafieldConfig = useMemo(() =>
+    parseMetafield(
+      data?.metafields?.find(
+        (metafield) => metafield.key === "function-configuration"
+      )?.value
+    ),
+    [data?.metafields]
   );
   
   const [percentages, setPercentages] = useState(metafieldConfig.percentages);


### PR DESCRIPTION
### Background

Howdy!

I was putting together a demo this morning and ran into a few bugs after generating a new extension-only app with a discount function + Discount function settings ui (CLI `3.85.4`)

- infinite `useEffect` render loop
- select menu not working

Both quick fixes that I've already tested for the demo, dropping them here in case it hasn't been flagged yet.

### Solution

- infinite render is resolve by apply `useMemo` (same dependency as react template)
- updated select menu to use <s-option> from polaris web components

### Checklist

- [x] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
