### PR TITLE
Use localized name and description in app-action-link template

### DIFF
--- a/app-action-link/locales/en.default.json.liquid
+++ b/app-action-link/locales/en.default.json.liquid
@@ -1,4 +1,4 @@
 {
-  "name": "{{ name }}",
-  "description": "An app action extension for Sidekick"
+  "name": "Edit email",
+  "description": "Edit an email campaign"
 }

--- a/app-action-link/locales/fr.json.liquid
+++ b/app-action-link/locales/fr.json.liquid
@@ -1,4 +1,4 @@
 {
-  "name": "{{ name }}",
-  "description": "Une extension d'action d'application pour Sidekick"
+  "name": "Modifier l'email",
+  "description": "Modifier une campagne email"
 }

--- a/app-action-link/shopify.extension.toml.liquid
+++ b/app-action-link/shopify.extension.toml.liquid
@@ -1,6 +1,7 @@
 [[extensions]]
-name = "Edit email"
-description = "Edit an email campaign"
+# Change the merchant-facing name and description of the extension in locales/en.default.json
+name = "t:name"
+description = "t:description"
 
 handle = "{{ handle }}"
 type = "admin_link"


### PR DESCRIPTION
## What

Use localized `t:name` and `t:description` references in the `app-action-link` template's `shopify.extension.toml.liquid` instead of hardcoded strings.

## Why

The template has locale files (`en.default.json.liquid`, `fr.json.liquid`) with the merchant-facing name and description values, but `shopify.extension.toml.liquid` was still hardcoding `name = "Edit email"` and `description = "Edit an email campaign"`. Referencing the locale keys makes the template consistent with the localized metadata.

## Changes

- `app-action-link/shopify.extension.toml.liquid`: replace hardcoded name/description with `t:name` / `t:description`
- Add a comment pointing developers to `locales/en.default.json` for changing the merchant-facing metadata

## Validation

- Rebased on current `main`
- Ran `git diff --check origin/main..HEAD`
