### PR TITLE
Update function templates to 2026-04 API version

### DIFF
--- a/.github/scripts/run-wasm-tests.sh
+++ b/.github/scripts/run-wasm-tests.sh
@@ -22,8 +22,20 @@ esac
 
 # Create a minimal app toml so Shopify CLI can discover the extensions
 cat > shopify.app.toml << EOF
-scopes = ""
+client_id = "test"
+name = "test"
+application_url = "https://example.com"
+embedded = true
 extension_directories = ["${EXT_DIR_PATTERN}"]
+
+[auth]
+redirect_urls = ["https://example.com/auth/callback"]
+
+[webhooks]
+api_version = "2025-01"
+
+[access_scopes]
+scopes = ""
 EOF
 
 for dir in $EXT_DIR_PATTERN; do

--- a/functions-cart-checkout-validation-js/schema.graphql
+++ b/functions-cart-checkout-validation-js/schema.graphql
@@ -120,6 +120,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -152,6 +157,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -193,6 +203,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -250,6 +266,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -358,6 +379,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2917,6 +2943,127 @@ enum DeliveryMethod {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 A Function error for a path.
 """
 input FunctionError {
@@ -4589,6 +4736,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4673,6 +4885,21 @@ input Operation @oneOf {
   """
   validationAdd: ValidationAddOperation
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -5016,6 +5243,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-cart-checkout-validation-js/shopify.extension.toml.liquid
+++ b/functions-cart-checkout-validation-js/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-cart-checkout-validation-rs/schema.graphql
+++ b/functions-cart-checkout-validation-rs/schema.graphql
@@ -120,6 +120,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -152,6 +157,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -193,6 +203,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -250,6 +266,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -358,6 +379,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2917,6 +2943,127 @@ enum DeliveryMethod {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 A Function error for a path.
 """
 input FunctionError {
@@ -4589,6 +4736,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4673,6 +4885,21 @@ input Operation @oneOf {
   """
   validationAdd: ValidationAddOperation
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -5016,6 +5243,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-cart-checkout-validation-rs/shopify.extension.toml.liquid
+++ b/functions-cart-checkout-validation-rs/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-cart-checkout-validation-wasm/schema.graphql
+++ b/functions-cart-checkout-validation-wasm/schema.graphql
@@ -120,6 +120,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -152,6 +157,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -193,6 +203,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -250,6 +266,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -358,6 +379,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2917,6 +2943,127 @@ enum DeliveryMethod {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 A Function error for a path.
 """
 input FunctionError {
@@ -4589,6 +4736,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4673,6 +4885,21 @@ input Operation @oneOf {
   """
   validationAdd: ValidationAddOperation
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -5016,6 +5243,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-cart-checkout-validation-wasm/shopify.extension.toml.liquid
+++ b/functions-cart-checkout-validation-wasm/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-cart-transform-js/schema.graphql
+++ b/functions-cart-transform-js/schema.graphql
@@ -104,6 +104,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -175,6 +180,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2733,6 +2743,127 @@ Example values: `"29.99"`, `"29.999"`.
 scalar Decimal
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 An operation that expands a single cart line item to form a
 [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
 of components.
@@ -4089,6 +4220,81 @@ type LocationAddress {
 }
 
 """
+Represents a mailing address.
+"""
+type MailingAddress {
+  """
+  The first line of the address. Typically the street address or PO Box number.
+  """
+  address1: String
+
+  """
+  The second line of the address. Typically the number of the apartment, suite, or unit.
+  """
+  address2: String
+
+  """
+  The name of the city, district, village, or town.
+  """
+  city: String
+
+  """
+  The name of the customer's company or organization.
+  """
+  company: String
+
+  """
+  The two-letter code for the country of the address. For example, US.
+  """
+  countryCode: CountryCode
+
+  """
+  The first name of the customer.
+  """
+  firstName: String
+
+  """
+  The last name of the customer.
+  """
+  lastName: String
+
+  """
+  The approximate latitude of the address.
+  """
+  latitude: Float
+
+  """
+  The approximate longitude of the address.
+  """
+  longitude: Float
+
+  """
+  The market of the address.
+  """
+  market: Market @deprecated(reason: "This `market` field will be removed in a future version of the API.")
+
+  """
+  The full name of the customer, based on firstName and lastName.
+  """
+  name: String
+
+  """
+  A unique phone number for the customer. Formatted using E.164 standard. For example, +16135551111.
+  """
+  phone: String
+
+  """
+  The alphanumeric code for the region. For example, ON.
+  """
+  provinceCode: String
+
+  """
+  The zip or postal code of the address.
+  """
+  zip: String
+}
+
+"""
 A market is a group of one or more regions that you want to target for international sales.
 By creating a market, you can configure a distinct, localized shopping experience for
 customers from a specific area of the world. For example, you can
@@ -4249,6 +4455,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4352,6 +4623,21 @@ input PriceAdjustmentValue {
   """
   value: Decimal!
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4695,6 +4981,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-cart-transform-js/shopify.extension.toml.liquid
+++ b/functions-cart-transform-js/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-cart-transform-rs/schema.graphql
+++ b/functions-cart-transform-rs/schema.graphql
@@ -104,6 +104,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -175,6 +180,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2733,6 +2743,127 @@ Example values: `"29.99"`, `"29.999"`.
 scalar Decimal
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 An operation that expands a single cart line item to form a
 [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
 of components.
@@ -4089,6 +4220,81 @@ type LocationAddress {
 }
 
 """
+Represents a mailing address.
+"""
+type MailingAddress {
+  """
+  The first line of the address. Typically the street address or PO Box number.
+  """
+  address1: String
+
+  """
+  The second line of the address. Typically the number of the apartment, suite, or unit.
+  """
+  address2: String
+
+  """
+  The name of the city, district, village, or town.
+  """
+  city: String
+
+  """
+  The name of the customer's company or organization.
+  """
+  company: String
+
+  """
+  The two-letter code for the country of the address. For example, US.
+  """
+  countryCode: CountryCode
+
+  """
+  The first name of the customer.
+  """
+  firstName: String
+
+  """
+  The last name of the customer.
+  """
+  lastName: String
+
+  """
+  The approximate latitude of the address.
+  """
+  latitude: Float
+
+  """
+  The approximate longitude of the address.
+  """
+  longitude: Float
+
+  """
+  The market of the address.
+  """
+  market: Market @deprecated(reason: "This `market` field will be removed in a future version of the API.")
+
+  """
+  The full name of the customer, based on firstName and lastName.
+  """
+  name: String
+
+  """
+  A unique phone number for the customer. Formatted using E.164 standard. For example, +16135551111.
+  """
+  phone: String
+
+  """
+  The alphanumeric code for the region. For example, ON.
+  """
+  provinceCode: String
+
+  """
+  The zip or postal code of the address.
+  """
+  zip: String
+}
+
+"""
 A market is a group of one or more regions that you want to target for international sales.
 By creating a market, you can configure a distinct, localized shopping experience for
 customers from a specific area of the world. For example, you can
@@ -4249,6 +4455,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4352,6 +4623,21 @@ input PriceAdjustmentValue {
   """
   value: Decimal!
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4695,6 +4981,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-cart-transform-rs/shopify.extension.toml.liquid
+++ b/functions-cart-transform-rs/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-cart-transform-wasm/schema.graphql
+++ b/functions-cart-transform-wasm/schema.graphql
@@ -104,6 +104,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -175,6 +180,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2733,6 +2743,127 @@ Example values: `"29.99"`, `"29.999"`.
 scalar Decimal
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 An operation that expands a single cart line item to form a
 [bundle](https://shopify.dev/docs/apps/build/product-merchandising/bundles)
 of components.
@@ -4089,6 +4220,81 @@ type LocationAddress {
 }
 
 """
+Represents a mailing address.
+"""
+type MailingAddress {
+  """
+  The first line of the address. Typically the street address or PO Box number.
+  """
+  address1: String
+
+  """
+  The second line of the address. Typically the number of the apartment, suite, or unit.
+  """
+  address2: String
+
+  """
+  The name of the city, district, village, or town.
+  """
+  city: String
+
+  """
+  The name of the customer's company or organization.
+  """
+  company: String
+
+  """
+  The two-letter code for the country of the address. For example, US.
+  """
+  countryCode: CountryCode
+
+  """
+  The first name of the customer.
+  """
+  firstName: String
+
+  """
+  The last name of the customer.
+  """
+  lastName: String
+
+  """
+  The approximate latitude of the address.
+  """
+  latitude: Float
+
+  """
+  The approximate longitude of the address.
+  """
+  longitude: Float
+
+  """
+  The market of the address.
+  """
+  market: Market @deprecated(reason: "This `market` field will be removed in a future version of the API.")
+
+  """
+  The full name of the customer, based on firstName and lastName.
+  """
+  name: String
+
+  """
+  A unique phone number for the customer. Formatted using E.164 standard. For example, +16135551111.
+  """
+  phone: String
+
+  """
+  The alphanumeric code for the region. For example, ON.
+  """
+  provinceCode: String
+
+  """
+  The zip or postal code of the address.
+  """
+  zip: String
+}
+
+"""
 A market is a group of one or more regions that you want to target for international sales.
 By creating a market, you can configure a distinct, localized shopping experience for
 customers from a specific area of the world. For example, you can
@@ -4249,6 +4455,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4352,6 +4623,21 @@ input PriceAdjustmentValue {
   """
   value: Decimal!
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4695,6 +4981,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-cart-transform-wasm/shopify.extension.toml.liquid
+++ b/functions-cart-transform-wasm/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-delivery-customization-js/schema.graphql
+++ b/functions-delivery-customization-js/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -337,6 +358,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2982,6 +3008,127 @@ input DeprecatedOperation @oneOf {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 The output of the Function run target.
 The object contains the operations to apply to delivery options in checkout. In
 API versions 2023-10 and beyond, this type is deprecated in favor of
@@ -4477,6 +4624,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4580,6 +4792,21 @@ input Operation @oneOf {
   """
   deliveryOptionRename: DeliveryOptionRenameOperation
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4943,6 +5170,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-delivery-customization-js/shopify.extension.toml.liquid
+++ b/functions-delivery-customization-js/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-delivery-customization-rs/schema.graphql
+++ b/functions-delivery-customization-rs/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -337,6 +358,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2982,6 +3008,127 @@ input DeprecatedOperation @oneOf {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 The output of the Function run target.
 The object contains the operations to apply to delivery options in checkout. In
 API versions 2023-10 and beyond, this type is deprecated in favor of
@@ -4477,6 +4624,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4580,6 +4792,21 @@ input Operation @oneOf {
   """
   deliveryOptionRename: DeliveryOptionRenameOperation
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4943,6 +5170,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-delivery-customization-rs/shopify.extension.toml.liquid
+++ b/functions-delivery-customization-rs/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-delivery-customization-wasm/schema.graphql
+++ b/functions-delivery-customization-wasm/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -337,6 +358,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2982,6 +3008,127 @@ input DeprecatedOperation @oneOf {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 The output of the Function run target.
 The object contains the operations to apply to delivery options in checkout. In
 API versions 2023-10 and beyond, this type is deprecated in favor of
@@ -4477,6 +4624,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4580,6 +4792,21 @@ input Operation @oneOf {
   """
   deliveryOptionRename: DeliveryOptionRenameOperation
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4943,6 +5170,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-delivery-customization-wasm/shopify.extension.toml.liquid
+++ b/functions-delivery-customization-wasm/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-discount-js/schema.graphql
+++ b/functions-discount-js/schema.graphql
@@ -102,6 +102,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -134,6 +139,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -175,6 +185,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -232,6 +248,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -363,6 +384,11 @@ type CartLine {
   cost: CartLineCost!
 
   """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
+
+  """
   The ID of the cart line.
   """
   id: ID!
@@ -463,6 +489,25 @@ type CartLineParentRelationship {
   The parent line in the relationship.
   """
   parent: CartLine!
+}
+
+"""
+A cart line that is required for the discount candidate to be applicable. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
+"""
+input CartLinePrerequisite {
+  """
+  The ID of the prerequisite cart line.
+  """
+  id: ID!
+
+  """
+  The number of line items that are required for the discount candidate to be applicable.
+
+  The value is validated against: > 0.
+  """
+  quantity: Int!
 }
 
 """
@@ -3203,6 +3248,127 @@ type Discount implements HasMetafields {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 The [discount class](https://help.shopify.com/manual/discounts/combining-discounts/discount-combinations)
 that's used to control how discounts can be combined.
 """
@@ -4921,6 +5087,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -5118,6 +5349,21 @@ input Percentage {
 }
 
 """
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
+
+"""
 The goods and services that merchants offer to customers. Products can include details such as
 title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 Products can be organized by grouping them into a collection.
@@ -5261,6 +5507,11 @@ input ProductDiscountCandidate {
   message: String
 
   """
+  The items required for the discount candidate to be applicable.
+  """
+  prerequisites: [ProductDiscountCandidatePrerequisite!]
+
+  """
   The targets of the discount to be applied to a cart line.
   """
   targets: [ProductDiscountCandidateTarget!]!
@@ -5291,6 +5542,18 @@ input ProductDiscountCandidateFixedAmount {
   When the value is `true`, the value will be applied to each of the entitled items.
   """
   appliesToEachItem: Boolean = false
+}
+
+"""
+The items required for the discount candidate to be applicable.
+"""
+input ProductDiscountCandidatePrerequisite @oneOf {
+  """
+  A cart line that is required for the discount candidate to be applicable. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
+  """
+  cartLine: CartLinePrerequisite
 }
 
 """
@@ -5590,6 +5853,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-discount-js/shopify.extension.toml.liquid
+++ b/functions-discount-js/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-discount-rs/schema.graphql
+++ b/functions-discount-rs/schema.graphql
@@ -102,6 +102,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -134,6 +139,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -175,6 +185,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -232,6 +248,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -363,6 +384,11 @@ type CartLine {
   cost: CartLineCost!
 
   """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
+
+  """
   The ID of the cart line.
   """
   id: ID!
@@ -463,6 +489,25 @@ type CartLineParentRelationship {
   The parent line in the relationship.
   """
   parent: CartLine!
+}
+
+"""
+A cart line that is required for the discount candidate to be applicable. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
+"""
+input CartLinePrerequisite {
+  """
+  The ID of the prerequisite cart line.
+  """
+  id: ID!
+
+  """
+  The number of line items that are required for the discount candidate to be applicable.
+
+  The value is validated against: > 0.
+  """
+  quantity: Int!
 }
 
 """
@@ -3203,6 +3248,127 @@ type Discount implements HasMetafields {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 The [discount class](https://help.shopify.com/manual/discounts/combining-discounts/discount-combinations)
 that's used to control how discounts can be combined.
 """
@@ -4921,6 +5087,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -5118,6 +5349,21 @@ input Percentage {
 }
 
 """
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
+
+"""
 The goods and services that merchants offer to customers. Products can include details such as
 title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 Products can be organized by grouping them into a collection.
@@ -5261,6 +5507,11 @@ input ProductDiscountCandidate {
   message: String
 
   """
+  The items required for the discount candidate to be applicable.
+  """
+  prerequisites: [ProductDiscountCandidatePrerequisite!]
+
+  """
   The targets of the discount to be applied to a cart line.
   """
   targets: [ProductDiscountCandidateTarget!]!
@@ -5291,6 +5542,18 @@ input ProductDiscountCandidateFixedAmount {
   When the value is `true`, the value will be applied to each of the entitled items.
   """
   appliesToEachItem: Boolean = false
+}
+
+"""
+The items required for the discount candidate to be applicable.
+"""
+input ProductDiscountCandidatePrerequisite @oneOf {
+  """
+  A cart line that is required for the discount candidate to be applicable. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
+  """
+  cartLine: CartLinePrerequisite
 }
 
 """
@@ -5590,6 +5853,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-discount-rs/shopify.extension.toml.liquid
+++ b/functions-discount-rs/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-discount-rs/src/cart_lines_discounts_generate_run.rs
+++ b/functions-discount-rs/src/cart_lines_discounts_generate_run.rs
@@ -73,6 +73,7 @@ fn cart_lines_discounts_generate_run(
                         value: Decimal(20.0),
                     }),
                     associated_discount_code: None,
+                    prerequisites: None,
                 }],
             },
         ));

--- a/functions-discount-wasm/schema.graphql
+++ b/functions-discount-wasm/schema.graphql
@@ -102,6 +102,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -134,6 +139,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -175,6 +185,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -232,6 +248,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -363,6 +384,11 @@ type CartLine {
   cost: CartLineCost!
 
   """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
+
+  """
   The ID of the cart line.
   """
   id: ID!
@@ -463,6 +489,25 @@ type CartLineParentRelationship {
   The parent line in the relationship.
   """
   parent: CartLine!
+}
+
+"""
+A cart line that is required for the discount candidate to be applicable. A cart line is an entry in the
+customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
+"""
+input CartLinePrerequisite {
+  """
+  The ID of the prerequisite cart line.
+  """
+  id: ID!
+
+  """
+  The number of line items that are required for the discount candidate to be applicable.
+
+  The value is validated against: > 0.
+  """
+  quantity: Int!
 }
 
 """
@@ -3203,6 +3248,127 @@ type Discount implements HasMetafields {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 The [discount class](https://help.shopify.com/manual/discounts/combining-discounts/discount-combinations)
 that's used to control how discounts can be combined.
 """
@@ -4921,6 +5087,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -5118,6 +5349,21 @@ input Percentage {
 }
 
 """
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
+
+"""
 The goods and services that merchants offer to customers. Products can include details such as
 title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 Products can be organized by grouping them into a collection.
@@ -5261,6 +5507,11 @@ input ProductDiscountCandidate {
   message: String
 
   """
+  The items required for the discount candidate to be applicable.
+  """
+  prerequisites: [ProductDiscountCandidatePrerequisite!]
+
+  """
   The targets of the discount to be applied to a cart line.
   """
   targets: [ProductDiscountCandidateTarget!]!
@@ -5291,6 +5542,18 @@ input ProductDiscountCandidateFixedAmount {
   When the value is `true`, the value will be applied to each of the entitled items.
   """
   appliesToEachItem: Boolean = false
+}
+
+"""
+The items required for the discount candidate to be applicable.
+"""
+input ProductDiscountCandidatePrerequisite @oneOf {
+  """
+  A cart line that is required for the discount candidate to be applicable. A cart line is an entry in the
+  customer's cart that represents a single unit of a product variant. For example, if a customer adds two
+  different sizes of the same t-shirt to their cart, then each size is represented as a separate cart line.
+  """
+  cartLine: CartLinePrerequisite
 }
 
 """
@@ -5590,6 +5853,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-discount-wasm/shopify.extension.toml.liquid
+++ b/functions-discount-wasm/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-discounts-allocator-js/schema.graphql
+++ b/functions-discounts-allocator-js/schema.graphql
@@ -82,6 +82,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -114,6 +119,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -157,6 +167,12 @@ type Cart implements HasMetafields {
   ): Metafield
 
   """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
+
+  """
   The physical location where a retail order is created or completed.
   """
   retailLocation: Location
@@ -168,7 +184,7 @@ the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount for the customer to pay at checkout, excluding taxes and discounts.
+  The amount, before taxes and cart-level discounts, for the customer to pay.
   """
   subtotalAmount: MoneyV2!
 
@@ -212,6 +228,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -304,7 +325,7 @@ type CartLine {
   gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
   Cart line attributes are equivalent to the
-  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  [`line_item`](https://shopify.dev/docs/api/liquid/objects/line_item)
   object in Liquid.
   """
   attribute(
@@ -322,6 +343,11 @@ type CartLine {
   cost: CartLineCost!
 
   """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
+
+  """
   The ID of the cart line.
   """
   id: ID!
@@ -332,7 +358,8 @@ type CartLine {
   merchandise: Merchandise!
 
   """
-  The relationship between this line and its parent line, if any.
+  The [nested relationship](https://shopify.dev/docs/apps/build/product-merchandising/nested-cart-lines)
+  between this line and its parent line, if any.
   """
   parentRelationship: CartLineParentRelationship
 
@@ -361,7 +388,7 @@ type CartLineCost {
   amountPerQuantity: MoneyV2!
 
   """
-  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  The `compareAt` price of a single unit before any discounts are applied. This field is used to calculate and display
   savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
   is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
   `null` when the value is hidden from buyers.
@@ -2806,7 +2833,7 @@ type DeliverableCartLine {
   gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
   Cart line attributes are equivalent to the
-  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  [`line_item`](https://shopify.dev/docs/api/liquid/objects/line_item)
   object in Liquid.
   """
   attribute(
@@ -2923,6 +2950,89 @@ type Discount implements HasMetafields {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
 The approach that determines how multiple discounts are evaluated and
 applied to a cart. You can apply all discounts with conditions that are met,
 apply a discount only to the first line item in a cart that meets conditions,
@@ -2952,6 +3062,44 @@ enum DiscountApplicationStrategy {
   Since $6 is more than $5, the 20% discount on the t-shirt is applied.
   """
   MAXIMUM
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
 }
 
 """
@@ -4545,7 +4693,74 @@ type Metafield {
 }
 
 """
-A precise monetary value and its associated currency. For example, 12.99 USD.
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
+A precise monetary value and its associated currency. Combines a decimal amount
+with a three-letter currency code to express prices, costs, and other financial
+values throughout the API. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
@@ -4598,6 +4813,21 @@ type Percentage {
   """
   value: Decimal!
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4941,6 +5171,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-discounts-allocator-rs/schema.graphql
+++ b/functions-discounts-allocator-rs/schema.graphql
@@ -82,6 +82,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -114,6 +119,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -157,6 +167,12 @@ type Cart implements HasMetafields {
   ): Metafield
 
   """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
+
+  """
   The physical location where a retail order is created or completed.
   """
   retailLocation: Location
@@ -168,7 +184,7 @@ the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount for the customer to pay at checkout, excluding taxes and discounts.
+  The amount, before taxes and cart-level discounts, for the customer to pay.
   """
   subtotalAmount: MoneyV2!
 
@@ -212,6 +228,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -304,7 +325,7 @@ type CartLine {
   gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
   Cart line attributes are equivalent to the
-  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  [`line_item`](https://shopify.dev/docs/api/liquid/objects/line_item)
   object in Liquid.
   """
   attribute(
@@ -322,6 +343,11 @@ type CartLine {
   cost: CartLineCost!
 
   """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
+
+  """
   The ID of the cart line.
   """
   id: ID!
@@ -332,7 +358,8 @@ type CartLine {
   merchandise: Merchandise!
 
   """
-  The relationship between this line and its parent line, if any.
+  The [nested relationship](https://shopify.dev/docs/apps/build/product-merchandising/nested-cart-lines)
+  between this line and its parent line, if any.
   """
   parentRelationship: CartLineParentRelationship
 
@@ -361,7 +388,7 @@ type CartLineCost {
   amountPerQuantity: MoneyV2!
 
   """
-  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  The `compareAt` price of a single unit before any discounts are applied. This field is used to calculate and display
   savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
   is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
   `null` when the value is hidden from buyers.
@@ -2806,7 +2833,7 @@ type DeliverableCartLine {
   gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
   Cart line attributes are equivalent to the
-  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  [`line_item`](https://shopify.dev/docs/api/liquid/objects/line_item)
   object in Liquid.
   """
   attribute(
@@ -2923,6 +2950,89 @@ type Discount implements HasMetafields {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
 The approach that determines how multiple discounts are evaluated and
 applied to a cart. You can apply all discounts with conditions that are met,
 apply a discount only to the first line item in a cart that meets conditions,
@@ -2952,6 +3062,44 @@ enum DiscountApplicationStrategy {
   Since $6 is more than $5, the 20% discount on the t-shirt is applied.
   """
   MAXIMUM
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
 }
 
 """
@@ -4545,7 +4693,74 @@ type Metafield {
 }
 
 """
-A precise monetary value and its associated currency. For example, 12.99 USD.
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
+A precise monetary value and its associated currency. Combines a decimal amount
+with a three-letter currency code to express prices, costs, and other financial
+values throughout the API. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
@@ -4598,6 +4813,21 @@ type Percentage {
   """
   value: Decimal!
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4941,6 +5171,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-discounts-allocator-wasm/schema.graphql
+++ b/functions-discounts-allocator-wasm/schema.graphql
@@ -82,6 +82,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -114,6 +119,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -157,6 +167,12 @@ type Cart implements HasMetafields {
   ): Metafield
 
   """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
+
+  """
   The physical location where a retail order is created or completed.
   """
   retailLocation: Location
@@ -168,7 +184,7 @@ the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount for the customer to pay at checkout, excluding taxes and discounts.
+  The amount, before taxes and cart-level discounts, for the customer to pay.
   """
   subtotalAmount: MoneyV2!
 
@@ -212,6 +228,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -304,7 +325,7 @@ type CartLine {
   gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
   Cart line attributes are equivalent to the
-  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  [`line_item`](https://shopify.dev/docs/api/liquid/objects/line_item)
   object in Liquid.
   """
   attribute(
@@ -322,6 +343,11 @@ type CartLine {
   cost: CartLineCost!
 
   """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
+
+  """
   The ID of the cart line.
   """
   id: ID!
@@ -332,7 +358,8 @@ type CartLine {
   merchandise: Merchandise!
 
   """
-  The relationship between this line and its parent line, if any.
+  The [nested relationship](https://shopify.dev/docs/apps/build/product-merchandising/nested-cart-lines)
+  between this line and its parent line, if any.
   """
   parentRelationship: CartLineParentRelationship
 
@@ -361,7 +388,7 @@ type CartLineCost {
   amountPerQuantity: MoneyV2!
 
   """
-  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  The `compareAt` price of a single unit before any discounts are applied. This field is used to calculate and display
   savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
   is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
   `null` when the value is hidden from buyers.
@@ -2806,7 +2833,7 @@ type DeliverableCartLine {
   gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
   Cart line attributes are equivalent to the
-  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  [`line_item`](https://shopify.dev/docs/api/liquid/objects/line_item)
   object in Liquid.
   """
   attribute(
@@ -2923,6 +2950,89 @@ type Discount implements HasMetafields {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
 The approach that determines how multiple discounts are evaluated and
 applied to a cart. You can apply all discounts with conditions that are met,
 apply a discount only to the first line item in a cart that meets conditions,
@@ -2952,6 +3062,44 @@ enum DiscountApplicationStrategy {
   Since $6 is more than $5, the 20% discount on the t-shirt is applied.
   """
   MAXIMUM
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
 }
 
 """
@@ -4545,7 +4693,74 @@ type Metafield {
 }
 
 """
-A precise monetary value and its associated currency. For example, 12.99 USD.
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
+A precise monetary value and its associated currency. Combines a decimal amount
+with a three-letter currency code to express prices, costs, and other financial
+values throughout the API. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
@@ -4598,6 +4813,21 @@ type Percentage {
   """
   value: Decimal!
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4941,6 +5171,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-fulfillment-constraints-js/schema.graphql
+++ b/functions-fulfillment-constraints-js/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -339,6 +360,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2924,6 +2950,127 @@ input DeprecatedOperation @oneOf {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 A customization which applies constraint rules to order routing and fulfillments.
 """
 type FulfillmentConstraintRule implements HasMetafields {
@@ -4460,6 +4607,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4561,6 +4773,21 @@ input Operation @oneOf {
   """
   deliverableLinesMustFulfillFromSameLocationAdd: DeliverableLinesMustFulfillFromSameLocationAddOperation
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4904,6 +5131,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-fulfillment-constraints-js/shopify.extension.toml.liquid
+++ b/functions-fulfillment-constraints-js/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-fulfillment-constraints-rs/schema.graphql
+++ b/functions-fulfillment-constraints-rs/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -339,6 +360,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2924,6 +2950,127 @@ input DeprecatedOperation @oneOf {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 A customization which applies constraint rules to order routing and fulfillments.
 """
 type FulfillmentConstraintRule implements HasMetafields {
@@ -4460,6 +4607,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4561,6 +4773,21 @@ input Operation @oneOf {
   """
   deliverableLinesMustFulfillFromSameLocationAdd: DeliverableLinesMustFulfillFromSameLocationAddOperation
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4904,6 +5131,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-fulfillment-constraints-rs/shopify.extension.toml.liquid
+++ b/functions-fulfillment-constraints-rs/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-fulfillment-constraints-wasm/schema.graphql
+++ b/functions-fulfillment-constraints-wasm/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -339,6 +360,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2924,6 +2950,127 @@ input DeprecatedOperation @oneOf {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 A customization which applies constraint rules to order routing and fulfillments.
 """
 type FulfillmentConstraintRule implements HasMetafields {
@@ -4460,6 +4607,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4561,6 +4773,21 @@ input Operation @oneOf {
   """
   deliverableLinesMustFulfillFromSameLocationAdd: DeliverableLinesMustFulfillFromSameLocationAddOperation
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4904,6 +5131,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-fulfillment-constraints-wasm/shopify.extension.toml.liquid
+++ b/functions-fulfillment-constraints-wasm/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-local-pickup-delivery-option-generators-js/schema.graphql
+++ b/functions-local-pickup-delivery-option-generators-js/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -162,6 +172,12 @@ type Cart implements HasMetafields {
   ): Metafield
 
   """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
+
+  """
   The physical location where a retail order is created or completed.
   """
   retailLocation: Location
@@ -173,7 +189,7 @@ the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount for the customer to pay at checkout, excluding taxes and discounts.
+  The amount, before taxes and cart-level discounts, for the customer to pay.
   """
   subtotalAmount: MoneyV2!
 
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -309,7 +330,7 @@ type CartLine {
   gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
   Cart line attributes are equivalent to the
-  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  [`line_item`](https://shopify.dev/docs/api/liquid/objects/line_item)
   object in Liquid.
   """
   attribute(
@@ -327,6 +348,11 @@ type CartLine {
   cost: CartLineCost!
 
   """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
+
+  """
   The ID of the cart line.
   """
   id: ID!
@@ -337,7 +363,8 @@ type CartLine {
   merchandise: Merchandise!
 
   """
-  The relationship between this line and its parent line, if any.
+  The [nested relationship](https://shopify.dev/docs/apps/build/product-merchandising/nested-cart-lines)
+  between this line and its parent line, if any.
   """
   parentRelationship: CartLineParentRelationship
 
@@ -366,7 +393,7 @@ type CartLineCost {
   amountPerQuantity: MoneyV2!
 
   """
-  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  The `compareAt` price of a single unit before any discounts are applied. This field is used to calculate and display
   savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
   is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
   `null` when the value is hidden from buyers.
@@ -2799,7 +2826,7 @@ type DeliverableCartLine {
   gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
   Cart line attributes are equivalent to the
-  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  [`line_item`](https://shopify.dev/docs/api/liquid/objects/line_item)
   object in Liquid.
   """
   attribute(
@@ -2889,6 +2916,127 @@ type DeliveryOptionGenerator implements HasMetafields {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 A group of one or more items to be fulfilled together. Every cart line belongs to
 exactly one fulfillment group.
 """
@@ -2921,6 +3069,16 @@ type FulfillmentGroup {
   The merchandise in the fulfillment group. A subset of cart lines.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
+}
+
+"""
+The fetch target result. Refer to network access for Shopify Functions.
+"""
+input FunctionFetchResult {
+  """
+  HTTP Request.
+  """
+  request: HttpRequest
 }
 
 """
@@ -3004,6 +3162,146 @@ type HasTagResponse {
 }
 
 """
+The attributes associated with an HTTP request.
+"""
+input HttpRequest {
+  """
+  The HTTP request body as a plain string.
+  Use this field when the body isn't in JSON format.
+  """
+  body: String
+
+  """
+  The HTTP headers.
+  """
+  headers: [HttpRequestHeader!]!
+
+  """
+  The HTTP request body as a JSON object.
+  Use this field when the body's in JSON format, to reduce function instruction consumption
+  and to ensure the body's formatted in logs.
+  Don't use this field together with the `body` field. If both are provided, then the `body` field
+  will take precedence.
+  If this field is specified and no `Content-Type` header is included, then the header will
+  automatically be set to `application/json`.
+  """
+  jsonBody: JSON
+
+  """
+  The HTTP method.
+  """
+  method: HttpRequestMethod!
+
+  """
+  Policy attached to the HTTP request.
+  """
+  policy: HttpRequestPolicy!
+
+  """
+  The HTTP url (eg.: https://example.com). The scheme needs to be HTTPS.
+  """
+  url: URL!
+}
+
+"""
+The attributes associated with an HTTP request header.
+"""
+input HttpRequestHeader {
+  """
+  Header name.
+  """
+  name: String!
+
+  """
+  Header value.
+  """
+  value: String!
+}
+
+"""
+The HTTP request available methods.
+"""
+enum HttpRequestMethod {
+  """
+  Http GET.
+  """
+  GET
+
+  """
+  Http POST.
+  """
+  POST
+}
+
+"""
+The attributes associated with an HTTP request policy.
+"""
+input HttpRequestPolicy {
+  """
+  Read timeout in milliseconds.
+  """
+  readTimeoutMs: Int!
+}
+
+"""
+The attributes associated with an HTTP response.
+"""
+type HttpResponse {
+  """
+  The HTTP response body as a plain string.
+  Use this field when the body is not in JSON format.
+  """
+  body: String
+
+  """
+  An HTTP header.
+  """
+  header(
+    """
+    A case-insensitive header name.
+    """
+    name: String!
+  ): HttpResponseHeader
+
+  """
+  The HTTP headers.
+  """
+  headers: [HttpResponseHeader!]! @deprecated(reason: "Use `header` instead.")
+
+  """
+  The HTTP response body parsed as JSON.
+  If the body is valid JSON, it will be parsed and returned as a JSON object.
+  If parsing fails, then raw body is returned as a string.
+  Use this field when you expect the response to be JSON, or when you're dealing
+  with mixed response types, meaning both JSON and non-JSON.
+  Using this field reduces function instruction consumption and ensures that the data is formatted in logs.
+  To prevent increasing the function target input size unnecessarily, avoid querying
+  both `body` and `jsonBody` simultaneously.
+  """
+  jsonBody: JSON
+
+  """
+  The HTTP status code.
+  """
+  status: Int!
+}
+
+"""
+The attributes associated with an HTTP response header.
+"""
+type HttpResponseHeader {
+  """
+  Header name.
+  """
+  name: String!
+
+  """
+  Header value.
+  """
+  value: String!
+}
+
+"""
 Represents a unique identifier, often used to refetch an object.
 The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
 
@@ -3025,6 +3323,11 @@ type Input {
   that are associated with the customization.
   """
   deliveryOptionGenerator: DeliveryOptionGenerator!
+
+  """
+  The result of the fetch target. Refer to network access for Shopify Functions.
+  """
+  fetchResult: HttpResponse @restrictTarget(only: ["purchase.local-pickup-delivery-option-generator.run"])
 
   """
   A list of
@@ -4499,7 +4802,74 @@ input MetafieldOutput {
 }
 
 """
-A precise monetary value and its associated currency. For example, 12.99 USD.
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
+A precise monetary value and its associated currency. Combines a decimal amount
+with a three-letter currency code to express prices, costs, and other financial
+values throughout the API. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
@@ -4520,6 +4890,16 @@ type MoneyV2 {
 The root mutation for the API.
 """
 type MutationRoot {
+  """
+  Handles the Function result for the purchase.local-pickup-delivery-option-generator.fetch target.
+  """
+  fetch(
+    """
+    The result of the Function.
+    """
+    result: FunctionFetchResult!
+  ): Void!
+
   """
   Handles the Function result.
   """
@@ -4563,6 +4943,21 @@ input PickupLocation {
   """
   pickupInstruction: String
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4906,6 +5301,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """
@@ -4914,6 +5325,15 @@ includes the time but not the date or timezone which is determined from context.
 For example, "05:43:21".
 """
 scalar TimeWithoutTimezone
+
+"""
+Represents an [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) and
+[RFC 3987](https://datatracker.ietf.org/doc/html/rfc3987)-compliant URI string.
+
+For example, `"https://example.myshopify.com"` is a valid URL. It includes a scheme (`https`) and a host
+(`example.myshopify.com`).
+"""
+scalar URL
 
 """
 A void type that can be used to return a null value from a mutation.

--- a/functions-local-pickup-delivery-option-generators-rs/schema.graphql
+++ b/functions-local-pickup-delivery-option-generators-rs/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -162,6 +172,12 @@ type Cart implements HasMetafields {
   ): Metafield
 
   """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
+
+  """
   The physical location where a retail order is created or completed.
   """
   retailLocation: Location
@@ -173,7 +189,7 @@ the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount for the customer to pay at checkout, excluding taxes and discounts.
+  The amount, before taxes and cart-level discounts, for the customer to pay.
   """
   subtotalAmount: MoneyV2!
 
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -309,7 +330,7 @@ type CartLine {
   gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
   Cart line attributes are equivalent to the
-  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  [`line_item`](https://shopify.dev/docs/api/liquid/objects/line_item)
   object in Liquid.
   """
   attribute(
@@ -327,6 +348,11 @@ type CartLine {
   cost: CartLineCost!
 
   """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
+
+  """
   The ID of the cart line.
   """
   id: ID!
@@ -337,7 +363,8 @@ type CartLine {
   merchandise: Merchandise!
 
   """
-  The relationship between this line and its parent line, if any.
+  The [nested relationship](https://shopify.dev/docs/apps/build/product-merchandising/nested-cart-lines)
+  between this line and its parent line, if any.
   """
   parentRelationship: CartLineParentRelationship
 
@@ -366,7 +393,7 @@ type CartLineCost {
   amountPerQuantity: MoneyV2!
 
   """
-  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  The `compareAt` price of a single unit before any discounts are applied. This field is used to calculate and display
   savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
   is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
   `null` when the value is hidden from buyers.
@@ -2799,7 +2826,7 @@ type DeliverableCartLine {
   gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
   Cart line attributes are equivalent to the
-  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  [`line_item`](https://shopify.dev/docs/api/liquid/objects/line_item)
   object in Liquid.
   """
   attribute(
@@ -2889,6 +2916,127 @@ type DeliveryOptionGenerator implements HasMetafields {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 A group of one or more items to be fulfilled together. Every cart line belongs to
 exactly one fulfillment group.
 """
@@ -2921,6 +3069,16 @@ type FulfillmentGroup {
   The merchandise in the fulfillment group. A subset of cart lines.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
+}
+
+"""
+The fetch target result. Refer to network access for Shopify Functions.
+"""
+input FunctionFetchResult {
+  """
+  HTTP Request.
+  """
+  request: HttpRequest
 }
 
 """
@@ -3004,6 +3162,146 @@ type HasTagResponse {
 }
 
 """
+The attributes associated with an HTTP request.
+"""
+input HttpRequest {
+  """
+  The HTTP request body as a plain string.
+  Use this field when the body isn't in JSON format.
+  """
+  body: String
+
+  """
+  The HTTP headers.
+  """
+  headers: [HttpRequestHeader!]!
+
+  """
+  The HTTP request body as a JSON object.
+  Use this field when the body's in JSON format, to reduce function instruction consumption
+  and to ensure the body's formatted in logs.
+  Don't use this field together with the `body` field. If both are provided, then the `body` field
+  will take precedence.
+  If this field is specified and no `Content-Type` header is included, then the header will
+  automatically be set to `application/json`.
+  """
+  jsonBody: JSON
+
+  """
+  The HTTP method.
+  """
+  method: HttpRequestMethod!
+
+  """
+  Policy attached to the HTTP request.
+  """
+  policy: HttpRequestPolicy!
+
+  """
+  The HTTP url (eg.: https://example.com). The scheme needs to be HTTPS.
+  """
+  url: URL!
+}
+
+"""
+The attributes associated with an HTTP request header.
+"""
+input HttpRequestHeader {
+  """
+  Header name.
+  """
+  name: String!
+
+  """
+  Header value.
+  """
+  value: String!
+}
+
+"""
+The HTTP request available methods.
+"""
+enum HttpRequestMethod {
+  """
+  Http GET.
+  """
+  GET
+
+  """
+  Http POST.
+  """
+  POST
+}
+
+"""
+The attributes associated with an HTTP request policy.
+"""
+input HttpRequestPolicy {
+  """
+  Read timeout in milliseconds.
+  """
+  readTimeoutMs: Int!
+}
+
+"""
+The attributes associated with an HTTP response.
+"""
+type HttpResponse {
+  """
+  The HTTP response body as a plain string.
+  Use this field when the body is not in JSON format.
+  """
+  body: String
+
+  """
+  An HTTP header.
+  """
+  header(
+    """
+    A case-insensitive header name.
+    """
+    name: String!
+  ): HttpResponseHeader
+
+  """
+  The HTTP headers.
+  """
+  headers: [HttpResponseHeader!]! @deprecated(reason: "Use `header` instead.")
+
+  """
+  The HTTP response body parsed as JSON.
+  If the body is valid JSON, it will be parsed and returned as a JSON object.
+  If parsing fails, then raw body is returned as a string.
+  Use this field when you expect the response to be JSON, or when you're dealing
+  with mixed response types, meaning both JSON and non-JSON.
+  Using this field reduces function instruction consumption and ensures that the data is formatted in logs.
+  To prevent increasing the function target input size unnecessarily, avoid querying
+  both `body` and `jsonBody` simultaneously.
+  """
+  jsonBody: JSON
+
+  """
+  The HTTP status code.
+  """
+  status: Int!
+}
+
+"""
+The attributes associated with an HTTP response header.
+"""
+type HttpResponseHeader {
+  """
+  Header name.
+  """
+  name: String!
+
+  """
+  Header value.
+  """
+  value: String!
+}
+
+"""
 Represents a unique identifier, often used to refetch an object.
 The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
 
@@ -3025,6 +3323,11 @@ type Input {
   that are associated with the customization.
   """
   deliveryOptionGenerator: DeliveryOptionGenerator!
+
+  """
+  The result of the fetch target. Refer to network access for Shopify Functions.
+  """
+  fetchResult: HttpResponse @restrictTarget(only: ["purchase.local-pickup-delivery-option-generator.run"])
 
   """
   A list of
@@ -4499,7 +4802,74 @@ input MetafieldOutput {
 }
 
 """
-A precise monetary value and its associated currency. For example, 12.99 USD.
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
+A precise monetary value and its associated currency. Combines a decimal amount
+with a three-letter currency code to express prices, costs, and other financial
+values throughout the API. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
@@ -4520,6 +4890,16 @@ type MoneyV2 {
 The root mutation for the API.
 """
 type MutationRoot {
+  """
+  Handles the Function result for the purchase.local-pickup-delivery-option-generator.fetch target.
+  """
+  fetch(
+    """
+    The result of the Function.
+    """
+    result: FunctionFetchResult!
+  ): Void!
+
   """
   Handles the Function result.
   """
@@ -4563,6 +4943,21 @@ input PickupLocation {
   """
   pickupInstruction: String
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4906,6 +5301,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """
@@ -4914,6 +5325,15 @@ includes the time but not the date or timezone which is determined from context.
 For example, "05:43:21".
 """
 scalar TimeWithoutTimezone
+
+"""
+Represents an [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) and
+[RFC 3987](https://datatracker.ietf.org/doc/html/rfc3987)-compliant URI string.
+
+For example, `"https://example.myshopify.com"` is a valid URL. It includes a scheme (`https`) and a host
+(`example.myshopify.com`).
+"""
+scalar URL
 
 """
 A void type that can be used to return a null value from a mutation.

--- a/functions-local-pickup-delivery-option-generators-wasm/schema.graphql
+++ b/functions-local-pickup-delivery-option-generators-wasm/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -162,6 +172,12 @@ type Cart implements HasMetafields {
   ): Metafield
 
   """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
+
+  """
   The physical location where a retail order is created or completed.
   """
   retailLocation: Location
@@ -173,7 +189,7 @@ the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount for the customer to pay at checkout, excluding taxes and discounts.
+  The amount, before taxes and cart-level discounts, for the customer to pay.
   """
   subtotalAmount: MoneyV2!
 
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -309,7 +330,7 @@ type CartLine {
   gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
   Cart line attributes are equivalent to the
-  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  [`line_item`](https://shopify.dev/docs/api/liquid/objects/line_item)
   object in Liquid.
   """
   attribute(
@@ -327,6 +348,11 @@ type CartLine {
   cost: CartLineCost!
 
   """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
+
+  """
   The ID of the cart line.
   """
   id: ID!
@@ -337,7 +363,8 @@ type CartLine {
   merchandise: Merchandise!
 
   """
-  The relationship between this line and its parent line, if any.
+  The [nested relationship](https://shopify.dev/docs/apps/build/product-merchandising/nested-cart-lines)
+  between this line and its parent line, if any.
   """
   parentRelationship: CartLineParentRelationship
 
@@ -366,7 +393,7 @@ type CartLineCost {
   amountPerQuantity: MoneyV2!
 
   """
-  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  The `compareAt` price of a single unit before any discounts are applied. This field is used to calculate and display
   savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
   is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
   `null` when the value is hidden from buyers.
@@ -2799,7 +2826,7 @@ type DeliverableCartLine {
   gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
   Cart line attributes are equivalent to the
-  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  [`line_item`](https://shopify.dev/docs/api/liquid/objects/line_item)
   object in Liquid.
   """
   attribute(
@@ -2889,6 +2916,127 @@ type DeliveryOptionGenerator implements HasMetafields {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 A group of one or more items to be fulfilled together. Every cart line belongs to
 exactly one fulfillment group.
 """
@@ -2921,6 +3069,16 @@ type FulfillmentGroup {
   The merchandise in the fulfillment group. A subset of cart lines.
   """
   lines: [CartLine!]! @scaleLimits(rate: 0.005)
+}
+
+"""
+The fetch target result. Refer to network access for Shopify Functions.
+"""
+input FunctionFetchResult {
+  """
+  HTTP Request.
+  """
+  request: HttpRequest
 }
 
 """
@@ -3004,6 +3162,146 @@ type HasTagResponse {
 }
 
 """
+The attributes associated with an HTTP request.
+"""
+input HttpRequest {
+  """
+  The HTTP request body as a plain string.
+  Use this field when the body isn't in JSON format.
+  """
+  body: String
+
+  """
+  The HTTP headers.
+  """
+  headers: [HttpRequestHeader!]!
+
+  """
+  The HTTP request body as a JSON object.
+  Use this field when the body's in JSON format, to reduce function instruction consumption
+  and to ensure the body's formatted in logs.
+  Don't use this field together with the `body` field. If both are provided, then the `body` field
+  will take precedence.
+  If this field is specified and no `Content-Type` header is included, then the header will
+  automatically be set to `application/json`.
+  """
+  jsonBody: JSON
+
+  """
+  The HTTP method.
+  """
+  method: HttpRequestMethod!
+
+  """
+  Policy attached to the HTTP request.
+  """
+  policy: HttpRequestPolicy!
+
+  """
+  The HTTP url (eg.: https://example.com). The scheme needs to be HTTPS.
+  """
+  url: URL!
+}
+
+"""
+The attributes associated with an HTTP request header.
+"""
+input HttpRequestHeader {
+  """
+  Header name.
+  """
+  name: String!
+
+  """
+  Header value.
+  """
+  value: String!
+}
+
+"""
+The HTTP request available methods.
+"""
+enum HttpRequestMethod {
+  """
+  Http GET.
+  """
+  GET
+
+  """
+  Http POST.
+  """
+  POST
+}
+
+"""
+The attributes associated with an HTTP request policy.
+"""
+input HttpRequestPolicy {
+  """
+  Read timeout in milliseconds.
+  """
+  readTimeoutMs: Int!
+}
+
+"""
+The attributes associated with an HTTP response.
+"""
+type HttpResponse {
+  """
+  The HTTP response body as a plain string.
+  Use this field when the body is not in JSON format.
+  """
+  body: String
+
+  """
+  An HTTP header.
+  """
+  header(
+    """
+    A case-insensitive header name.
+    """
+    name: String!
+  ): HttpResponseHeader
+
+  """
+  The HTTP headers.
+  """
+  headers: [HttpResponseHeader!]! @deprecated(reason: "Use `header` instead.")
+
+  """
+  The HTTP response body parsed as JSON.
+  If the body is valid JSON, it will be parsed and returned as a JSON object.
+  If parsing fails, then raw body is returned as a string.
+  Use this field when you expect the response to be JSON, or when you're dealing
+  with mixed response types, meaning both JSON and non-JSON.
+  Using this field reduces function instruction consumption and ensures that the data is formatted in logs.
+  To prevent increasing the function target input size unnecessarily, avoid querying
+  both `body` and `jsonBody` simultaneously.
+  """
+  jsonBody: JSON
+
+  """
+  The HTTP status code.
+  """
+  status: Int!
+}
+
+"""
+The attributes associated with an HTTP response header.
+"""
+type HttpResponseHeader {
+  """
+  Header name.
+  """
+  name: String!
+
+  """
+  Header value.
+  """
+  value: String!
+}
+
+"""
 Represents a unique identifier, often used to refetch an object.
 The ID type appears in a JSON response as a String, but it is not intended to be human-readable.
 
@@ -3025,6 +3323,11 @@ type Input {
   that are associated with the customization.
   """
   deliveryOptionGenerator: DeliveryOptionGenerator!
+
+  """
+  The result of the fetch target. Refer to network access for Shopify Functions.
+  """
+  fetchResult: HttpResponse @restrictTarget(only: ["purchase.local-pickup-delivery-option-generator.run"])
 
   """
   A list of
@@ -4499,7 +4802,74 @@ input MetafieldOutput {
 }
 
 """
-A precise monetary value and its associated currency. For example, 12.99 USD.
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
+A precise monetary value and its associated currency. Combines a decimal amount
+with a three-letter currency code to express prices, costs, and other financial
+values throughout the API. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
@@ -4520,6 +4890,16 @@ type MoneyV2 {
 The root mutation for the API.
 """
 type MutationRoot {
+  """
+  Handles the Function result for the purchase.local-pickup-delivery-option-generator.fetch target.
+  """
+  fetch(
+    """
+    The result of the Function.
+    """
+    result: FunctionFetchResult!
+  ): Void!
+
   """
   Handles the Function result.
   """
@@ -4563,6 +4943,21 @@ input PickupLocation {
   """
   pickupInstruction: String
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4906,6 +5301,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """
@@ -4914,6 +5325,15 @@ includes the time but not the date or timezone which is determined from context.
 For example, "05:43:21".
 """
 scalar TimeWithoutTimezone
+
+"""
+Represents an [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986) and
+[RFC 3987](https://datatracker.ietf.org/doc/html/rfc3987)-compliant URI string.
+
+For example, `"https://example.myshopify.com"` is a valid URL. It includes a scheme (`https`) and a host
+(`example.myshopify.com`).
+"""
+scalar URL
 
 """
 A void type that can be used to return a null value from a mutation.

--- a/functions-location-rules-js/schema.graphql
+++ b/functions-location-rules-js/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -338,6 +359,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2886,6 +2912,127 @@ input DeprecatedOperation @oneOf {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 A group of one or more items to be fulfilled together.
 """
 type FulfillmentGroup {
@@ -4455,6 +4602,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4547,6 +4759,21 @@ type OrderRoutingLocationRule implements HasMetafields {
     namespace: String
   ): Metafield
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4905,6 +5132,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-location-rules-js/shopify.extension.toml.liquid
+++ b/functions-location-rules-js/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-location-rules-rs/schema.graphql
+++ b/functions-location-rules-rs/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -338,6 +359,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2886,6 +2912,127 @@ input DeprecatedOperation @oneOf {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 A group of one or more items to be fulfilled together.
 """
 type FulfillmentGroup {
@@ -4455,6 +4602,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4547,6 +4759,21 @@ type OrderRoutingLocationRule implements HasMetafields {
     namespace: String
   ): Metafield
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4905,6 +5132,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-location-rules-rs/shopify.extension.toml.liquid
+++ b/functions-location-rules-rs/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-location-rules-wasm/schema.graphql
+++ b/functions-location-rules-wasm/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -338,6 +359,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2886,6 +2912,127 @@ input DeprecatedOperation @oneOf {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 A group of one or more items to be fulfilled together.
 """
 type FulfillmentGroup {
@@ -4455,6 +4602,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4547,6 +4759,21 @@ type OrderRoutingLocationRule implements HasMetafields {
     namespace: String
   ): Metafield
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4905,6 +5132,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-location-rules-wasm/shopify.extension.toml.liquid
+++ b/functions-location-rules-wasm/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-order-discounts-js/schema.graphql
+++ b/functions-order-discounts-js/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -325,6 +346,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2929,6 +2955,89 @@ input Discount {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
 The approach that determines how multiple discounts are evaluated and
 applied to a cart. You can apply a discount to the first line item in a cart that meets conditions,
 or apply the discount that offers the maximum price reduction.
@@ -2948,6 +3057,44 @@ enum DiscountApplicationStrategy {
   Since $6 is more than $5, the 20% discount on the t-shirt is applied.
   """
   MAXIMUM
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
 }
 
 """
@@ -4491,6 +4638,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4581,6 +4793,21 @@ input Percentage {
   """
   value: Decimal!
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4990,6 +5217,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-order-discounts-js/shopify.extension.toml.liquid
+++ b/functions-order-discounts-js/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-order-discounts-rs/schema.graphql
+++ b/functions-order-discounts-rs/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -325,6 +346,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2929,6 +2955,89 @@ input Discount {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
 The approach that determines how multiple discounts are evaluated and
 applied to a cart. You can apply a discount to the first line item in a cart that meets conditions,
 or apply the discount that offers the maximum price reduction.
@@ -2948,6 +3057,44 @@ enum DiscountApplicationStrategy {
   Since $6 is more than $5, the 20% discount on the t-shirt is applied.
   """
   MAXIMUM
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
 }
 
 """
@@ -4491,6 +4638,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4581,6 +4793,21 @@ input Percentage {
   """
   value: Decimal!
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4990,6 +5217,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-order-discounts-rs/shopify.extension.toml.liquid
+++ b/functions-order-discounts-rs/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-order-discounts-wasm/schema.graphql
+++ b/functions-order-discounts-wasm/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -325,6 +346,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2929,6 +2955,89 @@ input Discount {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
 The approach that determines how multiple discounts are evaluated and
 applied to a cart. You can apply a discount to the first line item in a cart that meets conditions,
 or apply the discount that offers the maximum price reduction.
@@ -2948,6 +3057,44 @@ enum DiscountApplicationStrategy {
   Since $6 is more than $5, the 20% discount on the t-shirt is applied.
   """
   MAXIMUM
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
 }
 
 """
@@ -4491,6 +4638,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4581,6 +4793,21 @@ input Percentage {
   """
   value: Decimal!
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4990,6 +5217,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-order-discounts-wasm/shopify.extension.toml.liquid
+++ b/functions-order-discounts-wasm/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-payment-customization-js/schema.graphql
+++ b/functions-payment-customization-js/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -325,6 +346,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2936,6 +2962,127 @@ input DeprecatedOperation @oneOf {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 The input to set event-based payment terms.
 """
 input EventPaymentTerms {
@@ -4478,6 +4625,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4847,6 +5059,21 @@ enum PaymentTermsTriggerEvent {
 }
 
 """
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
+
+"""
 The goods and services that merchants offer to customers. Products can include details such as
 title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 Products can be organized by grouping them into a collection.
@@ -5210,6 +5437,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-payment-customization-js/shopify.extension.toml.liquid
+++ b/functions-payment-customization-js/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-payment-customization-rs/schema.graphql
+++ b/functions-payment-customization-rs/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -325,6 +346,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2936,6 +2962,127 @@ input DeprecatedOperation @oneOf {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 The input to set event-based payment terms.
 """
 input EventPaymentTerms {
@@ -4478,6 +4625,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4847,6 +5059,21 @@ enum PaymentTermsTriggerEvent {
 }
 
 """
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
+
+"""
 The goods and services that merchants offer to customers. Products can include details such as
 title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 Products can be organized by grouping them into a collection.
@@ -5210,6 +5437,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-payment-customization-rs/shopify.extension.toml.liquid
+++ b/functions-payment-customization-rs/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-payment-customization-wasm/schema.graphql
+++ b/functions-payment-customization-wasm/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -325,6 +346,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2936,6 +2962,127 @@ input DeprecatedOperation @oneOf {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 The input to set event-based payment terms.
 """
 input EventPaymentTerms {
@@ -4478,6 +4625,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4847,6 +5059,21 @@ enum PaymentTermsTriggerEvent {
 }
 
 """
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
+
+"""
 The goods and services that merchants offer to customers. Products can include details such as
 title, vendor, and custom data stored in [metafields](https://shopify.dev/docs/apps/build/custom-data).
 Products can be organized by grouping them into a collection.
@@ -5210,6 +5437,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-payment-customization-wasm/shopify.extension.toml.liquid
+++ b/functions-payment-customization-wasm/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-pickup-point-delivery-option-generators-js/schema.graphql
+++ b/functions-pickup-point-delivery-option-generators-js/schema.graphql
@@ -133,6 +133,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -165,6 +170,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -208,6 +218,12 @@ type Cart implements HasMetafields {
   ): Metafield
 
   """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
+
+  """
   The physical location where a retail order is created or completed.
   """
   retailLocation: Location
@@ -219,7 +235,7 @@ the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount for the customer to pay at checkout, excluding taxes and discounts.
+  The amount, before taxes and cart-level discounts, for the customer to pay.
   """
   subtotalAmount: MoneyV2!
 
@@ -263,6 +279,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -355,7 +376,7 @@ type CartLine {
   gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
   Cart line attributes are equivalent to the
-  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  [`line_item`](https://shopify.dev/docs/api/liquid/objects/line_item)
   object in Liquid.
   """
   attribute(
@@ -373,6 +394,11 @@ type CartLine {
   cost: CartLineCost!
 
   """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
+
+  """
   The ID of the cart line.
   """
   id: ID!
@@ -383,7 +409,8 @@ type CartLine {
   merchandise: Merchandise!
 
   """
-  The relationship between this line and its parent line, if any.
+  The [nested relationship](https://shopify.dev/docs/apps/build/product-merchandising/nested-cart-lines)
+  between this line and its parent line, if any.
   """
   parentRelationship: CartLineParentRelationship
 
@@ -412,7 +439,7 @@ type CartLineCost {
   amountPerQuantity: MoneyV2!
 
   """
-  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  The `compareAt` price of a single unit before any discounts are applied. This field is used to calculate and display
   savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
   is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
   `null` when the value is hidden from buyers.
@@ -2845,7 +2872,7 @@ type DeliverableCartLine {
   gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
   Cart line attributes are equivalent to the
-  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  [`line_item`](https://shopify.dev/docs/api/liquid/objects/line_item)
   object in Liquid.
   """
   attribute(
@@ -2904,6 +2931,127 @@ enum DeliveryMethod {
   Shipping.
   """
   SHIPPING
+}
+
+"""
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
 }
 
 """
@@ -4582,7 +4730,74 @@ input MetafieldOutput {
 }
 
 """
-A precise monetary value and its associated currency. For example, 12.99 USD.
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
+A precise monetary value and its associated currency. Combines a decimal amount
+with a three-letter currency code to express prices, costs, and other financial
+values throughout the API. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
@@ -4757,6 +4972,21 @@ input PickupPointDeliveryOption {
   """
   pickupPoint: PickupPoint!
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -5116,6 +5346,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-pickup-point-delivery-option-generators-rs/schema.graphql
+++ b/functions-pickup-point-delivery-option-generators-rs/schema.graphql
@@ -133,6 +133,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -165,6 +170,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -208,6 +218,12 @@ type Cart implements HasMetafields {
   ): Metafield
 
   """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
+
+  """
   The physical location where a retail order is created or completed.
   """
   retailLocation: Location
@@ -219,7 +235,7 @@ the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount for the customer to pay at checkout, excluding taxes and discounts.
+  The amount, before taxes and cart-level discounts, for the customer to pay.
   """
   subtotalAmount: MoneyV2!
 
@@ -263,6 +279,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -355,7 +376,7 @@ type CartLine {
   gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
   Cart line attributes are equivalent to the
-  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  [`line_item`](https://shopify.dev/docs/api/liquid/objects/line_item)
   object in Liquid.
   """
   attribute(
@@ -373,6 +394,11 @@ type CartLine {
   cost: CartLineCost!
 
   """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
+
+  """
   The ID of the cart line.
   """
   id: ID!
@@ -383,7 +409,8 @@ type CartLine {
   merchandise: Merchandise!
 
   """
-  The relationship between this line and its parent line, if any.
+  The [nested relationship](https://shopify.dev/docs/apps/build/product-merchandising/nested-cart-lines)
+  between this line and its parent line, if any.
   """
   parentRelationship: CartLineParentRelationship
 
@@ -412,7 +439,7 @@ type CartLineCost {
   amountPerQuantity: MoneyV2!
 
   """
-  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  The `compareAt` price of a single unit before any discounts are applied. This field is used to calculate and display
   savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
   is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
   `null` when the value is hidden from buyers.
@@ -2845,7 +2872,7 @@ type DeliverableCartLine {
   gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
   Cart line attributes are equivalent to the
-  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  [`line_item`](https://shopify.dev/docs/api/liquid/objects/line_item)
   object in Liquid.
   """
   attribute(
@@ -2904,6 +2931,127 @@ enum DeliveryMethod {
   Shipping.
   """
   SHIPPING
+}
+
+"""
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
 }
 
 """
@@ -4582,7 +4730,74 @@ input MetafieldOutput {
 }
 
 """
-A precise monetary value and its associated currency. For example, 12.99 USD.
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
+A precise monetary value and its associated currency. Combines a decimal amount
+with a three-letter currency code to express prices, costs, and other financial
+values throughout the API. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
@@ -4757,6 +4972,21 @@ input PickupPointDeliveryOption {
   """
   pickupPoint: PickupPoint!
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -5116,6 +5346,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-pickup-point-delivery-option-generators-wasm/schema.graphql
+++ b/functions-pickup-point-delivery-option-generators-wasm/schema.graphql
@@ -133,6 +133,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -165,6 +170,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -208,6 +218,12 @@ type Cart implements HasMetafields {
   ): Metafield
 
   """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
+
+  """
   The physical location where a retail order is created or completed.
   """
   retailLocation: Location
@@ -219,7 +235,7 @@ the subtotal before taxes and duties, the tax amount, and duty charges.
 """
 type CartCost {
   """
-  The amount for the customer to pay at checkout, excluding taxes and discounts.
+  The amount, before taxes and cart-level discounts, for the customer to pay.
   """
   subtotalAmount: MoneyV2!
 
@@ -263,6 +279,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -355,7 +376,7 @@ type CartLine {
   gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
   Cart line attributes are equivalent to the
-  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  [`line_item`](https://shopify.dev/docs/api/liquid/objects/line_item)
   object in Liquid.
   """
   attribute(
@@ -373,6 +394,11 @@ type CartLine {
   cost: CartLineCost!
 
   """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
+
+  """
   The ID of the cart line.
   """
   id: ID!
@@ -383,7 +409,8 @@ type CartLine {
   merchandise: Merchandise!
 
   """
-  The relationship between this line and its parent line, if any.
+  The [nested relationship](https://shopify.dev/docs/apps/build/product-merchandising/nested-cart-lines)
+  between this line and its parent line, if any.
   """
   parentRelationship: CartLineParentRelationship
 
@@ -412,7 +439,7 @@ type CartLineCost {
   amountPerQuantity: MoneyV2!
 
   """
-  The cost of a single unit before any discounts are applied. This field is used to calculate and display
+  The `compareAt` price of a single unit before any discounts are applied. This field is used to calculate and display
   savings for customers. For example, if a product's `compareAtAmountPerQuantity` is $25 and its current price
   is $20, then the customer sees a $5 discount. This value can change based on the buyer's identity and is
   `null` when the value is hidden from buyers.
@@ -2845,7 +2872,7 @@ type DeliverableCartLine {
   gift wrapping requests, or custom product details. Attributes are stored as key-value pairs.
 
   Cart line attributes are equivalent to the
-  [`line_item`](https://shopify.dev/docs/apps/build/purchase-options/subscriptions/selling-plans)
+  [`line_item`](https://shopify.dev/docs/api/liquid/objects/line_item)
   object in Liquid.
   """
   attribute(
@@ -2904,6 +2931,127 @@ enum DeliveryMethod {
   Shipping.
   """
   SHIPPING
+}
+
+"""
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
 }
 
 """
@@ -4582,7 +4730,74 @@ input MetafieldOutput {
 }
 
 """
-A precise monetary value and its associated currency. For example, 12.99 USD.
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
+A precise monetary value and its associated currency. Combines a decimal amount
+with a three-letter currency code to express prices, costs, and other financial
+values throughout the API. For example, 12.99 USD.
 """
 type MoneyV2 {
   """
@@ -4757,6 +4972,21 @@ input PickupPointDeliveryOption {
   """
   pickupPoint: PickupPoint!
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -5116,6 +5346,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-product-discounts-js/schema.graphql
+++ b/functions-product-discounts-js/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -325,6 +346,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2920,6 +2946,89 @@ input Discount {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
 The approach that determines how multiple discounts are evaluated and
 applied to a cart. You can apply all discounts with conditions that are met,
 apply a discount only to the first line item in a cart that meets conditions,
@@ -2949,6 +3058,44 @@ enum DiscountApplicationStrategy {
   Since $6 is more than $5, the 20% discount on the t-shirt is applied.
   """
   MAXIMUM
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
 }
 
 """
@@ -4502,6 +4649,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4557,6 +4769,21 @@ input Percentage {
   """
   value: Decimal!
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4922,6 +5149,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-product-discounts-js/shopify.extension.toml.liquid
+++ b/functions-product-discounts-js/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-product-discounts-rs/schema.graphql
+++ b/functions-product-discounts-rs/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -325,6 +346,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2920,6 +2946,89 @@ input Discount {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
 The approach that determines how multiple discounts are evaluated and
 applied to a cart. You can apply all discounts with conditions that are met,
 apply a discount only to the first line item in a cart that meets conditions,
@@ -2949,6 +3058,44 @@ enum DiscountApplicationStrategy {
   Since $6 is more than $5, the 20% discount on the t-shirt is applied.
   """
   MAXIMUM
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
 }
 
 """
@@ -4502,6 +4649,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4557,6 +4769,21 @@ input Percentage {
   """
   value: Decimal!
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4922,6 +5149,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-product-discounts-rs/shopify.extension.toml.liquid
+++ b/functions-product-discounts-rs/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-product-discounts-wasm/schema.graphql
+++ b/functions-product-discounts-wasm/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -325,6 +346,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2920,6 +2946,89 @@ input Discount {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
 The approach that determines how multiple discounts are evaluated and
 applied to a cart. You can apply all discounts with conditions that are met,
 apply a discount only to the first line item in a cart that meets conditions,
@@ -2949,6 +3058,44 @@ enum DiscountApplicationStrategy {
   Since $6 is more than $5, the 20% discount on the t-shirt is applied.
   """
   MAXIMUM
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
 }
 
 """
@@ -4502,6 +4649,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4557,6 +4769,21 @@ input Percentage {
   """
   value: Decimal!
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4922,6 +5149,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-product-discounts-wasm/shopify.extension.toml.liquid
+++ b/functions-product-discounts-wasm/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-shipping-discounts-js/schema.graphql
+++ b/functions-shipping-discounts-js/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -325,6 +346,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2925,6 +2951,127 @@ input Discount {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 A discount wrapper node.
 """
 type DiscountNode implements HasMetafields {
@@ -4451,6 +4598,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4506,6 +4718,21 @@ input Percentage {
   """
   value: Decimal!
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4849,6 +5076,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-shipping-discounts-js/shopify.extension.toml.liquid
+++ b/functions-shipping-discounts-js/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-shipping-discounts-rs/schema.graphql
+++ b/functions-shipping-discounts-rs/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -325,6 +346,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2925,6 +2951,127 @@ input Discount {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 A discount wrapper node.
 """
 type DiscountNode implements HasMetafields {
@@ -4451,6 +4598,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4506,6 +4718,21 @@ input Percentage {
   """
   value: Decimal!
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4849,6 +5076,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-shipping-discounts-rs/shopify.extension.toml.liquid
+++ b/functions-shipping-discounts-rs/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"

--- a/functions-shipping-discounts-wasm/schema.graphql
+++ b/functions-shipping-discounts-wasm/schema.graphql
@@ -87,6 +87,11 @@ type Cart implements HasMetafields {
   ): Attribute
 
   """
+  The billing address associated with the cart.
+  """
+  billingAddress: MailingAddress
+
+  """
   Information about the customer that's interacting with the cart. It includes details such as the
   customer's email and phone number, and the total amount of money the customer has spent in the store.
   This information helps personalize the checkout experience and ensures that accurate pricing and delivery options
@@ -119,6 +124,11 @@ type Cart implements HasMetafields {
   instead.
   """
   deliveryGroups: [CartDeliveryGroup!]!
+
+  """
+  The discounts that have been applied to the cart.
+  """
+  discountApplications: [DiscountApplication!]!
 
   """
   The items in a cart that the customer intends to purchase. A cart line is an entry in the
@@ -160,6 +170,12 @@ type Cart implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  A purchase order number associated with the cart, often used for B2B transactions
+  to reference the buyer's internal purchase order.
+  """
+  poNumber: String
 
   """
   The physical location where a retail order is created or completed.
@@ -217,6 +233,11 @@ type CartDeliveryGroup {
   can choose to have their orders shipped. Examples include express shipping or standard shipping.
   """
   deliveryOptions: [CartDeliveryOption!]!
+
+  """
+  The discounts that have been applied to the delivery group.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The type of merchandise in the delivery group.
@@ -325,6 +346,11 @@ type CartLine {
   the same t-shirt to their cart, then each size is represented as a separate cart line.
   """
   cost: CartLineCost!
+
+  """
+  The discounts that have been applied to the cart line.
+  """
+  discountAllocations: [DiscountAllocation!]!
 
   """
   The ID of the cart line.
@@ -2925,6 +2951,127 @@ input Discount {
 }
 
 """
+The discount application and the amount applied.
+"""
+type DiscountAllocation {
+  """
+  The discount that was applied.
+  """
+  discountApplication: DiscountApplication!
+
+  """
+  The amount that was discounted.
+  """
+  discountedAmount: MoneyV2!
+}
+
+"""
+Discount that has been applied to the cart.
+"""
+type DiscountApplication implements HasMetafields {
+  """
+  The method by which the discount's value is allocated to its entitled items.
+  """
+  allocationMethod: DiscountApplicationAllocationMethod!
+
+  """
+  A [custom field](https://shopify.dev/docs/apps/build/custom-data) that stores additional information
+  about a Shopify resource, such as products, orders, and
+  [many more](https://shopify.dev/docs/api/admin-graphql/latest/enums/MetafieldOwnerType).
+  Using [metafields with Shopify Functions](https://shopify.dev/docs/apps/build/functions/input-output/metafields-for-input-queries)
+  enables you to customize the checkout experience.
+  """
+  metafield(
+    """
+    The unique identifier for the metafield within its namespace. A metafield is composed of a
+    namespace and a key, in the format `namespace.key`.
+    """
+    key: String!
+
+    """
+    A category that organizes a group of metafields. Namespaces are used to prevent naming conflicts
+    between different apps or different parts of the same app. If omitted, then the
+    [app-reserved namespace](https://shopify.dev/docs/apps/build/custom-data/ownership)
+    is used.
+    """
+    namespace: String
+  ): Metafield
+
+  """
+  The lines on the cart targeted by the discount.
+  """
+  targetSelection: DiscountApplicationTargetSelection!
+
+  """
+  The type of line (i.e. line item or shipping line) on a cart that the discount is applicable towards.
+  """
+  targetType: DiscountApplicationTarget!
+
+  """
+  The total allocated amount of the discount across all items.
+  """
+  totalAllocatedAmount: MoneyV2!
+
+  """
+  The value of the discount.
+  """
+  value: PricingValue!
+}
+
+"""
+The method by which the discount's value is allocated onto its entitled lines.
+"""
+enum DiscountApplicationAllocationMethod {
+  """
+  The value is spread across all entitled lines.
+  """
+  ACROSS
+
+  """
+  The value is applied onto every entitled line.
+  """
+  EACH
+}
+
+"""
+The type of line on an order that the discount is applicable towards.
+"""
+enum DiscountApplicationTarget {
+  """
+  The discount applies onto line items.
+  """
+  LINE_ITEM
+
+  """
+  The discount applies onto shipping lines.
+  """
+  SHIPPING_LINE
+}
+
+"""
+The lines on the order to which the discount is applied, of the type defined by
+the discount application's `targetType`. For example, the value `ENTITLED`, combined with a `targetType` of
+`LINE_ITEM`, applies the discount on all line items that are entitled to the discount.
+The value `ALL`, combined with a `targetType` of `SHIPPING_LINE`, applies the discount on all shipping lines.
+"""
+enum DiscountApplicationTargetSelection {
+  """
+  The discount is allocated onto all the lines.
+  """
+  ALL
+
+  """
+  The discount is allocated onto only the lines that it's entitled for.
+  """
+  ENTITLED
+
+  """
+  The discount is allocated onto explicitly chosen lines.
+  """
+  EXPLICIT
+}
+
+"""
 A discount wrapper node.
 """
 type DiscountNode implements HasMetafields {
@@ -4451,6 +4598,71 @@ type Metafield {
 }
 
 """
+An instance of custom structured data defined by a MetaobjectDefinition.
+"""
+type Metaobject {
+  """
+  The field for an object key, or null if the key has no field definition.
+  """
+  field(
+    """
+    The metaobject key to access.
+    """
+    key: String!
+  ): MetaobjectField
+
+  """
+  The unique handle of the metaobject, useful as a custom ID.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject.
+  """
+  type: String!
+}
+
+"""
+Provides a field definition and the data value assigned to it.
+"""
+type MetaobjectField {
+  """
+  The assigned field value in JSON format.
+  """
+  jsonValue: JSON
+
+  """
+  The object key of this field.
+  """
+  key: String!
+
+  """
+  The type of the field.
+  """
+  type: String!
+
+  """
+  The assigned field value, always stored as a string regardless of the field type.
+  """
+  value: String
+}
+
+"""
+The input fields for retrieving a metaobject by handle.
+"""
+input MetaobjectHandleInput {
+  """
+  The handle of the metaobject to retrieve.
+  """
+  handle: String!
+
+  """
+  The type of the metaobject. Must match an existing metaobject definition type.
+  """
+  type: String!
+}
+
+"""
 A precise monetary value and its associated currency. Combines a decimal amount
 with a three-letter currency code to express prices, costs, and other financial
 values throughout the API. For example, 12.99 USD.
@@ -4506,6 +4718,21 @@ input Percentage {
   """
   value: Decimal!
 }
+
+"""
+The percentage value of a discount.
+"""
+type PricingPercentageValue {
+  """
+  The percentage value of the discount.
+  """
+  value: Decimal!
+}
+
+"""
+The price value for a discount application.
+"""
+union PricingValue = MoneyV2 | PricingPercentageValue
 
 """
 The goods and services that merchants offer to customers. Products can include details such as
@@ -4849,6 +5076,22 @@ type Shop implements HasMetafields {
     """
     namespace: String
   ): Metafield
+
+  """
+  Fetch a specific Metaobject by one of its unique identifiers. Only app-owned
+  metaobjects with the $app reserved prefix are accessible to functions.
+  """
+  metaobject(
+    """
+    The handle and type of the metaobject.
+    """
+    handle: MetaobjectHandleInput
+
+    """
+    The ID of the metaobject.
+    """
+    id: ID
+  ): Metaobject
 }
 
 """

--- a/functions-shipping-discounts-wasm/shopify.extension.toml.liquid
+++ b/functions-shipping-discounts-wasm/shopify.extension.toml.liquid
@@ -1,4 +1,4 @@
-api_version = "2026-01"
+api_version = "2026-04"
 
 [[extensions]]
 name = "t:name"


### PR DESCRIPTION
### Background

Update all function extension templates from the 2026-01 API version to 2026-04. This follows the same pattern as the previous 2026-01 update (PR #373).

### Solution

- Updated `api_version` from `"2026-01"` to `"2026-04"` in all 30 function `shopify.extension.toml.liquid` files (js/rs/wasm variants)
- Regenerated `schema.graphql` files for all 13 function types (39 files) using `shopify app function schema`

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages