### PR TITLE
Reference tool schema in admin-tools tools.json

### DIFF
--- a/admin-tools/tools.json
+++ b/admin-tools/tools.json
@@ -1,5 +1,6 @@
 [
   {
+    "$schema": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/tool.json",
     "name": "search",
     "description": "Search for data from this app's external data source",
     "inputSchema": {


### PR DESCRIPTION
Add `$schema` field to each tool object in `admin-tools/tools.json` so editors/tooling can validate against the Shopify tool schema.

Requested by Trish Ta <trish.ta@shopify.com>

