### PR TITLE
Group Sidekick extension templates under a 'Sidekick' group

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -401,9 +401,9 @@
   },
   {
     "identifier": "app_tools",
-    "name": "Admin app tools",
+    "name": "App data",
     "defaultName": "app-tools",
-    "group": "UI extensions",
+    "group": "Sidekick",
     "supportLinks": [],
     "url": "https://github.com/Shopify/extensions-templates",
     "type": "ui_extension",
@@ -2104,9 +2104,9 @@
   },
   {
     "identifier": "admin_intent_link",
-    "name": "Admin intent link",
+    "name": "App actions",
     "defaultName": "admin-intent-link",
-    "group": "Links",
+    "group": "Sidekick",
     "supportLinks": [],
     "url": "https://github.com/Shopify/extensions-templates",
     "type": "admin_link",


### PR DESCRIPTION
Both the `admin_intent_link` and `app_tools` extension templates are surfaced on shopify.dev under the Sidekick section, but in `shopify app generate extension` they were split across separate CLI groups ("Links" and "UI extensions" respectively). This didn't match the docs and made the two Sidekick templates harder to find.

Reassign both templates to a new 'Sidekick' group so the CLI picker shows them together, matching the shopify.dev grouping.

Refs: https://github.com/shop/issues-admin-extensibility/issues/2431 Requested by Adam Barrus <adam.barrus@shopify.com> Slack thread: https://shopify.slack.com/archives/C0AJ1DFDP7T/p1776726773827859

### Testing instructions

```
shopify app generate extension --clone-url https://github.com/Shopify/extensions-templates#river-group-sidekick-extension-templates
```

Expected: a new Sidekick group appears with both Admin intent link and Admin app tools under it.

### Background

- @jenstanicak's note in the [issue](https://vault.shopify.io/gsd/reviews/67579#gsd_reviews_feedback_403681) ("types ending in _link get grouped under Links") isn't how the current CLI works — there's no suffix rule in code. The group is whatever `templates.json` says. So this templates-only change is sufficient; no CLI code changes needed.
- Sidekick will land between UI extensions and Functions in the picker (section order follows first-appearance in the JSON). If product wants it elsewhere, moving the two objects within `templates.json` is the knob.

### Solution

(Describe your solution, why this approach was chosen, and what the alternatives/impacts may be)

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
