### PR TITLE
Add app home template

### DIFF
--- a/app-home/README.md.liquid
+++ b/app-home/README.md.liquid
@@ -1,0 +1,48 @@
+# {{ name }}
+
+A simple app home extension that demonstrates:
+- Basic UI with Shopify's Remote DOM components
+- Simple client-side routing (list view / add view)
+- KV storage for persisting data
+
+## Features
+
+This extension creates a FAQ manager directly in your app's home page:
+
+- **Add FAQs**: Create question and answer pairs
+- **List FAQs**: View all stored FAQs
+- **Delete FAQs**: Remove FAQs you no longer need
+- **Persist data**: Uses `shopify.storage` API to store data
+
+## Storage API
+
+This extension uses Shopify's [Storage API](https://shopify.dev/docs/api/admin-extensions/2026-04-rc/target-apis/core-apis/standard-api#standardapi-propertydetail-storage) to persist FAQ data:
+
+- **App-scoped**: Data is isolated to your app
+- **Simple**: No GraphQL queries needed - `shopify.storage.getItem()` / `shopify.storage.setItem()`
+- **Persistent**: Data survives page reloads
+- **Extension-specific**: Each extension instance has its own storage
+
+## Routing
+
+The extension demonstrates simple view-based routing:
+- `list` - Shows all FAQs (default view)
+- `add` - Form to create a new FAQ
+
+Routing is handled with React state (`useState`), showing how to build multi-view experiences without additional libraries.
+
+## Development
+
+```bash
+# Start dev server
+npm run dev
+
+# Build for production
+npm run build
+```
+
+## Learn More
+
+- [App Home documentation](https://shopify.dev/docs/api/app-home)
+- [Storage API](https://shopify.dev/docs/api/admin-extensions/2026-04-rc/target-apis/core-apis/standard-api#standardapi-propertydetail-storage)
+- [Remote DOM Components](https://shopify.dev/docs/api/app-bridge-library/components)

--- a/app-home/locales/en.default.json.liquid
+++ b/app-home/locales/en.default.json.liquid
@@ -1,0 +1,4 @@
+{
+  "name": "{{ name }}",
+  "welcome": "Welcome to the {% raw %}{{target}}{% endraw %} extension!"
+}

--- a/app-home/locales/fr.json.liquid
+++ b/app-home/locales/fr.json.liquid
@@ -1,0 +1,4 @@
+{
+  "name": "{{ name }}",
+  "welcome": "Bienvenue dans l'extension {% raw %}{{target}}{% endraw %}!"
+}

--- a/app-home/package.json.liquid
+++ b/app-home/package.json.liquid
@@ -1,0 +1,11 @@
+{
+  "name": "{{ handle }}",
+  "private": true,
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "scripts": {},
+  "dependencies": {
+    "preact": "^10.10.x",
+    "@shopify/ui-extensions": "0.0.0-snapshot-20260423130041"
+  }
+}

--- a/app-home/package.json.liquid
+++ b/app-home/package.json.liquid
@@ -6,6 +6,6 @@
   "scripts": {},
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "0.0.0-snapshot-20260423130041"
+    "@shopify/ui-extensions": "rc"
   }
 }

--- a/app-home/shopify.extension.toml.liquid
+++ b/app-home/shopify.extension.toml.liquid
@@ -1,0 +1,17 @@
+api_version = "2026-04"
+
+[[extensions]]
+# Change the merchant-facing name of the extension in locales/en.default.json
+name = "t:name"
+handle = "{{ handle }}"
+type = "ui_extension"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+
+# Only 1 target can be specified for each app-home extension
+[[extensions.targeting]]
+module = "./src/AppHome.{{ srcFileExtension }}"
+target = "admin.app.home.render"
+
+[access_scopes]
+# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
+scopes = ""

--- a/app-home/src/AppHome.liquid
+++ b/app-home/src/AppHome.liquid
@@ -1,0 +1,218 @@
+import {render} from 'preact';
+import {useState, useEffect} from 'preact/hooks';
+
+export default async () => {
+  render(<App />, document.body);
+};
+
+function App() {
+  const [currentView, setCurrentView] = useState('list');
+  const [faqs, setFaqs] = useState([]);
+  const [newQuestion, setNewQuestion] = useState('');
+  const [newAnswer, setNewAnswer] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  // Load FAQs from storage on mount
+  useEffect(() => {
+    loadFAQs();
+  }, []);
+
+  async function loadFAQs() {
+    setLoading(true);
+    try {
+      const stored = await shopify.storage.getItem('faqs');
+      setFaqs(stored ? JSON.parse(stored) : []);
+    } catch (err) {
+      console.error('Failed to load FAQs:', err);
+      setFaqs([]);
+    }
+    setLoading(false);
+  }
+
+  async function saveFAQ() {
+    if (!newQuestion.trim() || !newAnswer.trim()) {
+      return;
+    }
+
+    const newFaq = {
+      id: Date.now(),
+      question: newQuestion,
+      answer: newAnswer,
+    };
+
+    const updatedFaqs = [...faqs, newFaq];
+
+    try {
+      await shopify.storage.setItem('faqs', JSON.stringify(updatedFaqs));
+      setFaqs(updatedFaqs);
+      setNewQuestion('');
+      setNewAnswer('');
+      setCurrentView('list');
+    } catch (err) {
+      console.error('Failed to save FAQ:', err);
+    }
+  }
+
+  async function deleteFAQ(id) {
+    const updatedFaqs = faqs.filter(faq => faq.id !== id);
+    try {
+      await shopify.storage.setItem('faqs', JSON.stringify(updatedFaqs));
+      setFaqs(updatedFaqs);
+    } catch (err) {
+      console.error('Failed to delete FAQ:', err);
+    }
+  }
+
+  // Add FAQ view
+  if (currentView === 'add') {
+    return (
+      <s-page heading="Add New FAQ">
+        <s-button
+          slot="secondary-actions"
+          onclick={() => setCurrentView('list')}
+        >
+          Cancel
+        </s-button>
+        <s-button
+          slot="primary-action"
+          variant="primary"
+          onclick={saveFAQ}
+        >
+          Save FAQ
+        </s-button>
+
+        <s-section>
+          <s-stack gap="base">
+            <s-text-field
+              label="Question"
+              value={newQuestion}
+              oninput={(e) => setNewQuestion(e.target.value)}
+            />
+
+            <s-text-area
+              label="Answer"
+              value={newAnswer}
+              oninput={(e) => setNewAnswer(e.target.value)}
+              rows={4}
+            />
+          </s-stack>
+        </s-section>
+      </s-page>
+    );
+  }
+
+  // List view (default)
+  const hasFaqs = faqs.length > 0;
+
+  return (
+    <s-page heading="FAQ Manager">
+      <s-button
+        slot="primary-action"
+        variant="primary"
+        onclick={() => setCurrentView('add')}
+      >
+        Add FAQ
+      </s-button>
+
+      <s-section slot="aside" heading="About this template">
+        <s-paragraph>
+          <s-text>{shopify.i18n.translate('welcome', {target: shopify.extension.target})}</s-text>
+        </s-paragraph>
+        <s-paragraph>
+          <s-text>This extension demonstrates:</s-text>
+        </s-paragraph>
+        <s-paragraph>
+          <s-text>• Simple view routing</s-text>
+        </s-paragraph>
+        <s-paragraph>
+          <s-text>• </s-text>
+          <s-link
+            href="https://shopify.dev/docs/api/admin-extensions/2026-04-rc/target-apis/core-apis/standard-api#standardapi-propertydetail-storage"
+            target="_blank"
+          >
+            Storage API
+          </s-link>
+          <s-text> for persistence</s-text>
+        </s-paragraph>
+        <s-paragraph>
+          <s-text>• </s-text>
+          <s-link
+            href="https://shopify.dev/docs/api/app-home/using-polaris-components"
+            target="_blank"
+          >
+            Polaris components
+          </s-link>
+        </s-paragraph>
+      </s-section>
+
+      {loading && (
+        <s-section>
+          <s-paragraph>Loading...</s-paragraph>
+        </s-section>
+      )}
+
+      {!loading && !hasFaqs && (
+        <s-section accessibilityLabel="Empty state section">
+          <s-grid gap="base" justifyItems="center" paddingBlock="large-400">
+            <s-box maxInlineSize="200px" maxBlockSize="200px">
+              <s-image
+                aspectRatio="1/0.5"
+                src="https://cdn.shopify.com/static/images/polaris/patterns/callout.png"
+                alt="Illustration of FAQ creation"
+              />
+            </s-box>
+            <s-grid justifyItems="center" maxInlineSize="450px" gap="base">
+              <s-stack alignItems="center">
+                <s-heading>Start creating FAQs</s-heading>
+                <s-paragraph>
+                  Create frequently asked questions using the Storage API.
+                </s-paragraph>
+              </s-stack>
+              <s-button-group>
+                <s-button
+                  accessibilityLabel="Add a new FAQ"
+                  onclick={() => setCurrentView('add')}
+                >
+                  Add FAQ
+                </s-button>
+              </s-button-group>
+            </s-grid>
+          </s-grid>
+        </s-section>
+      )}
+
+      {!loading && hasFaqs && (
+        <s-section padding="none" accessibilityLabel="FAQs table section">
+          <s-table>
+            <s-table-header-row>
+              <s-table-header listSlot="primary">Question</s-table-header>
+              <s-table-header>Answer</s-table-header>
+              <s-table-header>Actions</s-table-header>
+            </s-table-header-row>
+            <s-table-body>
+              {faqs.map((faq) => (
+                <s-table-row key={faq.id}>
+                  <s-table-cell>
+                    <s-text weight="bold">{faq.question}</s-text>
+                  </s-table-cell>
+                  <s-table-cell>
+                    <s-text>{faq.answer}</s-text>
+                  </s-table-cell>
+                  <s-table-cell>
+                    <s-button
+                      onclick={() => deleteFAQ(faq.id)}
+                      variant="plain"
+                      tone="critical"
+                    >
+                      Delete
+                    </s-button>
+                  </s-table-cell>
+                </s-table-row>
+              ))}
+            </s-table-body>
+          </s-table>
+        </s-section>
+      )}
+    </s-page>
+  );
+}

--- a/app-home/tsconfig.json.liquid
+++ b/app-home/tsconfig.json.liquid
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "target": "ES2020",
+    "checkJs": true,
+    "allowJs": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  }
+}

--- a/templates.json
+++ b/templates.json
@@ -2162,6 +2162,8 @@
         "path": "app-home"
       }
     ],
-    "minimumCliVersion": "3.90.0"
+    "organizationExpFlags": [
+      "d867a776"
+    ]
   }
 ]

--- a/templates.json
+++ b/templates.json
@@ -2143,5 +2143,25 @@
       "99125067"
     ],
     "minimumCliVersion": "3.94.0"
+  },
+  {
+    "identifier": "app_home",
+    "name": "App home",
+    "defaultName": "app-home",
+    "group": "UI extensions",
+    "supportLinks": [
+      "https://shopify.dev/docs/api/app-home"
+    ],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Preact",
+        "value": "preact",
+        "path": "app-home"
+      }
+    ],
+    "minimumCliVersion": "3.90.0"
   }
 ]


### PR DESCRIPTION
### Background
Adds a template for the app-home extension.
Closes https://github.com/shop/issues-admin-extensibility/issues/2472

### Solution

Based on work on this branch in our demo app: https://github.com/shopify-playground/ui-ext-hosted-jam/pull/4
As well as the original hosted app template: https://github.com/Shopify/shopify-app-template-extension-only

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages


### 🎩 

Ensure you have the `f_hosted_app_org` flag enabled for your organization. And run `shopify app init` (*without* the HOSTED_APPS env var. This will give you a "classic" extension-only app).

```
SHOPIFY_CLI_APP_TEMPLATES_JSON_PATH=/path/to/this/repo/templates.json \
  shopify app generate extension \
  --clone-url https://github.com/Shopify/extensions-templates#cx-create-app-home-template
```

Note: you may get an issue about npm not being allowed. I had to pass my PATH with an explicit npm path from nix to get it to work, e.g. `PATH="/nix/store/0x0x0x0x0x-node-22.22.0/bin:$PATH" SHOPIFY_CLI_APP_TEMPLATES_JSON_PATH=...`
