### PR TITLE
add version header to schema files

### DIFF
--- a/functions-cart-checkout-validation-js/schema.graphql
+++ b/functions-cart-checkout-validation-js/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-cart-checkout-validation-rs/schema.graphql
+++ b/functions-cart-checkout-validation-rs/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-cart-checkout-validation-wasm/schema.graphql
+++ b/functions-cart-checkout-validation-wasm/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-cart-transform-js/schema.graphql
+++ b/functions-cart-transform-js/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-cart-transform-rs/schema.graphql
+++ b/functions-cart-transform-rs/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-cart-transform-wasm/schema.graphql
+++ b/functions-cart-transform-wasm/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-delivery-customization-js/schema.graphql
+++ b/functions-delivery-customization-js/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-delivery-customization-rs/schema.graphql
+++ b/functions-delivery-customization-rs/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-delivery-customization-wasm/schema.graphql
+++ b/functions-delivery-customization-wasm/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-discount-js/schema.graphql
+++ b/functions-discount-js/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-discount-rs/schema.graphql
+++ b/functions-discount-rs/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-discount-wasm/schema.graphql
+++ b/functions-discount-wasm/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-discounts-allocator-js/schema.graphql
+++ b/functions-discounts-allocator-js/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: unstable
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-discounts-allocator-rs/schema.graphql
+++ b/functions-discounts-allocator-rs/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: unstable
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-discounts-allocator-wasm/schema.graphql
+++ b/functions-discounts-allocator-wasm/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: unstable
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-fulfillment-constraints-js/schema.graphql
+++ b/functions-fulfillment-constraints-js/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-fulfillment-constraints-rs/schema.graphql
+++ b/functions-fulfillment-constraints-rs/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-fulfillment-constraints-wasm/schema.graphql
+++ b/functions-fulfillment-constraints-wasm/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-local-pickup-delivery-option-generators-js/schema.graphql
+++ b/functions-local-pickup-delivery-option-generators-js/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: unstable
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-local-pickup-delivery-option-generators-rs/schema.graphql
+++ b/functions-local-pickup-delivery-option-generators-rs/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: unstable
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-local-pickup-delivery-option-generators-wasm/schema.graphql
+++ b/functions-local-pickup-delivery-option-generators-wasm/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: unstable
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-location-rules-js/schema.graphql
+++ b/functions-location-rules-js/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-location-rules-rs/schema.graphql
+++ b/functions-location-rules-rs/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-location-rules-wasm/schema.graphql
+++ b/functions-location-rules-wasm/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-order-discounts-js/schema.graphql
+++ b/functions-order-discounts-js/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-order-discounts-rs/schema.graphql
+++ b/functions-order-discounts-rs/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-order-discounts-wasm/schema.graphql
+++ b/functions-order-discounts-wasm/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-payment-customization-js/schema.graphql
+++ b/functions-payment-customization-js/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-payment-customization-rs/schema.graphql
+++ b/functions-payment-customization-rs/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-payment-customization-wasm/schema.graphql
+++ b/functions-payment-customization-wasm/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-pickup-point-delivery-option-generators-js/schema.graphql
+++ b/functions-pickup-point-delivery-option-generators-js/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: unstable
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-pickup-point-delivery-option-generators-rs/schema.graphql
+++ b/functions-pickup-point-delivery-option-generators-rs/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: unstable
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-pickup-point-delivery-option-generators-wasm/schema.graphql
+++ b/functions-pickup-point-delivery-option-generators-wasm/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: unstable
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-product-discounts-js/schema.graphql
+++ b/functions-product-discounts-js/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-product-discounts-rs/schema.graphql
+++ b/functions-product-discounts-rs/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-product-discounts-wasm/schema.graphql
+++ b/functions-product-discounts-wasm/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-shipping-discounts-js/schema.graphql
+++ b/functions-shipping-discounts-js/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-shipping-discounts-rs/schema.graphql
+++ b/functions-shipping-discounts-rs/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot

--- a/functions-shipping-discounts-wasm/schema.graphql
+++ b/functions-shipping-discounts-wasm/schema.graphql
@@ -1,3 +1,5 @@
+# api_version: 2026-04
+
 schema {
   query: Input
   mutation: MutationRoot


### PR DESCRIPTION
### Background

Part of https://github.com/shop/issues-shopifyvm/issues/945
Follow up to https://github.com/Shopify/cli/pull/7480


### Solution

Adds the version header to the schema files, which enables the CLI to determine if the schema/toml version got out of sync. The CLI will auto populate this header, and this PR just covers the initial generate.

### Tophat

```
shopify app generate extension --clone-url=https://github.com/Shopify/extensions-templates#lopert.add-version-header-comment
```

### Checklist

- [x] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
