### PR TITLE
Remove organizationExpFlags from app_data template

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -415,9 +415,6 @@
         "path": "app-data"
       }
     ],
-    "organizationExpFlags": [
-      "d7c1b4ad"
-    ],
     "minimumCliVersion": "3.90.0"
   },
   {


### PR DESCRIPTION
## Summary

- Drop the `organizationExpFlags: ["d7c1b4ad"]` block from the `app_data` template in `templates.json`.
- The flag handle is `f_enable_cli_admin_app_tools_data_extension_template` (full client handle `f_d7c1b4ad66e69099cd8b5233b0144dec`).

## Why

- ExP says `state: released` with a 100% default rollout — every org already gets `true`, so removing the gate is a behavioural no-op.
- Public Sidekick docs describe the template without any "beta" / "early access" / "request access" wording.
- An auto-generated resiliency tracker is open: shop/issues#35000 (already extended once, expiring 2026-05-20). I'm the flag owner.
- The matching flag-definition deletion in `shop/world` and the ExP archive will follow in separate steps.

## Test plan

- [x] `jq . templates.json` parses cleanly after the edit.
- [ ] After merge, confirm the regenerated `Shopify/static-cdn-assets/static-24h/cli/extensions/templates.json` no longer contains `"d7c1b4ad"`.
- [ ] After merge, run `shopify app generate extension --template app_data` from an org *without* the manual flag assignment and confirm the template scaffolds.

## Out of scope

The sibling `f_enable_cli_admin_app_intent_extension_template` (hash `99125067`) gates the `app_intent` template and is **not** ready for cleanup — intents rollout is still partner-org-scoped.

Refs: shop/issues-admin-extensibility#2561
Refs: shop/issues#35000

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes shop/issues#35000