### PR TITLE
add minimum cli version for app home extension template

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -2161,6 +2161,7 @@
     ],
     "organizationExpFlags": [
       "d867a776"
-    ]
+    ],
+    "minimumCliVersion": "4.0.0"
   }
 ]


### PR DESCRIPTION
### Background

closes https://github.com/Shopify/extensions-templates/pull/406
instead of removing static assets from templates, we are opting to add a minimumCliVersion to this template.  

 Adds minimumCliVersion: "4.0.0" to the app home extension template entry.

CLI 4.0.0 (released 2026-05-21) is the first version that includes all the static asset deployment and dev server fixes needed for app home extensions to work correctly. The critical dependency is Shopify/cli#7502 (f9da828) — a fix for the dev server registering static assets at the wrong path, which broke relative src references (e.g. src='./cat.png') during `shopify app dev`.
 

 Confirmed f9da828 is included in 4.0.0 but not in the previous release (3.94.3):

   `$ git merge-base --is-ancestor f9da828fd4 4.0.0 && echo "included" || echo "NOT included"`
   `included`

   `$ git merge-base --is-ancestor f9da828fd4 3.94.3 && echo "included" || echo "NOT included"`
   `NOT included`
