### PR TITLE
Propagate app home save failures

### DIFF
--- a/app-home/src/AppHome.liquid
+++ b/app-home/src/AppHome.liquid
@@ -61,6 +61,7 @@ function App() {
       setCurrentView('list');
     } catch (err) {
       console.error('Failed to save FAQ:', err);
+      throw err;
     }
   }
 


### PR DESCRIPTION
Port follow-up from Shopify/shopify-app-template-extension-only#34.

When the app-home FAQ form save fails, rethrow the storage error after logging it so the submit promise passed to `event.waitUntil` rejects and the host can be notified.