### PR TITLE
Add admin.abandoned-checkout-index.action.link target

### DIFF
--- a/admin-link/README.md.liquid
+++ b/admin-link/README.md.liquid
@@ -4,7 +4,8 @@ When configuring your Admin Link extensions, you can specify various targeting o
 
 ### Valid Extension Targets
 
-- **Abandoned Checkout Details Page**
+- **Abandoned Checkout Index and Detail Pages**
+  - `admin.abandoned-checkout-index.action.link`
   - `admin.abandoned-checkout-details.action.link`
 
 - **Collection Index and Detail Pages**

--- a/admin-link/shopify.extension.toml.liquid
+++ b/admin-link/shopify.extension.toml.liquid
@@ -20,7 +20,8 @@ url = "/"
 
 # Valid Extension Targets
 #
-# Abandoned Checkout Details Page
+# Abandoned Checkout Index and Detail Pages
+#  - admin.abandoned-checkout-index.action.link
 #  - admin.abandoned-checkout-details.action.link
 #
 # Collection Index and Detail Pages


### PR DESCRIPTION
### Background

Resolves https://github.com/shop/issues-admin-mobile/issues/5059

Adds support for the Abandoned Checkout Index page as a valid Admin Link extension target. The backend target was added in https://github.com/shop/world/pull/751905, and the corresponding UI extensions library entry is in https://github.com/Shopify/ui-extensions/pull/4491.

### Solution

- Add `admin.abandoned-checkout-index.action.link` alongside the existing `admin.abandoned-checkout-details.action.link` in both `admin-link/shopify.extension.toml.liquid` and `admin-link/README.md.liquid`.
- Rename the section from "Abandoned Checkout Details Page" to "Abandoned Checkout Index and Detail Pages" to reflect both available targets.

### Tophat

```
shopify app generate extension --clone-url=https://github.com/Shopify/extensions-templates#add-abandoned-checkout-index-link-target --template=admin_link
```

Then configure the generated extension with `target = "admin.abandoned-checkout-index.action.link"` and confirm the link appears on the Abandoned Checkout index page in the Shopify Admin.

### Checklist

- [ ] I have :tophat:'d these changes
- [ ] I have squashed my commits into chunks of work with meaningful commit messages
