### PR TITLE
Remove hosted app home org flag

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -113,9 +113,6 @@
         "path": "app-home"
       }
     ],
-    "organizationExpFlags": [
-      "d867a776"
-    ],
     "minimumCliVersion": "4.1.0"
   },
   {


### PR DESCRIPTION
### Background

Post-release cleanup of the `f_hosted_app_org` ExP flag — see shop/issues-admin-extensibility#2614 and https://experiments.shopify.io/flags/22132. Same shape as the recent `app_data` cleanup in #405.

### Solution

Remove the `f_hosted_app_org` (`d867a776`) `organizationExpFlags` gate from the `app_home` extension template so the CLI no longer needs to call Verdict for it.

