### PR TITLE
Add POS background extension template

### DIFF
--- a/pos-background/README.md
+++ b/pos-background/README.md
@@ -1,0 +1,8 @@
+# POS background extension
+
+Scaffold for a non-visual POS background extension targeting `pos.app.ready.data`.
+
+The background target runs for the full POS session and observes events via
+`shopify.addEventListener()`. It does not render UI. See the example handlers in
+`src/background-extension.{js,ts}` for `transactioncomplete`,
+`cashtrackingsessionstart`, and `cashtrackingsessioncomplete`.

--- a/pos-background/package.json.liquid
+++ b/pos-background/package.json.liquid
@@ -1,0 +1,9 @@
+{
+  "name": "{{ handle }}",
+  "private": true,
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "@shopify/ui-extensions": "2026.7.x"
+  }
+}

--- a/pos-background/shopify.extension.toml.liquid
+++ b/pos-background/shopify.extension.toml.liquid
@@ -1,0 +1,12 @@
+api_version = "2026-07"
+
+[[extensions]]
+type = "ui_extension"
+name = "{{ name }}"
+{% if uid %}uid = "{{ uid }}"{% endif %}
+handle = "{{ handle }}"
+description = "A {{ flavor }} POS background extension"
+
+[[extensions.targeting]]
+module = "./src/background-extension.{{ srcFileExtension }}"
+target = "pos.app.ready.data"

--- a/pos-background/src/background-extension.liquid
+++ b/pos-background/src/background-extension.liquid
@@ -9,38 +9,28 @@ import type { Api } from '@shopify/ui-extensions/pos.app.ready.data';
 {% endif %}
 
 export default ({% if flavor contains "typescript" %}api: Api{% else %}_api{% endif %}) => {
-  console.log('background extension started');
-
-  shopify.addEventListener(
-    POS_EVENT_NAMES.TRANSACTION_COMPLETE,
-    (event{% if flavor contains "typescript" %}: TransactionCompleteEvent{% endif %}) => {
-      try {
+  try {
+    shopify.addEventListener(
+      POS_EVENT_NAMES.TRANSACTION_COMPLETE,
+      (event{% if flavor contains "typescript" %}: TransactionCompleteEvent{% endif %}) => {
         console.log('transaction complete', event);
-      } catch (error) {
-        console.error('transaction complete handler failed', error);
-      }
-    },
-  );
+      },
+    );
 
-  shopify.addEventListener(
-    POS_EVENT_NAMES.CASH_TRACKING_SESSION_START,
-    (event{% if flavor contains "typescript" %}: CashTrackingSessionStartEvent{% endif %}) => {
-      try {
+    shopify.addEventListener(
+      POS_EVENT_NAMES.CASH_TRACKING_SESSION_START,
+      (event{% if flavor contains "typescript" %}: CashTrackingSessionStartEvent{% endif %}) => {
         console.log('cash tracking session start', event);
-      } catch (error) {
-        console.error('cash tracking session start handler failed', error);
-      }
-    },
-  );
+      },
+    );
 
-  shopify.addEventListener(
-    POS_EVENT_NAMES.CASH_TRACKING_SESSION_COMPLETE,
-    (event{% if flavor contains "typescript" %}: CashTrackingSessionCompleteEvent{% endif %}) => {
-      try {
+    shopify.addEventListener(
+      POS_EVENT_NAMES.CASH_TRACKING_SESSION_COMPLETE,
+      (event{% if flavor contains "typescript" %}: CashTrackingSessionCompleteEvent{% endif %}) => {
         console.log('cash tracking session complete', event);
-      } catch (error) {
-        console.error('cash tracking session complete handler failed', error);
-      }
-    },
-  );
+      },
+    );
+  } catch (error) {
+    console.error('failed to register background extension listeners', error);
+  }
 };

--- a/pos-background/src/background-extension.liquid
+++ b/pos-background/src/background-extension.liquid
@@ -1,0 +1,46 @@
+import { POS_EVENT_NAMES } from '@shopify/ui-extensions/point-of-sale';
+{% if flavor contains "typescript" %}
+import type {
+  TransactionCompleteEvent,
+  CashTrackingSessionStartEvent,
+  CashTrackingSessionCompleteEvent,
+} from '@shopify/ui-extensions/point-of-sale';
+import type { Api } from '@shopify/ui-extensions/pos.app.ready.data';
+{% endif %}
+
+export default ({% if flavor contains "typescript" %}api: Api{% else %}_api{% endif %}) => {
+  console.log('background extension started');
+
+  shopify.addEventListener(
+    POS_EVENT_NAMES.TRANSACTION_COMPLETE,
+    (event{% if flavor contains "typescript" %}: TransactionCompleteEvent{% endif %}) => {
+      try {
+        console.log('transaction complete', event);
+      } catch (error) {
+        console.error('transaction complete handler failed', error);
+      }
+    },
+  );
+
+  shopify.addEventListener(
+    POS_EVENT_NAMES.CASH_TRACKING_SESSION_START,
+    (event{% if flavor contains "typescript" %}: CashTrackingSessionStartEvent{% endif %}) => {
+      try {
+        console.log('cash tracking session start', event);
+      } catch (error) {
+        console.error('cash tracking session start handler failed', error);
+      }
+    },
+  );
+
+  shopify.addEventListener(
+    POS_EVENT_NAMES.CASH_TRACKING_SESSION_COMPLETE,
+    (event{% if flavor contains "typescript" %}: CashTrackingSessionCompleteEvent{% endif %}) => {
+      try {
+        console.log('cash tracking session complete', event);
+      } catch (error) {
+        console.error('cash tracking session complete handler failed', error);
+      }
+    },
+  );
+};

--- a/pos-background/tsconfig.json.liquid
+++ b/pos-background/tsconfig.json.liquid
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "checkJs": true,
+    "allowJs": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["./src", "./shopify.d.ts"]
+}

--- a/templates.json
+++ b/templates.json
@@ -1341,6 +1341,29 @@
     "minimumCliVersion": "3.85.3"
   },
   {
+    "identifier": "pos_background",
+    "name": "POS background",
+    "defaultName": "pos-background",
+    "group": "UI extensions",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "ui_extension",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "TypeScript",
+        "value": "typescript",
+        "path": "pos-background"
+      },
+      {
+        "name": "JavaScript",
+        "value": "vanilla-js",
+        "path": "pos-background"
+      }
+    ],
+    "minimumCliVersion": "3.85.3"
+  },
+  {
     "identifier": "cart_checkout_validation",
     "name": "Cart and checkout validation",
     "defaultName": "cart-checkout-validation",


### PR DESCRIPTION
### Background

Adds a scaffold for POS background extensions targeting `pos.app.ready.data`, the persistent background target shipping in the 2026-07 API. Resolves shop/issues-retail#29623.

Supersedes the earlier closed attempt (#408), which built the scaffold by overwriting the `web-pixel-extension` template. This lands it as its own template instead, leaving `web-pixel-extension` untouched.

### Solution

- New `pos-background/` template dir, mirroring the existing `pos-action` / `pos-block` / `pos-smart-grid` structure.
- Registered `pos_background` in `templates.json` (`ui_extension`, TypeScript + JavaScript flavors).
- Scaffold targets `pos.app.ready.data` with `api_version = "2026-07"` and example `shopify.addEventListener` handlers for `transactioncomplete`, `cashtrackingsessionstart`, and `cashtrackingsessioncomplete`.
- Dependency pinned to the published `@shopify/ui-extensions` `2026.7.x`, matching sibling templates.

### Checklist

- [ ] I have :tophat:'d these changes
- [x] I have squashed my commits into chunks of work with meaningful commit messages
