### PR TITLE
Add routing to app-home extension template

### DIFF
--- a/app-home/README.md.liquid
+++ b/app-home/README.md.liquid
@@ -2,7 +2,8 @@
 
 A simple app home extension that demonstrates:
 - Basic UI with Shopify's Remote DOM components
-- Simple client-side routing (list view / add view)
+- URL-based client-side routing with preact-iso
+- App sub-navigation with `s-app-nav`
 - KV storage for persisting data
 
 ## Features
@@ -11,9 +12,11 @@ This extension creates a FAQ manager directly in your app's home page:
 
 - **Add FAQs**: Create question and answer pairs
 - **List FAQs**: View all stored FAQs
+- **Edit FAQs**: Update existing question and answer pairs
 - **Delete FAQs**: Remove FAQs you no longer need
 - **Persist data**: Uses `shopify.storage` API to store data
 - **Local assets**: Demonstrates loading images from the extension's assets folder
+- **Client-side routing**: Uses preact-iso to route between the FAQ list, add/edit FAQ, settings, and not-found pages
 
 ## Using Local Assets
 
@@ -47,11 +50,24 @@ This extension uses Shopify's [Storage API](https://shopify.dev/docs/api/admin-e
 
 ## Routing
 
-The extension demonstrates simple view-based routing:
-- `list` - Shows all FAQs (default view)
-- `add` - Form to create a new FAQ
+The extension demonstrates URL-based client-side routing with [preact-iso](https://github.com/preactjs/preact-iso):
+- `/` - Shows all FAQs (default route)
+- `/faq/new` - Form to create a new FAQ
+- `/faq/:id` - Form to edit an existing FAQ
+- `/settings` - Example settings page registered in `s-app-nav`
 
-Routing is handled with React state (`useState`), showing how to build multi-view experiences without additional libraries.
+The router keeps internal app navigation in sync with the Admin URL, so routes can be deep-linked and refreshed.
+
+## Code structure
+
+Route components live in `src/pages/`:
+
+- `src/pages/HomePage.jsx` lists FAQs
+- `src/pages/FAQPage.jsx` handles both `/faq/new` and `/faq/:id`
+- `src/pages/SettingsPage.jsx` renders the `s-app-nav` settings route
+- `src/pages/NotFoundPage.jsx` renders the fallback route
+
+Shared FAQ storage helpers live in `src/models/faqs.js`, and the aside content lives in `src/components/AboutTemplate.jsx`.
 
 ## Development
 

--- a/app-home/package.json.liquid
+++ b/app-home/package.json.liquid
@@ -6,6 +6,7 @@
   "scripts": {},
   "dependencies": {
     "preact": "^10.10.x",
+    "preact-iso": "^2.9.1",
     "@shopify/ui-extensions": "rc"
   }
 }

--- a/app-home/src/AppHome.liquid
+++ b/app-home/src/AppHome.liquid
@@ -1,268 +1,29 @@
 import {render} from 'preact';
-import {useState, useEffect} from 'preact/hooks';
+import {LocationProvider, ErrorBoundary, Router, Route} from 'preact-iso';
+
+import HomePage from './pages/HomePage.jsx';
+import FAQPage from './pages/FAQPage.jsx';
+import SettingsPage from './pages/SettingsPage.jsx';
+import NotFoundPage from './pages/NotFoundPage.jsx';
 
 export default async () => {
   render(<App />, document.body);
 };
 
-const FAQ_STORAGE_KEY = 'faqs';
-
 function App() {
-  const [currentView, setCurrentView] = useState('list');
-  const [faqs, setFaqs] = useState([]);
-  const [newQuestion, setNewQuestion] = useState('');
-  const [newAnswer, setNewAnswer] = useState('');
-  const [loading, setLoading] = useState(true);
-
-  // Load FAQs from storage on mount
-  useEffect(() => {
-    loadFAQs();
-  }, []);
-
-  async function readFAQs() {
-    const stored = await shopify.storage.getItem(FAQ_STORAGE_KEY);
-    const parsedFaqs = stored ? JSON.parse(stored) : [];
-    return Array.isArray(parsedFaqs) ? parsedFaqs : [];
-  }
-
-  async function loadFAQs() {
-    setLoading(true);
-    try {
-      setFaqs(await readFAQs());
-    } catch (err) {
-      console.error('Failed to load FAQs:', err);
-      setFaqs([]);
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function saveFAQ() {
-    const question = newQuestion.trim();
-    const answer = newAnswer.trim();
-
-    if (!question || !answer) {
-      return;
-    }
-
-    const newFaq = {
-      id: Date.now(),
-      question,
-      answer,
-    };
-
-    try {
-      const latestFaqs = await readFAQs();
-      const updatedFaqs = [...latestFaqs, newFaq];
-      await shopify.storage.setItem(FAQ_STORAGE_KEY, JSON.stringify(updatedFaqs));
-      setFaqs(updatedFaqs);
-      setNewQuestion('');
-      setNewAnswer('');
-      setCurrentView('list');
-    } catch (err) {
-      console.error('Failed to save FAQ:', err);
-      throw err;
-    }
-  }
-
-  async function deleteFAQ(id) {
-    try {
-      const latestFaqs = await readFAQs();
-      const updatedFaqs = latestFaqs.filter((faq) => faq.id !== id);
-      await shopify.storage.setItem(FAQ_STORAGE_KEY, JSON.stringify(updatedFaqs));
-      setFaqs(updatedFaqs);
-    } catch (err) {
-      console.error('Failed to delete FAQ:', err);
-    }
-  }
-
-  // Add FAQ view
-  if (currentView === 'add') {
-    const handleSubmit = (event) => {
-      const promise = saveFAQ();
-      event?.waitUntil?.(promise);
-      return promise;
-    };
-
-    const handleReset = () => {
-      setNewQuestion('');
-      setNewAnswer('');
-      setCurrentView('list');
-    };
-
-    return (
-      <s-page heading="Add New FAQ">
-        <s-form id="add-faq-form" onSubmit={handleSubmit} onReset={handleReset}>
-          <s-section>
-            <s-stack gap="base">
-              <s-text-field
-                label="Question"
-                name="question"
-                value={newQuestion}
-                oninput={(e) => setNewQuestion(e.target.value)}
-              />
-
-              <s-text-area
-                label="Answer"
-                name="answer"
-                value={newAnswer}
-                oninput={(e) => setNewAnswer(e.target.value)}
-                rows={4}
-              />
-            </s-stack>
-          </s-section>
-        </s-form>
-      </s-page>
-    );
-  }
-
-  // List view (default)
-  const hasFaqs = faqs.length > 0;
-
   return (
-    <s-page heading="FAQ Manager">
-      <s-button
-        slot="primary-action"
-        variant="primary"
-        onclick={() => setCurrentView('add')}
-      >
-        Add FAQ
-      </s-button>
-
-      <s-section slot="aside" heading="About this template">
-        <s-paragraph>
-          <s-text>{shopify.i18n.translate('welcome', {target: shopify.extension.target})}</s-text>
-        </s-paragraph>
-        <s-stack direction="inline" gap="small" alignItems="center">
-          <s-paragraph>
-            <s-text>Framework: </s-text>
-            <s-link href="https://preactjs.com/" target="_blank">
-              Preact
-            </s-link>
-          </s-paragraph>
-          <s-link href="https://preactjs.com/" target="_blank">
-            <s-box maxInlineSize="24px" maxBlockSize="24px">
-              <s-image src="./preact-logo.png" alt="Preact logo" />
-            </s-box>
-          </s-link>
-        </s-stack>
-        <s-stack direction="inline" gap="small" alignItems="center">
-          <s-paragraph>
-            <s-text>Interface: </s-text>
-            <s-link
-              href="https://shopify.dev/docs/api/app-home/web-components"
-              target="_blank"
-            >
-              Polaris web components
-            </s-link>
-          </s-paragraph>
-          <s-link
-            href="https://shopify.dev/docs/api/app-home/web-components"
-            target="_blank"
-          >
-            <s-box maxInlineSize="32px" maxBlockSize="32px">
-              <s-image src="./polaris-icon.png" alt="Polaris logo" />
-            </s-box>
-          </s-link>
-        </s-stack>
-        <s-stack direction="inline" gap="small" alignItems="center">
-          <s-paragraph>
-            <s-text>API: </s-text>
-            <s-link
-              href="https://shopify.dev/docs/api/admin-graphql"
-              target="_blank"
-            >
-              GraphQL Admin API
-            </s-link>
-          </s-paragraph>
-          <s-link
-            href="https://shopify.dev/docs/api/admin-graphql"
-            target="_blank"
-          >
-            <s-box maxInlineSize="24px" maxBlockSize="24px">
-              <s-image src="./graphql-logo.png" alt="GraphQL logo" />
-            </s-box>
-          </s-link>
-        </s-stack>
-        <s-paragraph>
-          <s-text>Database: </s-text>
-          <s-link
-            href="https://shopify.dev/docs/api/admin-extensions/2026-04-rc/target-apis/core-apis/standard-api#standardapi-propertydetail-storage"
-            target="_blank"
-          >
-            Storage API
-          </s-link>
-        </s-paragraph>
-      </s-section>
-
-      {loading && (
-        <s-section>
-          <s-paragraph>Loading...</s-paragraph>
-        </s-section>
-      )}
-
-      {!loading && !hasFaqs && (
-        <s-section accessibilityLabel="Empty state section">
-          <s-grid gap="base" justifyItems="center" paddingBlock="large-400">
-            <s-box maxInlineSize="200px" maxBlockSize="200px">
-              <s-image
-                aspectRatio="1/0.5"
-                src="https://cdn.shopify.com/static/images/polaris/patterns/callout.png"
-                alt="Illustration of FAQ creation"
-              />
-            </s-box>
-            <s-grid justifyItems="center" maxInlineSize="450px" gap="base">
-              <s-stack alignItems="center">
-                <s-heading>Start creating FAQs</s-heading>
-                <s-paragraph>
-                  Create frequently asked questions using the Storage API.
-                </s-paragraph>
-              </s-stack>
-              <s-button-group>
-                <s-button
-                  accessibilityLabel="Add a new FAQ"
-                  onclick={() => setCurrentView('add')}
-                >
-                  Add FAQ
-                </s-button>
-              </s-button-group>
-            </s-grid>
-          </s-grid>
-        </s-section>
-      )}
-
-      {!loading && hasFaqs && (
-        <s-section padding="none" accessibilityLabel="FAQs table section">
-          <s-table>
-            <s-table-header-row>
-              <s-table-header listSlot="primary">Question</s-table-header>
-              <s-table-header>Answer</s-table-header>
-              <s-table-header>Actions</s-table-header>
-            </s-table-header-row>
-            <s-table-body>
-              {faqs.map((faq) => (
-                <s-table-row key={faq.id}>
-                  <s-table-cell>
-                    <s-text weight="bold">{faq.question}</s-text>
-                  </s-table-cell>
-                  <s-table-cell>
-                    <s-text>{faq.answer}</s-text>
-                  </s-table-cell>
-                  <s-table-cell>
-                    <s-button
-                      onclick={() => deleteFAQ(faq.id)}
-                      variant="plain"
-                      tone="critical"
-                    >
-                      Delete
-                    </s-button>
-                  </s-table-cell>
-                </s-table-row>
-              ))}
-            </s-table-body>
-          </s-table>
-        </s-section>
-      )}
-    </s-page>
+    <LocationProvider>
+      <s-app-nav>
+        <s-link href="/settings">Settings</s-link>
+      </s-app-nav>
+      <ErrorBoundary>
+        <Router>
+          <Route path="/" component={HomePage} />
+          <Route path="/faq/:id" component={FAQPage} />
+          <Route path="/settings" component={SettingsPage} />
+          <Route default component={NotFoundPage} />
+        </Router>
+      </ErrorBoundary>
+    </LocationProvider>
   );
 }

--- a/app-home/src/components/AboutTemplate.jsx.liquid
+++ b/app-home/src/components/AboutTemplate.jsx.liquid
@@ -1,0 +1,77 @@
+export default function AboutTemplate() {
+  return (
+    <s-section slot="aside" heading="About this template">
+      <s-paragraph>
+        <s-text>{shopify.i18n.translate('welcome', {target: shopify.extension.target})}</s-text>
+      </s-paragraph>
+      <s-stack direction="inline" gap="small" alignItems="center">
+        <s-paragraph>
+          <s-text>Framework: </s-text>
+          <s-link href="https://preactjs.com/" target="_blank">
+            Preact
+          </s-link>
+        </s-paragraph>
+        <s-link href="https://preactjs.com/" target="_blank">
+          <s-box maxInlineSize="24px" maxBlockSize="24px">
+            <s-image src="./preact-logo.png" alt="Preact logo" />
+          </s-box>
+        </s-link>
+      </s-stack>
+      <s-stack direction="inline" gap="small" alignItems="center">
+        <s-paragraph>
+          <s-text>Router: </s-text>
+          <s-link href="https://github.com/preactjs/preact-iso" target="_blank">
+            preact-iso
+          </s-link>
+        </s-paragraph>
+      </s-stack>
+      <s-stack direction="inline" gap="small" alignItems="center">
+        <s-paragraph>
+          <s-text>Interface: </s-text>
+          <s-link
+            href="https://shopify.dev/docs/api/app-home/web-components"
+            target="_blank"
+          >
+            Polaris web components
+          </s-link>
+        </s-paragraph>
+        <s-link
+          href="https://shopify.dev/docs/api/app-home/web-components"
+          target="_blank"
+        >
+          <s-box maxInlineSize="32px" maxBlockSize="32px">
+            <s-image src="./polaris-icon.png" alt="Polaris logo" />
+          </s-box>
+        </s-link>
+      </s-stack>
+      <s-stack direction="inline" gap="small" alignItems="center">
+        <s-paragraph>
+          <s-text>API: </s-text>
+          <s-link
+            href="https://shopify.dev/docs/api/admin-graphql"
+            target="_blank"
+          >
+            GraphQL Admin API
+          </s-link>
+        </s-paragraph>
+        <s-link
+          href="https://shopify.dev/docs/api/admin-graphql"
+          target="_blank"
+        >
+          <s-box maxInlineSize="24px" maxBlockSize="24px">
+            <s-image src="./graphql-logo.png" alt="GraphQL logo" />
+          </s-box>
+        </s-link>
+      </s-stack>
+      <s-paragraph>
+        <s-text>Database: </s-text>
+        <s-link
+          href="https://shopify.dev/docs/api/admin-extensions/2026-04-rc/target-apis/core-apis/standard-api#standardapi-propertydetail-storage"
+          target="_blank"
+        >
+          Storage API
+        </s-link>
+      </s-paragraph>
+    </s-section>
+  );
+}

--- a/app-home/src/models/faqs.js.liquid
+++ b/app-home/src/models/faqs.js.liquid
@@ -1,0 +1,49 @@
+export const EMPTY_FAQ = {question: '', answer: ''};
+
+const FAQ_STORAGE_KEY = 'faqs';
+
+export async function listFAQs() {
+  const stored = await shopify.storage.getItem(FAQ_STORAGE_KEY);
+  const parsedFaqs = stored ? JSON.parse(stored) : [];
+  return Array.isArray(parsedFaqs) ? parsedFaqs : [];
+}
+
+export async function getFAQ(id) {
+  const faqs = await listFAQs();
+  return faqs.find((faq) => String(faq.id) === String(id));
+}
+
+export async function createFAQ(faq) {
+  const faqs = await listFAQs();
+  const savedFAQ = {
+    id: Date.now(),
+    question: faq.question,
+    answer: faq.answer,
+  };
+  await writeFAQs([...faqs, savedFAQ]);
+  return savedFAQ;
+}
+
+export async function updateFAQ(id, faq) {
+  const faqs = await listFAQs();
+  const savedFAQ = {
+    id,
+    question: faq.question,
+    answer: faq.answer,
+  };
+  await writeFAQs(
+    faqs.map((storedFAQ) =>
+      String(storedFAQ.id) === String(id) ? savedFAQ : storedFAQ,
+    ),
+  );
+  return savedFAQ;
+}
+
+export async function deleteFAQ(id) {
+  const faqs = await listFAQs();
+  await writeFAQs(faqs.filter((faq) => String(faq.id) !== String(id)));
+}
+
+async function writeFAQs(faqs) {
+  await shopify.storage.setItem(FAQ_STORAGE_KEY, JSON.stringify(faqs));
+}

--- a/app-home/src/pages/FAQPage.jsx.liquid
+++ b/app-home/src/pages/FAQPage.jsx.liquid
@@ -1,0 +1,213 @@
+import {useState, useEffect, useRef} from 'preact/hooks';
+import {useLocation} from 'preact-iso';
+
+import {createFAQ, deleteFAQ, EMPTY_FAQ, getFAQ, updateFAQ} from '../models/faqs.js';
+
+export default function FAQPage({id}) {
+  const {route} = useLocation();
+  const isNew = !id || id === 'new';
+  const [faq, setFaq] = useState({...EMPTY_FAQ});
+  const snapshot = useRef({...EMPTY_FAQ});
+  const [status, setStatus] = useState(isNew ? 'idle' : 'loading');
+  const [error, setError] = useState(null);
+  const [fieldErrors, setFieldErrors] = useState(emptyFieldErrors());
+
+  useEffect(() => {
+    if (isNew) {
+      const emptyFAQ = {...EMPTY_FAQ};
+      snapshot.current = emptyFAQ;
+      setFaq(emptyFAQ);
+      setStatus('idle');
+      setError(null);
+      setFieldErrors(emptyFieldErrors());
+      return;
+    }
+
+    loadFAQ();
+  }, [id]);
+
+  async function loadFAQ() {
+    setStatus('loading');
+    setError(null);
+
+    try {
+      const existingFAQ = await getFAQ(id);
+
+      if (!existingFAQ) {
+        setStatus('not-found');
+        return;
+      }
+
+      const nextFAQ = {
+        id: existingFAQ.id,
+        question: existingFAQ.question || '',
+        answer: existingFAQ.answer || '',
+      };
+      snapshot.current = nextFAQ;
+      setFaq(nextFAQ);
+      setFieldErrors(emptyFieldErrors());
+      setStatus('idle');
+    } catch (err) {
+      console.error('Failed to load FAQ:', err);
+      setError('Failed to load FAQ');
+      setStatus('idle');
+    }
+  }
+
+  function setFaqField(key, value) {
+    setFaq((currentFAQ) => ({...currentFAQ, [key]: value}));
+    setFieldErrors((errors) => ({...errors, [key]: undefined}));
+  }
+
+  async function saveFAQ() {
+    const question = faq.question.trim();
+    const answer = faq.answer.trim();
+    const nextFieldErrors = emptyFieldErrors();
+
+    if (!question) nextFieldErrors.question = 'Question is required';
+    if (!answer) nextFieldErrors.answer = 'Answer is required';
+
+    if (nextFieldErrors.question || nextFieldErrors.answer) {
+      setFieldErrors(nextFieldErrors);
+      throw new Error('Validation failed');
+    }
+
+    setStatus('saving');
+    setError(null);
+
+    try {
+      const savedFAQ = isNew
+        ? await createFAQ({question, answer})
+        : await updateFAQ(id, {question, answer});
+
+      snapshot.current = savedFAQ;
+      setFaq(savedFAQ);
+      setFieldErrors(emptyFieldErrors());
+      setStatus('idle');
+      return savedFAQ;
+    } catch (err) {
+      console.error('Failed to save FAQ:', err);
+      setError(isNew ? 'Failed to save FAQ' : 'Failed to update FAQ');
+      setStatus('idle');
+      throw err;
+    }
+  }
+
+  async function handleSubmit(event) {
+    const promise = saveFAQ();
+    event?.waitUntil?.(promise);
+    await promise;
+
+    if (isNew) {
+      route('/');
+    }
+  }
+
+  function handleReset() {
+    setFaq({...snapshot.current});
+    setFieldErrors(emptyFieldErrors());
+  }
+
+  async function handleDelete() {
+    if (isNew) return;
+
+    setStatus('deleting');
+    setError(null);
+
+    try {
+      await deleteFAQ(id);
+      route('/');
+    } catch (err) {
+      console.error('Failed to delete FAQ:', err);
+      setError('Failed to delete FAQ');
+      setStatus('idle');
+    }
+  }
+
+  if (status === 'not-found') {
+    return (
+      <s-page heading="FAQ not found">
+        <s-link slot="breadcrumb-actions" href="/">
+          FAQs
+        </s-link>
+        <s-section>
+          <s-grid gap="base" justifyItems="center" paddingBlock="large-400">
+            <s-paragraph>The FAQ you're looking for doesn't exist.</s-paragraph>
+            <s-button href="/">Go home</s-button>
+          </s-grid>
+        </s-section>
+      </s-page>
+    );
+  }
+
+  const isLoading = status === 'loading';
+  const heading = isNew ? 'Add New FAQ' : isLoading ? 'Loading FAQ' : faq.question || 'Edit FAQ';
+
+  return (
+    <s-page heading={heading} inlineSize="small">
+      <s-link slot="breadcrumb-actions" href="/">
+        FAQs
+      </s-link>
+
+      {!isNew && (
+        <s-button
+          slot="secondary-actions"
+          onClick={handleDelete}
+          loading={status === 'deleting'}
+          disabled={isLoading}
+          tone="critical"
+        >
+          Delete
+        </s-button>
+      )}
+
+      {error && (
+        <s-section>
+          <s-banner tone="critical">{error}</s-banner>
+        </s-section>
+      )}
+
+      {isLoading && (
+        <s-section>
+          <s-paragraph>Loading...</s-paragraph>
+        </s-section>
+      )}
+
+      {!isLoading && (
+        <s-form id="faq-form" onSubmit={handleSubmit} onReset={handleReset}>
+          <s-section heading="FAQ details">
+            <s-stack gap="base">
+              <s-text-field
+                label="Question"
+                name="question"
+                value={faq.question}
+                onInput={(event) => setFaqField('question', inputValue(event))}
+                error={fieldErrors.question}
+                required
+              />
+
+              <s-text-area
+                label="Answer"
+                name="answer"
+                value={faq.answer}
+                onInput={(event) => setFaqField('answer', inputValue(event))}
+                error={fieldErrors.answer}
+                rows={4}
+                required
+              />
+            </s-stack>
+          </s-section>
+        </s-form>
+      )}
+    </s-page>
+  );
+}
+
+function inputValue(event) {
+  const target = event.target;
+  return target && 'value' in target ? String(target.value) : '';
+}
+
+function emptyFieldErrors() {
+  return {question: undefined, answer: undefined};
+}

--- a/app-home/src/pages/HomePage.jsx.liquid
+++ b/app-home/src/pages/HomePage.jsx.liquid
@@ -1,0 +1,117 @@
+import {useState, useEffect} from 'preact/hooks';
+
+import AboutTemplate from '../components/AboutTemplate.jsx';
+import {deleteFAQ, listFAQs} from '../models/faqs.js';
+
+export default function HomePage() {
+  const [faqs, setFaqs] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    loadFAQs();
+  }, []);
+
+  async function loadFAQs() {
+    setLoading(true);
+    try {
+      setFaqs(await listFAQs());
+    } catch (err) {
+      console.error('Failed to load FAQs:', err);
+      setFaqs([]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleDelete(id) {
+    try {
+      await deleteFAQ(id);
+      setFaqs(await listFAQs());
+    } catch (err) {
+      console.error('Failed to delete FAQ:', err);
+    }
+  }
+
+  const hasFaqs = faqs.length > 0;
+
+  return (
+    <s-page heading="FAQ Manager">
+      <s-button slot="primary-action" variant="primary" href="/faq/new">
+        Add FAQ
+      </s-button>
+
+      <AboutTemplate />
+
+      {loading && (
+        <s-section>
+          <s-paragraph>Loading...</s-paragraph>
+        </s-section>
+      )}
+
+      {!loading && !hasFaqs && (
+        <s-section accessibilityLabel="Empty state section">
+          <s-grid gap="base" justifyItems="center" paddingBlock="large-400">
+            <s-box maxInlineSize="200px" maxBlockSize="200px">
+              <s-image
+                aspectRatio="1/0.5"
+                src="https://cdn.shopify.com/static/images/polaris/patterns/callout.png"
+                alt="Illustration of FAQ creation"
+              />
+            </s-box>
+            <s-grid justifyItems="center" maxInlineSize="450px" gap="base">
+              <s-stack alignItems="center">
+                <s-heading>Start creating FAQs</s-heading>
+                <s-paragraph>
+                  Create frequently asked questions using the Storage API.
+                </s-paragraph>
+              </s-stack>
+              <s-button-group>
+                <s-button accessibilityLabel="Add a new FAQ" href="/faq/new">
+                  Add FAQ
+                </s-button>
+              </s-button-group>
+            </s-grid>
+          </s-grid>
+        </s-section>
+      )}
+
+      {!loading && hasFaqs && (
+        <s-section padding="none" accessibilityLabel="FAQs table section">
+          <s-table>
+            <s-table-header-row>
+              <s-table-header listSlot="primary">Question</s-table-header>
+              <s-table-header>Answer</s-table-header>
+              <s-table-header>Actions</s-table-header>
+            </s-table-header-row>
+            <s-table-body>
+              {faqs.map((faq) => (
+                <s-table-row key={faq.id}>
+                  <s-table-cell>
+                    <s-link href={`/faq/${faq.id}`}>
+                      <s-text type="strong">{faq.question || 'Untitled'}</s-text>
+                    </s-link>
+                  </s-table-cell>
+                  <s-table-cell>
+                    <s-text>{faq.answer}</s-text>
+                  </s-table-cell>
+                  <s-table-cell>
+                    <s-button href={`/faq/${faq.id}`} variant="tertiary">
+                      Edit
+                    </s-button>
+                    <s-button
+                      onClick={() => handleDelete(faq.id)}
+                      variant="tertiary"
+                      tone="critical"
+                    >
+                      Delete
+                    </s-button>
+                  </s-table-cell>
+                </s-table-row>
+              ))}
+            </s-table-body>
+          </s-table>
+        </s-section>
+      )}
+    </s-page>
+  );
+}

--- a/app-home/src/pages/NotFoundPage.jsx.liquid
+++ b/app-home/src/pages/NotFoundPage.jsx.liquid
@@ -1,0 +1,12 @@
+export default function NotFoundPage() {
+  return (
+    <s-page heading="Page not found">
+      <s-section>
+        <s-grid gap="base" justifyItems="center" paddingBlock="large-400">
+          <s-paragraph>The page you're looking for doesn't exist.</s-paragraph>
+          <s-button href="/">Go home</s-button>
+        </s-grid>
+      </s-section>
+    </s-page>
+  );
+}

--- a/app-home/src/pages/SettingsPage.jsx.liquid
+++ b/app-home/src/pages/SettingsPage.jsx.liquid
@@ -1,0 +1,14 @@
+export default function SettingsPage() {
+  return (
+    <s-page heading="Settings" inlineSize="small">
+      <s-link slot="breadcrumb-actions" href="/">
+        FAQs
+      </s-link>
+      <s-section>
+        <s-paragraph>
+          This route demonstrates app home sub-navigation with <s-text type="strong">s-app-nav</s-text> and preact-iso.
+        </s-paragraph>
+      </s-section>
+    </s-page>
+  );
+}


### PR DESCRIPTION
TL;DR: This adds the same URL-based routing capability to the generated App Home extension template that the extension-only app template already demonstrates.

## What changed

- Adds `preact-iso` to the `app-home` template dependencies.
- Wraps the template in `LocationProvider`, `ErrorBoundary`, and `Router`.
- Splits the sample into route components:
  - `/` for the FAQ list
  - `/faq/new` for the FAQ creation form
  - `/faq/:id` for editing an existing FAQ
  - `/settings` as an `s-app-nav` sub-navigation example
  - default not-found route
- Keeps the Storage API sample, but moves add/list/edit navigation from local `useState` view switching to router navigation.
- Adds edit affordances from the list view and an edit form route for existing FAQs.
- Splits the generated source into multiple files so the route structure is easier to follow:
  - `src/AppHome.jsx`
  - `src/pages/HomePage.jsx`
  - `src/pages/FAQPage.jsx`
  - `src/pages/SettingsPage.jsx`
  - `src/pages/NotFoundPage.jsx`
  - `src/models/faqs.js`
  - `src/components/AboutTemplate.jsx`
- Updates README copy to describe URL-based routing, `s-app-nav`, and the generated file structure.

## Why this shape

The extension-only app template already ships a routed App Home. This brings the `shopify app generate extension` path closer to that capability while keeping the generated extension self-contained: no shared app scaffold, no app-level metaobject setup, and no API routes required.

## Validation

- `shopify app init --template remix --flavor javascript --package-manager pnpm`
- `shopify app generate extension --template app_home --name app-home --clone-url https://github.com/Shopify/extensions-templates#mlillie/app-home-router-template`
- Confirm the generated source tree includes the split route files listed above.
- `shopify app dev`
- Confirm that all FAQ functions work: create, delete, edit.
