### PR TITLE
Add Discounts app action link extension template

### DIFF
--- a/discount-app-action-link/README.md
+++ b/discount-app-action-link/README.md
@@ -17,7 +17,7 @@ The module defines two `admin.app.intent.link` extensions, each registering one 
 
 Both intents are navigation-only: Sidekick routes the merchant to your app to complete the action, and the intents alone make the extension discoverable by Sidekick (no `tools.json` needed). The create intent ships an `instructions.md` telling Sidekick to pass your `functionId` so it resolves directly to your app's create flow.
 
-Each `admin.app.intent.link` extension registers exactly one intent, which is why create and edit are two `[[extensions]]` blocks (with distinct handles `{handle}-create` and `{handle}-edit`) rather than one.
+Each `admin.app.intent.link` extension is tied to only a single url, which is why create and edit are two `[[extensions]]` blocks (with distinct handles `{handle}-create` and `{handle}-edit`) rather than one.
 
 ### Key files
 
@@ -62,8 +62,7 @@ If your app ships more than one discount function, register one create intent pe
 
 ### Limits
 
-- Maximum of 5 intents per app
-- Description fields: 256-token limit
+See the [Sidekick app action limits](https://shopify.dev/docs/apps/build/sidekick#limits) in the developer docs.
 
 ### Testing
 

--- a/discount-app-action-link/README.md
+++ b/discount-app-action-link/README.md
@@ -66,6 +66,4 @@ See the [Sidekick app action limits](https://shopify.dev/docs/apps/build/sidekic
 
 ### Testing
 
-Run `shopify app deploy` to deploy your extensions and test them with Sidekick in the Shopify Admin.
-
-> **Note:** `shopify app dev` may not upload the intent schema correctly. Use `shopify app deploy` for testing.
+Run `shopify app dev` to preview your extensions and test them with Sidekick in the Shopify Admin.

--- a/discount-app-action-link/README.md
+++ b/discount-app-action-link/README.md
@@ -13,9 +13,9 @@ Learn more about app action extensions in Shopify's [developer documentation](ht
 The module defines two `admin.app.intent.link` extensions, each registering one intent:
 
 - **Create** (`action = "create"`) — opens your app's discount creation flow. Pinned to a single discount function via the `functionId` `matchValue` in `intent-schema.json`.
-- **Edit** (`action = "edit"`) — opens your app's discount edit flow for a specific discount. Maps the discount GID to the `:id` route param.
+- **Edit** (`action = "edit"`) — opens your app's discount edit flow for a specific discount. Maps the discount GID to the `:id` route param and pins the same `functionId` via `matchValue`.
 
-Both intents are navigation-only: Sidekick routes the merchant to your app to complete the action, and the intents alone make the extension discoverable by Sidekick (no `tools.json` needed). The create intent ships an `instructions.md` telling Sidekick to pass your `functionId` so it resolves directly to your app's create flow.
+Both intents are navigation-only: Sidekick routes the merchant to your app to complete the action, and the intents alone make the extension discoverable by Sidekick (no `tools.json` needed). Both intents ship an `instructions.md` telling Sidekick to pass your `functionId` so it resolves directly to your app.
 
 Each `admin.app.intent.link` extension is tied to only a single url, which is why create and edit are two `[[extensions]]` blocks (with distinct handles `{handle}-create` and `{handle}-edit`) rather than one.
 
@@ -24,23 +24,23 @@ Each `admin.app.intent.link` extension is tied to only a single url, which is wh
 - `shopify.extension.toml` - Two `[[extensions]]` blocks defining the create and edit intent targets, URLs, and action types
 - `intent-schema.json` - Create intent schema (references the `shopify/discount.json` baseline, pins `functionId`, returns the created discount's GID)
 - `intent-schema-edit.json` - Edit intent schema (maps the discount GID to the `:id` route param and returns the edited discount's GID)
-- `instructions.md` - Tells Sidekick to pass your `functionId` when invoking `create` (create intent only)
+- `instructions.md` - Tells Sidekick to pass your `functionId` when invoking `create` or `edit`
 
 ### How it works
 
 1. Each extension registers an intent via `[[extensions.targeting.intents]]` with `type = "shopify/Discount"` and `action = "create"` or `"edit"`.
-2. The create schema uses the `shopify-intent.json` meta-schema and references the `shopify/discount.json` baseline for the input; `functionId` `matchValue` narrows a generic "create a discount" request to your function. The edit schema uses a top-level `value` block to map the discount GID to the `id` route param (`fieldName: "id"`), so Sidekick fills the `:id` in the URL.
+2. The create schema uses the `shopify-intent.json` meta-schema and references the `shopify/discount.json` baseline for the input; `functionId` `matchValue` narrows a generic "create a discount" request to your function. The edit schema uses a top-level `value` block to map the discount GID to the `id` route param (`fieldName: "id"`), so Sidekick fills the `:id` in the URL, and pins `functionId` via `matchValue` (same as create) so Sidekick resolves the edit to this app.
 3. When Sidekick invokes an action, the merchant is navigated to your app at the configured `url` (with the discount id filled in for edit).
 
 ### Customizing the intents
 
 1. **Set your URLs.** Replace `YOUR_CREATE_ROUTE` and `YOUR_EDIT_ROUTE` in `shopify.extension.toml` with the routes in your app that create and edit the discount. The whole path is up to your app (there's no required prefix), but each must be a stable, unique route (for example `/discounts/loyalty/new` and `/discounts/:id`). Keep the `:id` param on the edit route. Avoid wildcard placeholders.
-2. **Pin your function.** Replace `YOUR_DISCOUNT_FUNCTION_ID` in `intent-schema.json` and `instructions.md` with the ID of the discount function this extension creates discounts for. The `functionId` `matchValue` narrows a generic "create a discount" request to your function; without it, a generic create routes to the native discount picker instead. If your create route needs the function ID, you can also embed it in the URL (`/discounts/{functionId}/new`). The edit route derives the function from the existing discount, so it needs no `functionId`.
+2. **Pin your function.** Replace `YOUR_DISCOUNT_FUNCTION_ID` in `intent-schema.json`, `intent-schema-edit.json`, and `instructions.md` with the ID of the discount function this extension targets. The `functionId` `matchValue` narrows a generic "create a discount" request to your function; without it, a generic create routes to the native discount picker instead. If your create route needs the function ID, you can also embed it in the URL (`/discounts/{functionId}/new`). The edit intent pins the same `functionId` via `matchValue` so Sidekick resolves the edit directly to this app rather than relying on a discount-only owner lookup.
 3. Update the merchant-facing names and descriptions in `locales/en.default.json` (under the `create` and `edit` keys).
 
 ### Get your function ID
 
-`YOUR_DISCOUNT_FUNCTION_ID` (in `intent-schema.json` and `instructions.md`) is the ID of the discount function this extension targets. Two ways to find it:
+`YOUR_DISCOUNT_FUNCTION_ID` (in `intent-schema.json`, `intent-schema-edit.json`, and `instructions.md`) is the ID of the discount function this extension targets. Two ways to find it:
 
 - **CLI** — after `shopify app deploy` (or `shopify app function deploy`), the CLI prints the registered function's ID.
 - **Admin API** — query [`shopifyFunctions`](https://shopify.dev/docs/api/admin-graphql/latest/queries/shopifyFunctions):

--- a/discount-app-action-link/README.md
+++ b/discount-app-action-link/README.md
@@ -1,0 +1,72 @@
+# Sidekick Discount App Action Link Extension
+
+Sidekick app action link extensions let app developers expose actions to Sidekick in the Shopify Admin. This template registers **two discount app actions** in one extension module — a `create` intent and an `edit` intent for the `shopify/Discount` type — so that when a merchant asks Sidekick to create or change a discount your app powers, Sidekick navigates the merchant to the right page in your app to complete it.
+
+Apps that power discounts with a function typically want both intents so Sidekick can drive the full create + edit flow. If your app only supports one, delete the other `[[extensions]]` block in `shopify.extension.toml`.
+
+Learn more about app action extensions in Shopify's [developer documentation](https://shopify.dev/docs/apps/build/sidekick/build-app-actions).
+
+---
+
+## Get started with this extension
+
+The module defines two `admin.app.intent.link` extensions, each registering one intent:
+
+- **Create** (`action = "create"`) — opens your app's discount creation flow. Pinned to a single discount function via the `functionId` `matchValue` in `intent-schema.json`.
+- **Edit** (`action = "edit"`) — opens your app's discount edit flow for a specific discount. Maps the discount GID to the `:id` route param.
+
+Both intents are navigation-only: Sidekick routes the merchant to your app to complete the action, and the intents alone make the extension discoverable by Sidekick (no `tools.json` needed). The create intent ships an `instructions.md` telling Sidekick to pass your `functionId` so it resolves directly to your app's create flow.
+
+Each `admin.app.intent.link` extension registers exactly one intent, which is why create and edit are two `[[extensions]]` blocks (with distinct handles `{handle}-create` and `{handle}-edit`) rather than one.
+
+### Key files
+
+- `shopify.extension.toml` - Two `[[extensions]]` blocks defining the create and edit intent targets, URLs, and action types
+- `intent-schema.json` - Create intent schema (references the `shopify/discount.json` baseline, pins `functionId`, returns the created discount's GID)
+- `intent-schema-edit.json` - Edit intent schema (maps the discount GID to the `:id` route param and returns the edited discount's GID)
+- `instructions.md` - Tells Sidekick to pass your `functionId` when invoking `create` (create intent only)
+
+### How it works
+
+1. Each extension registers an intent via `[[extensions.targeting.intents]]` with `type = "shopify/Discount"` and `action = "create"` or `"edit"`.
+2. The create schema uses the `shopify-intent.json` meta-schema and references the `shopify/discount.json` baseline for the input; `functionId` `matchValue` narrows a generic "create a discount" request to your function. The edit schema uses a top-level `value` block to map the discount GID to the `id` route param (`fieldName: "id"`), so Sidekick fills the `:id` in the URL.
+3. When Sidekick invokes an action, the merchant is navigated to your app at the configured `url` (with the discount id filled in for edit).
+
+### Customizing the intents
+
+1. **Set your URLs.** Replace `YOUR_CREATE_ROUTE` and `YOUR_EDIT_ROUTE` in `shopify.extension.toml` with the routes in your app that create and edit the discount. The whole path is up to your app (there's no required prefix), but each must be a stable, unique route (for example `/discounts/loyalty/new` and `/discounts/:id`). Keep the `:id` param on the edit route. Avoid wildcard placeholders.
+2. **Pin your function.** Replace `YOUR_DISCOUNT_FUNCTION_ID` in `intent-schema.json` and `instructions.md` with the ID of the discount function this extension creates discounts for. The `functionId` `matchValue` narrows a generic "create a discount" request to your function; without it, a generic create routes to the native discount picker instead. If your create route needs the function ID, you can also embed it in the URL (`/discounts/{functionId}/new`). The edit route derives the function from the existing discount, so it needs no `functionId`.
+3. Update the merchant-facing names and descriptions in `locales/en.default.json` (under the `create` and `edit` keys).
+
+### Get your function ID
+
+`YOUR_DISCOUNT_FUNCTION_ID` (in `intent-schema.json` and `instructions.md`) is the ID of the discount function this extension targets. Two ways to find it:
+
+- **CLI** — after `shopify app deploy` (or `shopify app function deploy`), the CLI prints the registered function's ID.
+- **Admin API** — query [`shopifyFunctions`](https://shopify.dev/docs/api/admin-graphql/latest/queries/shopifyFunctions):
+  ```graphql
+  {
+    shopifyFunctions(first: 50) {
+      nodes {
+        id
+        title
+        description
+      }
+    }
+  }
+  ```
+
+### Disambiguation (multiple functions)
+
+If your app ships more than one discount function, register one create intent per function (each in its own extension) and use the `functionId` `matchValue` to narrow each intent to a single function. Each registered intent counts toward the per-app intent limit below.
+
+### Limits
+
+- Maximum of 5 intents per app
+- Description fields: 256-token limit
+
+### Testing
+
+Run `shopify app deploy` to deploy your extensions and test them with Sidekick in the Shopify Admin.
+
+> **Note:** `shopify app dev` may not upload the intent schema correctly. Use `shopify app deploy` for testing.

--- a/discount-app-action-link/README.md
+++ b/discount-app-action-link/README.md
@@ -13,7 +13,7 @@ Learn more about app action extensions in Shopify's [developer documentation](ht
 The module defines two `admin.app.intent.link` extensions, each registering one intent:
 
 - **Create** (`action = "create"`) — opens your app's discount creation flow. Pinned to a single discount function via the `functionId` `matchValue` in `intent-schema.json`.
-- **Edit** (`action = "edit"`) — opens your app's discount edit flow for a specific discount. Maps the discount GID to the `:id` route param and pins the same `functionId` via `matchValue`.
+- **Edit** (`action = "edit"`) — opens your app's discount edit flow for a specific discount. Maps the discount GID to the `{id}` route param and pins the same `functionId` via `matchValue`.
 
 Both intents are navigation-only: Sidekick routes the merchant to your app to complete the action, and the intents alone make the extension discoverable by Sidekick (no `tools.json` needed). Both intents ship an `instructions.md` telling Sidekick to pass your `functionId` so it resolves directly to your app.
 
@@ -23,18 +23,18 @@ Each `admin.app.intent.link` extension is tied to only a single url, which is wh
 
 - `shopify.extension.toml` - Two `[[extensions]]` blocks defining the create and edit intent targets, URLs, and action types
 - `intent-schema.json` - Create intent schema (references the `shopify/discount.json` baseline, pins `functionId`, returns the created discount's GID)
-- `intent-schema-edit.json` - Edit intent schema (maps the discount GID to the `:id` route param and returns the edited discount's GID)
+- `intent-schema-edit.json` - Edit intent schema (maps the discount GID to the `{id}` route param and returns the edited discount's GID)
 - `instructions.md` - Tells Sidekick to pass your `functionId` when invoking `create` or `edit`
 
 ### How it works
 
 1. Each extension registers an intent via `[[extensions.targeting.intents]]` with `type = "shopify/Discount"` and `action = "create"` or `"edit"`.
-2. The create schema uses the `shopify-intent.json` meta-schema and references the `shopify/discount.json` baseline for the input; `functionId` `matchValue` narrows a generic "create a discount" request to your function. The edit schema uses a top-level `value` block to map the discount GID to the `id` route param (`fieldName: "id"`), so Sidekick fills the `:id` in the URL, and pins `functionId` via `matchValue` (same as create) so Sidekick resolves the edit to this app.
+2. The create schema uses the `shopify-intent.json` meta-schema and references the `shopify/discount.json` baseline for the input; `functionId` `matchValue` narrows a generic "create a discount" request to your function. The edit schema uses a top-level `value` block to map the discount GID to the `id` route param (`fieldName: "id"`), so Sidekick fills the `{id}` in the URL, and pins `functionId` via `matchValue` (same as create) so Sidekick resolves the edit to this app.
 3. When Sidekick invokes an action, the merchant is navigated to your app at the configured `url` (with the discount id filled in for edit).
 
 ### Customizing the intents
 
-1. **Set your URLs.** Replace `YOUR_CREATE_ROUTE` and `YOUR_EDIT_ROUTE` in `shopify.extension.toml` with the routes in your app that create and edit the discount. The whole path is up to your app (there's no required prefix), but each must be a stable, unique route (for example `/discounts/loyalty/new` and `/discounts/:id`). Keep the `:id` param on the edit route. Avoid wildcard placeholders.
+1. **Set your URLs.** Replace `YOUR_CREATE_ROUTE` and `YOUR_EDIT_ROUTE` in `shopify.extension.toml` with the routes in your app that create and edit the discount. The whole path is up to your app (there's no required prefix), but each must be a stable, unique route (for example `/discounts/loyalty/new` and `/discounts/{id}`). Keep the `{id}` param on the edit route. Avoid wildcard placeholders.
 2. **Pin your function.** Replace `YOUR_DISCOUNT_FUNCTION_ID` in `intent-schema.json`, `intent-schema-edit.json`, and `instructions.md` with the ID of the discount function this extension targets. The `functionId` `matchValue` narrows a generic "create a discount" request to your function; without it, a generic create routes to the native discount picker instead. If your create route needs the function ID, you can also embed it in the URL (`/discounts/{functionId}/new`). The edit intent pins the same `functionId` via `matchValue` so Sidekick resolves the edit directly to this app rather than relying on a discount-only owner lookup.
 3. Update the merchant-facing names and descriptions in `locales/en.default.json` (under the `create` and `edit` keys).
 

--- a/discount-app-action-link/instructions.md
+++ b/discount-app-action-link/instructions.md
@@ -1,0 +1,5 @@
+Use this app when the merchant wants to create or edit a discount powered by this app's Shopify Function.
+
+When invoking `create:shopify/Discount`, pass `functionId: "YOUR_DISCOUNT_FUNCTION_ID"` so Shopify resolves directly to this app's create flow.
+
+`edit:shopify/Discount` is invoked with the discount's GID — default to the canonical `gid://shopify/DiscountNode/{id}`. Shopify derives the function from the existing discount, so no `functionId` is needed.

--- a/discount-app-action-link/instructions.md
+++ b/discount-app-action-link/instructions.md
@@ -2,4 +2,4 @@ Use this app when the merchant wants to create or edit a discount powered by thi
 
 When invoking `create:shopify/Discount`, pass `functionId: "YOUR_DISCOUNT_FUNCTION_ID"` so Shopify resolves directly to this app's create flow.
 
-`edit:shopify/Discount` is invoked with the discount's GID — default to the canonical `gid://shopify/DiscountNode/{id}`. Shopify derives the function from the existing discount, so no `functionId` is needed.
+When invoking `edit:shopify/Discount`, pass the discount's GID (default to the canonical `gid://shopify/DiscountNode/{id}`) and `functionId: "YOUR_DISCOUNT_FUNCTION_ID"` so Shopify resolves the edit directly to this app.

--- a/discount-app-action-link/intent-schema-edit.json
+++ b/discount-app-action-link/intent-schema-edit.json
@@ -9,7 +9,12 @@
     "type": "object",
     "$ref": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify/discount.json",
     "additionalProperties": true,
-    "properties": {}
+    "properties": {
+      "functionId": {
+        "mapTo": "param",
+        "matchValue": "YOUR_DISCOUNT_FUNCTION_ID"
+      }
+    }
   },
   "outputSchema": {
     "type": "object",

--- a/discount-app-action-link/intent-schema-edit.json
+++ b/discount-app-action-link/intent-schema-edit.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify-intent.json",
+  "value": {
+    "$ref": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify/discount/gid.json",
+    "mapTo": "param",
+    "fieldName": "id"
+  },
+  "inputSchema": {
+    "type": "object",
+    "$ref": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify/discount.json",
+    "additionalProperties": true,
+    "properties": {}
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "$ref": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify/discount/gid.json"
+      }
+    }
+  }
+}

--- a/discount-app-action-link/intent-schema.json
+++ b/discount-app-action-link/intent-schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify-intent.json",
+  "inputSchema": {
+    "type": "object",
+    "$ref": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify/discount.json",
+    "additionalProperties": true,
+    "properties": {
+      "functionId": {
+        "mapTo": "param",
+        "matchValue": "YOUR_DISCOUNT_FUNCTION_ID"
+      }
+    }
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "$ref": "https://extensions.shopifycdn.com/shopifycloud/schemas/v1/shopify/discount/gid.json"
+      }
+    }
+  }
+}

--- a/discount-app-action-link/locales/en.default.json.liquid
+++ b/discount-app-action-link/locales/en.default.json.liquid
@@ -1,0 +1,10 @@
+{
+  "create": {
+    "name": "Create discount",
+    "description": "Create a discount powered by your app's discount function"
+  },
+  "edit": {
+    "name": "Edit discount",
+    "description": "Edit a discount powered by your app's discount function"
+  }
+}

--- a/discount-app-action-link/locales/fr.json.liquid
+++ b/discount-app-action-link/locales/fr.json.liquid
@@ -1,0 +1,10 @@
+{
+  "create": {
+    "name": "Créer une réduction",
+    "description": "Créer une réduction gérée par la fonction de réduction de votre application"
+  },
+  "edit": {
+    "name": "Modifier une réduction",
+    "description": "Modifier une réduction gérée par la fonction de réduction de votre application"
+  }
+}

--- a/discount-app-action-link/shopify.extension.toml.liquid
+++ b/discount-app-action-link/shopify.extension.toml.liquid
@@ -50,12 +50,15 @@ type = "admin_link"
 [[extensions.targeting]]
 target = "admin.app.intent.link"
 # When Sidekick invokes this action, the merchant is navigated to this URL to edit the discount.
-# The edit route derives the function from the discount, so it only needs the discount id. Replace
-# YOUR_EDIT_ROUTE with the edit path in your own app (the prefix is entirely up to your app), but
-# keep the `:id` param so the discount id is passed through. The id is filled from the intent
+# Replace YOUR_EDIT_ROUTE with the edit path in your own app (the prefix is entirely up to your app),
+# but keep the `:id` param so the discount id is passed through. The id is filled from the intent
 # `value` block in intent-schema-edit.json and mapped to the `:id` route param (for example
-# /discounts/:id).
+# /discounts/:id). Like create, the edit intent also pins your `functionId` via `matchValue` in
+# intent-schema-edit.json so Sidekick resolves the edit directly to this app.
 url = "/YOUR_EDIT_ROUTE/:id"
+
+# Instructions tell Sidekick to pass functionId on edit so it resolves to this app's edit flow.
+instructions = "./instructions.md"
 
 [[extensions.targeting.intents]]
 type = "shopify/Discount"

--- a/discount-app-action-link/shopify.extension.toml.liquid
+++ b/discount-app-action-link/shopify.extension.toml.liquid
@@ -1,0 +1,63 @@
+# This template registers two Sidekick app action link intents in one extension module:
+# a `create` intent and an `edit` intent for the shopify/Discount type. Apps that power
+# discounts with a function typically want both so Sidekick can drive the full create and
+# edit flow. Each [[extensions]] block below is its own admin.app.intent.link extension
+# with its own handle; delete one block if your app only supports that action.
+
+[[extensions]]
+# Merchant-facing name and description live in locales/en.default.json under the `create` key.
+name = "t:create.name"
+description = "t:create.description"
+
+handle = "{{ handle }}-create"
+type = "admin_link"
+
+# For embedded apps, URIs are defined relative to the domain of the configured application_url
+# in your shopify.app.toml. For example, `url = "/path"` with `application_url =
+# "https://my-app-domain.com/home"` resolves to https://my-app-domain.com/path. For non-embedded
+# apps, use an absolute path to your app (https://yourappdomain.com/path).
+[[extensions.targeting]]
+target = "admin.app.intent.link"
+# When Sidekick invokes this action, the merchant is navigated to this URL to create the discount.
+# Replace YOUR_CREATE_ROUTE with the route in your own app that opens this discount's create flow.
+# The whole path is up to your app; there is no required prefix. The one requirement: the route
+# must be stable and unique to the kind of discount this extension creates, so Sidekick can route
+# to it deterministically. Examples: /discounts/loyalty/new, /bundles/create, /promotions/create.
+# Avoid wildcard placeholders. To target a specific function, encode it in the route and pair it
+# with the `functionId` matchValue in intent-schema.json (for example /discounts/YOUR_FUNCTION_ID/new).
+url = "/YOUR_CREATE_ROUTE"
+
+# Instructions tell Sidekick to pass functionId on create so it resolves to this app's intent.
+instructions = "./instructions.md"
+
+# Register an intent to declare what action your app can perform.
+# `type` describes the kind of data your action works with (here, shopify/Discount).
+# `action` describes what the action does (create or edit).
+# `schema` points to a JSON file defining the input your action accepts.
+[[extensions.targeting.intents]]
+type = "shopify/Discount"
+action = "create"
+schema = "./intent-schema.json"
+
+[[extensions]]
+# Merchant-facing name and description live in locales/en.default.json under the `edit` key.
+name = "t:edit.name"
+description = "t:edit.description"
+
+handle = "{{ handle }}-edit"
+type = "admin_link"
+
+[[extensions.targeting]]
+target = "admin.app.intent.link"
+# When Sidekick invokes this action, the merchant is navigated to this URL to edit the discount.
+# The edit route derives the function from the discount, so it only needs the discount id. Replace
+# YOUR_EDIT_ROUTE with the edit path in your own app (the prefix is entirely up to your app), but
+# keep the `:id` param so the discount id is passed through. The id is filled from the intent
+# `value` block in intent-schema-edit.json and mapped to the `:id` route param (for example
+# /discounts/:id).
+url = "/YOUR_EDIT_ROUTE/:id"
+
+[[extensions.targeting.intents]]
+type = "shopify/Discount"
+action = "edit"
+schema = "./intent-schema-edit.json"

--- a/discount-app-action-link/shopify.extension.toml.liquid
+++ b/discount-app-action-link/shopify.extension.toml.liquid
@@ -12,10 +12,9 @@ description = "t:create.description"
 handle = "{{ handle }}-create"
 type = "admin_link"
 
-# For embedded apps, URIs are defined relative to the domain of the configured application_url
-# in your shopify.app.toml. For example, `url = "/path"` with `application_url =
-# "https://my-app-domain.com/home"` resolves to https://my-app-domain.com/path. For non-embedded
-# apps, use an absolute path to your app (https://yourappdomain.com/path).
+# App intent links require an embedded app. URIs are relative to the domain of the configured
+# application_url in your shopify.app.toml — e.g. `url = "/path"` with
+# `application_url = "https://my-app-domain.com/home"` resolves to https://my-app-domain.com/path.
 [[extensions.targeting]]
 target = "admin.app.intent.link"
 # When Sidekick invokes this action, the merchant is navigated to this URL to create the discount.
@@ -23,8 +22,9 @@ target = "admin.app.intent.link"
 # The whole path is up to your app; there is no required prefix. The one requirement: the route
 # must be stable and unique to the kind of discount this extension creates, so Sidekick can route
 # to it deterministically. Examples: /discounts/loyalty/new, /bundles/create, /promotions/create.
-# Avoid wildcard placeholders. To target a specific function, encode it in the route and pair it
-# with the `functionId` matchValue in intent-schema.json (for example /discounts/YOUR_FUNCTION_ID/new).
+# Avoid wildcard placeholders. To target a specific function, template it into the route with
+# `{functionId}` (matching the intent input property) — e.g. /discounts/{functionId}/new — and the
+# platform fills it from the `functionId` matchValue in intent-schema.json.
 url = "/YOUR_CREATE_ROUTE"
 
 # Instructions tell Sidekick to pass functionId on create so it resolves to this app's intent.
@@ -51,11 +51,14 @@ type = "admin_link"
 target = "admin.app.intent.link"
 # When Sidekick invokes this action, the merchant is navigated to this URL to edit the discount.
 # Replace YOUR_EDIT_ROUTE with the edit path in your own app (the prefix is entirely up to your app),
-# but keep the `:id` param so the discount id is passed through. The id is filled from the intent
-# `value` block in intent-schema-edit.json and mapped to the `:id` route param (for example
-# /discounts/:id). Like create, the edit intent also pins your `functionId` via `matchValue` in
+# but keep the `{id}` template param so the discount id is passed through. The id is filled from the
+# intent `value` block in intent-schema-edit.json and mapped into the `{id}` route param (e.g.
+# /discounts/{id}). Like create, the edit intent also pins your `functionId` via `matchValue` in
 # intent-schema-edit.json so Sidekick resolves the edit directly to this app.
-url = "/YOUR_EDIT_ROUTE/:id"
+# How intent values map into the URL, and how GIDs are handled:
+#   https://shopify.dev/docs/apps/build/sidekick/build-app-actions#map-intent-values-into-the-url
+#   https://shopify.dev/docs/apps/build/sidekick/build-app-actions#working-with-gids
+url = "/YOUR_EDIT_ROUTE/{id}"
 
 # Instructions tell Sidekick to pass functionId on edit so it resolves to this app's edit flow.
 instructions = "./instructions.md"

--- a/templates.json
+++ b/templates.json
@@ -100,9 +100,7 @@
     "name": "App home",
     "defaultName": "app-home",
     "group": "UI extensions",
-    "supportLinks": [
-      "https://shopify.dev/docs/api/app-home"
-    ],
+    "supportLinks": ["https://shopify.dev/docs/api/app-home"],
     "url": "https://github.com/Shopify/extensions-templates",
     "type": "ui_extension",
     "extensionPoints": [],
@@ -120,9 +118,7 @@
     "name": "Post-purchase UI",
     "defaultName": "post-purchase-ui",
     "group": "UI extensions",
-    "supportLinks": [
-      "https://shopify.dev/docs/apps/checkout/post-purchase"
-    ],
+    "supportLinks": ["https://shopify.dev/docs/apps/checkout/post-purchase"],
     "url": "https://github.com/Shopify/extensions-templates",
     "type": "checkout_post_purchase",
     "extensionPoints": [],
@@ -757,9 +753,7 @@
         "path": "customer-segment-template-extension"
       }
     ],
-    "organizationBetaFlags": [
-      "enable_cli_customer_segment_template_extension"
-    ],
+    "organizationBetaFlags": ["enable_cli_customer_segment_template_extension"],
     "deprecatedFromCliVersion": "3.85.0"
   },
   {
@@ -863,9 +857,7 @@
     "name": "Discount function settings",
     "defaultName": "Discount function settings",
     "group": "UI extensions",
-    "supportLinks": [
-      "https://shopify.dev/docs/apps/discounts"
-    ],
+    "supportLinks": ["https://shopify.dev/docs/apps/discounts"],
     "url": "https://github.com/Shopify/extensions-templates",
     "type": "ui_extension",
     "extensionPoints": [],
@@ -883,9 +875,7 @@
     "name": "Discount function settings",
     "defaultName": "Discount function settings",
     "group": "UI extensions",
-    "supportLinks": [
-      "https://shopify.dev/docs/apps/discounts"
-    ],
+    "supportLinks": ["https://shopify.dev/docs/apps/discounts"],
     "url": "https://github.com/Shopify/extensions-templates",
     "type": "ui_extension",
     "extensionPoints": [],
@@ -1027,9 +1017,7 @@
         "path": "order-routing-location-rule"
       }
     ],
-    "organizationBetaFlags": [
-      "order_routing_extensibility_partner"
-    ],
+    "organizationBetaFlags": ["order_routing_extensibility_partner"],
     "minimumCliVersion": "3.85.3"
   },
   {
@@ -1065,9 +1053,7 @@
         "path": "order-routing-location-rule"
       }
     ],
-    "organizationBetaFlags": [
-      "order_routing_extensibility_partner"
-    ],
+    "organizationBetaFlags": ["order_routing_extensibility_partner"],
     "deprecatedFromCliVersion": "3.85.3"
   },
   {
@@ -1443,9 +1429,7 @@
     "name": "Discount",
     "defaultName": "discount-function",
     "group": "Functions",
-    "supportLinks": [
-      "https://shopify.dev/docs/apps/discounts"
-    ],
+    "supportLinks": ["https://shopify.dev/docs/apps/discounts"],
     "url": "https://github.com/Shopify/extensions-templates",
     "type": "function",
     "extensionPoints": [],
@@ -1477,9 +1461,7 @@
     "name": "Order discount (deprecated)",
     "defaultName": "order-discount",
     "group": "Functions",
-    "supportLinks": [
-      "https://shopify.dev/docs/apps/discounts"
-    ],
+    "supportLinks": ["https://shopify.dev/docs/apps/discounts"],
     "url": "https://github.com/Shopify/extensions-templates",
     "type": "function",
     "extensionPoints": [],
@@ -1511,9 +1493,7 @@
     "name": "Product discount (deprecated)",
     "defaultName": "product-discount",
     "group": "Functions",
-    "supportLinks": [
-      "https://shopify.dev/docs/apps/discounts"
-    ],
+    "supportLinks": ["https://shopify.dev/docs/apps/discounts"],
     "url": "https://github.com/Shopify/extensions-templates",
     "type": "function",
     "extensionPoints": [],
@@ -1545,9 +1525,7 @@
     "name": "Shipping discount (deprecated)",
     "defaultName": "shipping-discount",
     "group": "Functions",
-    "supportLinks": [
-      "https://shopify.dev/docs/apps/discounts"
-    ],
+    "supportLinks": ["https://shopify.dev/docs/apps/discounts"],
     "url": "https://github.com/Shopify/extensions-templates",
     "type": "function",
     "extensionPoints": [],
@@ -1579,9 +1557,7 @@
     "name": "Discounts allocator",
     "defaultName": "discounts-allocator",
     "group": "Functions",
-    "supportLinks": [
-      "https://shopify.dev/docs/apps/discounts"
-    ],
+    "supportLinks": ["https://shopify.dev/docs/apps/discounts"],
     "url": "https://github.com/Shopify/extensions-templates",
     "type": "function",
     "extensionPoints": [],
@@ -1769,9 +1745,7 @@
         "path": "functions-location-rules-wasm"
       }
     ],
-    "organizationBetaFlags": [
-      "order_routing_extensibility_partner"
-    ]
+    "organizationBetaFlags": ["order_routing_extensibility_partner"]
   },
   {
     "identifier": "theme_app_extension",
@@ -1964,9 +1938,7 @@
         "path": "payments-app-extension-card-present"
       }
     ],
-    "organizationBetaFlags": [
-      "payments_extensions_card_present"
-    ]
+    "organizationBetaFlags": ["payments_extensions_card_present"]
   },
   {
     "identifier": "credit_card_payments",
@@ -1984,9 +1956,7 @@
         "path": "payments-app-extension-credit-card"
       }
     ],
-    "organizationBetaFlags": [
-      "payments_extensions_credit_card"
-    ]
+    "organizationBetaFlags": ["payments_extensions_credit_card"]
   },
   {
     "identifier": "custom_credit_card_payments",
@@ -2004,9 +1974,7 @@
         "path": "payments-app-extension-custom-credit-card"
       }
     ],
-    "organizationBetaFlags": [
-      "payments_extensions_custom_credit_card"
-    ]
+    "organizationBetaFlags": ["payments_extensions_custom_credit_card"]
   },
   {
     "identifier": "custom_onsite_payments",
@@ -2024,9 +1992,7 @@
         "path": "payments-app-extension-custom-onsite"
       }
     ],
-    "organizationBetaFlags": [
-      "payments_extensions_custom_onsite"
-    ]
+    "organizationBetaFlags": ["payments_extensions_custom_onsite"]
   },
   {
     "identifier": "offsite_payments",
@@ -2044,9 +2010,7 @@
         "path": "payments-app-extension-offsite"
       }
     ],
-    "organizationBetaFlags": [
-      "payments_extensions_offsite"
-    ]
+    "organizationBetaFlags": ["payments_extensions_offsite"]
   },
   {
     "identifier": "redeemable_payments",
@@ -2064,9 +2028,7 @@
         "path": "payments-app-extension-redeemable"
       }
     ],
-    "organizationBetaFlags": [
-      "payments_extensions_redeemable"
-    ]
+    "organizationBetaFlags": ["payments_extensions_redeemable"]
   },
   {
     "identifier": "channel_config",
@@ -2153,10 +2115,8 @@
         "path": "discount-app-action-link"
       }
     ],
-    "organizationExpFlags": [
-      "a9b1bd3a"
-    ],
-    "minimumCliVersion": "3.92.0"
+    "organizationExpFlags": ["a9b1bd3a"],
+    "minimumCliVersion": "3.90.0"
   },
   {
     "identifier": "app_action",

--- a/templates.json
+++ b/templates.json
@@ -2138,6 +2138,27 @@
     "minimumCliVersion": "3.90.0"
   },
   {
+    "identifier": "discount_app_action_link",
+    "name": "Discount app action link",
+    "defaultName": "discount-app-action-link",
+    "group": "Sidekick",
+    "supportLinks": [],
+    "url": "https://github.com/Shopify/extensions-templates",
+    "type": "admin_link",
+    "extensionPoints": [],
+    "supportedFlavors": [
+      {
+        "name": "Config only",
+        "value": "config-only",
+        "path": "discount-app-action-link"
+      }
+    ],
+    "organizationExpFlags": [
+      "a9b1bd3a"
+    ],
+    "minimumCliVersion": "3.92.0"
+  },
+  {
     "identifier": "app_action",
     "name": "App action",
     "defaultName": "app-action",


### PR DESCRIPTION
## Problem

No template exists for partners who want to expose **discount** app actions (create/edit a discount their app powers) to Sidekick. The only app action link template today is the email `app_action_link`.

## What this PR does

Adds a `discount_app_action_link` template that registers Sidekick app action link intents for the `shopify/Discount` type. One extension module ships **two** `admin.app.intent.link` extensions — a `create` and an `edit` intent — so an app can drive the full create + edit flow. Modeled on the existing `app_action_link` template.

- New `discount-app-action-link/` — README, create + edit intent schemas, locales, and `shopify.extension.toml.liquid` (two `[[extensions]]` blocks with unique `-create`/`-edit` handles).
- Registers the template under the Sidekick group in `templates.json`, gated by org beta `a9b1bd3a`.
- Intents-only (no `tools.json`): the extension is Sidekick-discoverable via its intents alone (pairs with shop/world#876126, which makes tools optional).

## Test plan

- `templates.json`, `intent-schema.json`, and `intent-schema-edit.json` validated as well-formed JSON.
- Dogfooded end-to-end via the CLI into the discount-functions-testing app: generated the module, wired it to a real discount function, loaded in `dev`, and verified create + edit render.

## What's next

Enable the `discount_app_action_link` beta (`a9b1bd3a`) for partner orgs once ready.
